### PR TITLE
Add job category management functionality with staff-only feature

### DIFF
--- a/apps/api/src/jobs/categories/categories.controller.spec.ts
+++ b/apps/api/src/jobs/categories/categories.controller.spec.ts
@@ -6,7 +6,6 @@ import { RolesGuard } from '../../auth/guards/roles.guard';
 
 describe('CategoriesController', () => {
   let controller: CategoriesController;
-  let service: CategoriesService;
 
   // Sample data with staffOnly field
   const mockCategories = [
@@ -64,7 +63,6 @@ describe('CategoriesController', () => {
       .compile();
 
     controller = module.get<CategoriesController>(CategoriesController);
-    service = module.get<CategoriesService>(CategoriesService);
 
     // Reset all mocks
     jest.clearAllMocks();

--- a/apps/api/src/jobs/categories/categories.controller.spec.ts
+++ b/apps/api/src/jobs/categories/categories.controller.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+import { UserRole } from '@prisma/client';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+
+describe('CategoriesController', () => {
+  let controller: CategoriesController;
+  let service: CategoriesService;
+
+  // Sample data with staffOnly field
+  const mockCategories = [
+    {
+      id: '1',
+      name: 'Test Category 1',
+      description: 'Test Description 1',
+      staffOnly: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      alwaysRequired: false,
+      location: null,
+      jobs: [],
+    },
+    {
+      id: '2',
+      name: 'Test Category 2',
+      description: 'Test Description 2',
+      staffOnly: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      alwaysRequired: false,
+      location: null,
+      jobs: [],
+    },
+  ];
+
+  // Mock the categories service
+  const mockCategoriesService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  // Mock guards
+  const mockJwtAuthGuard = { canActivate: jest.fn().mockReturnValue(true) };
+  const mockRolesGuard = { canActivate: jest.fn().mockReturnValue(true) };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoriesController],
+      providers: [
+        {
+          provide: CategoriesService,
+          useValue: mockCategoriesService,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtAuthGuard)
+      .overrideGuard(RolesGuard)
+      .useValue(mockRolesGuard)
+      .compile();
+
+    controller = module.get<CategoriesController>(CategoriesController);
+    service = module.get<CategoriesService>(CategoriesService);
+
+    // Reset all mocks
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a job category with staffOnly field', async () => {
+      const createDto = {
+        name: 'New Staff Category',
+        description: 'New staff-only category',
+        staffOnly: true,
+      };
+
+      const expectedResult = {
+        ...createDto,
+        id: '3',
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        alwaysRequired: false,
+        location: null,
+      };
+
+      mockCategoriesService.create.mockResolvedValue(expectedResult);
+
+      const result = await controller.create(createDto);
+      
+      expect(mockCategoriesService.create).toHaveBeenCalledWith(createDto);
+      expect(result).toEqual(expectedResult);
+      expect(result.staffOnly).toBe(true);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all job categories with staffOnly field', async () => {
+      mockCategoriesService.findAll.mockResolvedValue(mockCategories);
+
+      const result = await controller.findAll();
+      
+      expect(mockCategoriesService.findAll).toHaveBeenCalled();
+      expect(result).toEqual(mockCategories);
+      expect(result[0].staffOnly).toBe(false);
+      expect(result[1].staffOnly).toBe(true);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single job category with staffOnly field', async () => {
+      mockCategoriesService.findOne.mockResolvedValue(mockCategories[1]);
+
+      const result = await controller.findOne('2');
+      
+      expect(mockCategoriesService.findOne).toHaveBeenCalledWith('2');
+      expect(result).toEqual(mockCategories[1]);
+      expect(result.staffOnly).toBe(true);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a job category including the staffOnly field', async () => {
+      const updateDto = {
+        staffOnly: true,
+      };
+
+      const updatedCategory = {
+        ...mockCategories[0],
+        staffOnly: true,
+      };
+
+      mockCategoriesService.update.mockResolvedValue(updatedCategory);
+
+      const result = await controller.update('1', updateDto);
+      
+      expect(mockCategoriesService.update).toHaveBeenCalledWith('1', updateDto);
+      expect(result).toEqual(updatedCategory);
+      expect(result.staffOnly).toBe(true);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a job category', async () => {
+      mockCategoriesService.remove.mockResolvedValue(mockCategories[0]);
+
+      const result = await controller.remove('1');
+      
+      expect(mockCategoriesService.remove).toHaveBeenCalledWith('1');
+      expect(result).toEqual(mockCategories[0]);
+    });
+  });
+}); 

--- a/apps/api/src/jobs/categories/categories.controller.spec.ts
+++ b/apps/api/src/jobs/categories/categories.controller.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoriesController } from './categories.controller';
 import { CategoriesService } from './categories.service';
-import { UserRole } from '@prisma/client';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 

--- a/apps/api/src/jobs/categories/categories.service.spec.ts
+++ b/apps/api/src/jobs/categories/categories.service.spec.ts
@@ -1,0 +1,222 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesService } from './categories.service';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { NotFoundException, ConflictException } from '@nestjs/common';
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+  let prismaService: PrismaService;
+
+  // Mock data
+  const mockCategories = [
+    {
+      id: '1',
+      name: 'Test Category 1',
+      description: 'Test Description 1',
+      staffOnly: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      alwaysRequired: false,
+      location: null,
+      jobs: [],
+    },
+    {
+      id: '2',
+      name: 'Test Category 2',
+      description: 'Test Description 2',
+      staffOnly: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      alwaysRequired: false,
+      location: null,
+      jobs: [],
+    },
+  ];
+
+  // Create mock Prisma service
+  const mockPrismaService = {
+    jobCategory: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategoriesService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CategoriesService>(CategoriesService);
+    prismaService = module.get<PrismaService>(PrismaService);
+
+    // Reset mock implementation for each test
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new job category with staffOnly=false by default', async () => {
+      const createDto = {
+        name: 'New Category',
+        description: 'New Description',
+      };
+
+      const expectedResult = {
+        id: '3',
+        name: 'New Category',
+        description: 'New Description',
+        staffOnly: false, // Default value when not provided
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        alwaysRequired: false,
+        location: null,
+      };
+
+      mockPrismaService.jobCategory.create.mockResolvedValue(expectedResult);
+
+      const result = await service.create(createDto);
+      
+      expect(mockPrismaService.jobCategory.create).toHaveBeenCalledWith({
+        data: createDto,
+      });
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should create a job category with staffOnly=true when specified', async () => {
+      const createDto = {
+        name: 'Staff Category',
+        description: 'Staff Only Description',
+        staffOnly: true,
+      };
+
+      const expectedResult = {
+        id: '4',
+        name: 'Staff Category',
+        description: 'Staff Only Description',
+        staffOnly: true,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        alwaysRequired: false,
+        location: null,
+      };
+
+      mockPrismaService.jobCategory.create.mockResolvedValue(expectedResult);
+
+      const result = await service.create(createDto);
+      
+      expect(mockPrismaService.jobCategory.create).toHaveBeenCalledWith({
+        data: createDto,
+      });
+      expect(result).toEqual(expectedResult);
+      expect(result.staffOnly).toBe(true);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of job categories including staffOnly field', async () => {
+      mockPrismaService.jobCategory.findMany.mockResolvedValue(mockCategories);
+
+      const result = await service.findAll();
+      
+      expect(mockPrismaService.jobCategory.findMany).toHaveBeenCalled();
+      expect(result).toEqual(mockCategories);
+      expect(result[0].staffOnly).toBe(false);
+      expect(result[1].staffOnly).toBe(true);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single job category with staffOnly field', async () => {
+      mockPrismaService.jobCategory.findUnique.mockResolvedValue(mockCategories[1]);
+
+      const result = await service.findOne('2');
+      
+      expect(mockPrismaService.jobCategory.findUnique).toHaveBeenCalledWith({
+        where: { id: '2' },
+        include: { jobs: true },
+      });
+      expect(result).toEqual(mockCategories[1]);
+      expect(result.staffOnly).toBe(true);
+    });
+
+    it('should throw NotFoundException when category not found', async () => {
+      mockPrismaService.jobCategory.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('999')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a job category including the staffOnly field', async () => {
+      const updateDto = {
+        staffOnly: true,
+        description: 'Updated description',
+      };
+
+      const updatedCategory = {
+        ...mockCategories[0],
+        staffOnly: true,
+        description: 'Updated description',
+      };
+
+      mockPrismaService.jobCategory.update.mockResolvedValue(updatedCategory);
+
+      const result = await service.update('1', updateDto);
+      
+      expect(mockPrismaService.jobCategory.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: updateDto,
+        include: { jobs: true },
+      });
+      expect(result).toEqual(updatedCategory);
+      expect(result.staffOnly).toBe(true);
+    });
+
+    it('should throw NotFoundException when trying to update non-existent category', async () => {
+      mockPrismaService.jobCategory.update.mockRejectedValue(new Error());
+
+      await expect(service.update('999', { name: 'Test' })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a job category', async () => {
+      mockPrismaService.jobCategory.delete.mockResolvedValue(mockCategories[0]);
+
+      const result = await service.remove('1');
+      
+      expect(mockPrismaService.jobCategory.delete).toHaveBeenCalledWith({
+        where: { id: '1' },
+      });
+      expect(result).toEqual(mockCategories[0]);
+    });
+
+    it('should throw NotFoundException when trying to delete non-existent category', async () => {
+      const error = new Error();
+      Object.defineProperty(error, 'code', { value: 'P2025' });
+      mockPrismaService.jobCategory.delete.mockRejectedValue(error);
+
+      await expect(service.remove('999')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ConflictException when category is in use', async () => {
+      const error = new Error();
+      Object.defineProperty(error, 'code', { value: 'P2003' });
+      mockPrismaService.jobCategory.delete.mockRejectedValue(error);
+
+      await expect(service.remove('1')).rejects.toThrow(ConflictException);
+    });
+  });
+}); 

--- a/apps/api/src/jobs/categories/categories.service.spec.ts
+++ b/apps/api/src/jobs/categories/categories.service.spec.ts
@@ -5,8 +5,7 @@ import { NotFoundException, ConflictException } from '@nestjs/common';
 
 describe('CategoriesService', () => {
   let service: CategoriesService;
-  let prismaService: PrismaService;
-
+  
   // Mock data
   const mockCategories = [
     {
@@ -56,7 +55,6 @@ describe('CategoriesService', () => {
     }).compile();
 
     service = module.get<CategoriesService>(CategoriesService);
-    prismaService = module.get<PrismaService>(PrismaService);
 
     // Reset mock implementation for each test
     jest.clearAllMocks();

--- a/apps/api/src/jobs/categories/dto/create-category.dto.ts
+++ b/apps/api/src/jobs/categories/dto/create-category.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, IsBoolean, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateCategoryDto {
@@ -17,4 +17,14 @@ export class CreateCategoryDto {
   @IsString()
   @IsNotEmpty()
   description!: string;
+
+  @ApiProperty({
+    description: 'Whether the category should only be visible to staff members',
+    example: false,
+    default: false,
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  staffOnly?: boolean;
 } 

--- a/apps/api/src/jobs/categories/dto/update-category.dto.ts
+++ b/apps/api/src/jobs/categories/dto/update-category.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional } from 'class-validator';
+import { IsString, IsOptional, IsBoolean } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateCategoryDto {
@@ -19,4 +19,13 @@ export class UpdateCategoryDto {
   @IsString()
   @IsOptional()
   description?: string;
+
+  @ApiProperty({
+    description: 'Whether the category should only be visible to staff members',
+    example: false,
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  staffOnly?: boolean;
 } 

--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useAuth } from '../../store/AuthContext';
+import { useAuth } from '../../store/authUtils';
 
 const LoginForm: React.FC = () => {
   // Form state

--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -42,7 +42,7 @@ const LoginForm: React.FC = () => {
   useEffect(() => {
     if (authError) {
       setError(authError);
-      // Reset loading state when there's an error
+      // Reset loading state when there's an error from auth context
       setLocalLoading(false);
     }
   }, [authError]);
@@ -110,11 +110,16 @@ const LoginForm: React.FC = () => {
       // Call the API to verify the code
       await verifyCode(email, verificationCode);
       // Successful verification will trigger a redirect via the isAuthenticated useEffect
-    } catch (error) {
-      // Error is already set in the auth context and will update via useEffect
-      console.error('Verification failed:', error);
+    } catch (err) {
+      // If there's an error, display it to the user
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Verification failed. Please check your code and try again.');
+      }
+      console.error('Verification failed:', err);
     } finally {
-      // Always reset loading state
+      // Always reset loading state regardless of success or failure
       setLocalLoading(false);
     }
   };
@@ -126,8 +131,9 @@ const LoginForm: React.FC = () => {
       </h2>
       
       {error && (
-        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-          {error}
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4" role="alert">
+          <p className="font-medium">Error:</p>
+          <p>{error}</p>
         </div>
       )}
       

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { useAuth } from '../../store/AuthContext';
+import { useAuth } from '../../store/authUtils';
 import { LogOut, User, Tent, Calendar, FileText, Settings } from 'lucide-react';
 import { PATHS } from '../../routes';
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -639,6 +639,7 @@ export const JobCategorySchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
+  staffOnly: z.boolean().default(false),
 });
 
 export type JobCategory = z.infer<typeof JobCategorySchema>;

--- a/apps/web/src/pages/AdminJobCategoriesPage.tsx
+++ b/apps/web/src/pages/AdminJobCategoriesPage.tsx
@@ -213,7 +213,7 @@ export default function AdminJobCategoriesPage() {
                   onChange={handleFormChange}
                 />
                 <label htmlFor="staffOnly" className="ml-2 block text-sm text-gray-900">
-                  Staff Only (only visible to staff members)
+                  Only visible to staff
                 </label>
               </div>
               {formError && <div className="text-red-600 mb-2">{formError}</div>}

--- a/apps/web/src/pages/AdminJobCategoriesPage.tsx
+++ b/apps/web/src/pages/AdminJobCategoriesPage.tsx
@@ -6,6 +6,7 @@ import { isAxiosError } from 'axios';
 interface CategoryFormState {
   name: string;
   description: string;
+  staffOnly: boolean;
 }
 
 export default function AdminJobCategoriesPage() {
@@ -20,14 +21,14 @@ export default function AdminJobCategoriesPage() {
 
   const [modalOpen, setModalOpen] = useState(false);
   const [editId, setEditId] = useState<string | null>(null);
-  const [form, setForm] = useState<CategoryFormState>({ name: '', description: '' });
+  const [form, setForm] = useState<CategoryFormState>({ name: '', description: '', staffOnly: false });
   const [formError, setFormError] = useState<string | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const openAddModal = () => {
     setEditId(null);
-    setForm({ name: '', description: '' });
+    setForm({ name: '', description: '', staffOnly: false });
     setFormError(null);
     setDeleteError(null);
     setDeleteId(null);
@@ -36,7 +37,11 @@ export default function AdminJobCategoriesPage() {
 
   const openEditModal = (category: JobCategory) => {
     setEditId(category.id);
-    setForm({ name: category.name, description: category.description });
+    setForm({ 
+      name: category.name, 
+      description: category.description,
+      staffOnly: category.staffOnly || false
+    });
     setFormError(null);
     setDeleteError(null);
     setDeleteId(null);
@@ -51,7 +56,11 @@ export default function AdminJobCategoriesPage() {
   };
 
   const handleFormChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const value = e.target.type === 'checkbox' 
+      ? (e.target as HTMLInputElement).checked 
+      : e.target.value;
+    
+    setForm({ ...form, [e.target.name]: value });
   };
 
   const handleFormSubmit = async (e: React.FormEvent) => {
@@ -109,6 +118,7 @@ export default function AdminJobCategoriesPage() {
             <tr>
               <th className="px-4 py-2 border-b">Name</th>
               <th className="px-4 py-2 border-b">Description</th>
+              <th className="px-4 py-2 border-b">Staff Only</th>
               <th className="px-4 py-2 border-b">Actions</th>
             </tr>
           </thead>
@@ -119,6 +129,17 @@ export default function AdminJobCategoriesPage() {
               <tr key={cat.id} className="hover:bg-gray-50">
                 <td className="px-4 py-2 border-b">{cat.name}</td>
                 <td className="px-4 py-2 border-b">{cat.description}</td>
+                <td className="px-4 py-2 border-b text-center">
+                  {cat.staffOnly ? (
+                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                      Staff Only
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                      All Users
+                    </span>
+                  )}
+                </td>
                 <td className="px-4 py-2 border-b text-center">
                   <div className="flex justify-center space-x-2">
                     <button
@@ -142,7 +163,7 @@ export default function AdminJobCategoriesPage() {
             ))}
             {categories.length === 0 && !loading && (
               <tr>
-                <td colSpan={3} className="text-center py-4 text-gray-500">No job categories found.</td>
+                <td colSpan={4} className="text-center py-4 text-gray-500">No job categories found.</td>
               </tr>
             )}
           </tbody>
@@ -181,6 +202,19 @@ export default function AdminJobCategoriesPage() {
                   maxLength={500}
                   rows={3}
                 />
+              </div>
+              <div className="mb-4 flex items-center">
+                <input
+                  id="staffOnly"
+                  name="staffOnly"
+                  type="checkbox"
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                  checked={form.staffOnly}
+                  onChange={handleFormChange}
+                />
+                <label htmlFor="staffOnly" className="ml-2 block text-sm text-gray-900">
+                  Staff Only (only visible to staff members)
+                </label>
               </div>
               {formError && <div className="text-red-600 mb-2">{formError}</div>}
               <div className="flex justify-end gap-2">

--- a/apps/web/src/pages/AdminPage.tsx
+++ b/apps/web/src/pages/AdminPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAuth } from '../store/AuthContext';
+import { useAuth } from '../store/authUtils';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../routes';
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { useAuth } from '../store/AuthContext';
+import { useAuth } from '../store/authUtils';
 import { useProfile } from '../hooks/useProfile';
 import { PATHS } from '../routes';
 

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useAuth } from '../store/AuthContext';
+import { useAuth } from '../store/authUtils';
 import { PATHS } from '../routes';
 
 /**

--- a/apps/web/src/pages/admin/AdminJobCategoriesPage.test.tsx
+++ b/apps/web/src/pages/admin/AdminJobCategoriesPage.test.tsx
@@ -32,10 +32,27 @@ describe('AdminJobCategoriesPage', () => {
   it('should render the job categories table', () => {
     render(<AdminJobCategoriesPage />);
     expect(screen.getByText('Job Category Management')).toBeInTheDocument();
+    
+    // Check that the categories are rendered
     expect(screen.getByText('Kitchen')).toBeInTheDocument();
     expect(screen.getByText('Greeter')).toBeInTheDocument();
     expect(screen.getByText('All Users')).toBeInTheDocument();
-    expect(screen.getAllByText('Staff Only')).toHaveLength(2);
+    
+    // Check staffOnly status by finding the table rows and checking the staffOnly cell
+    const table = screen.getByRole('table');
+    const rows = table.querySelectorAll('tbody tr');
+    
+    // Check that we have the expected number of rows
+    expect(rows).toHaveLength(2); // 2 categories from mock data
+    
+    // Count how many rows have staffOnly set to true
+    const staffOnlyCount = Array.from(rows).filter(row => {
+      const staffOnlyCell = row.querySelector('td:nth-child(3)'); // 3rd column is staffOnly
+      return staffOnlyCell?.textContent?.includes('Staff Only') || false;
+    }).length;
+    
+    // Verify that we have 1 staffOnly category (from mock data)
+    expect(staffOnlyCount).toBe(1);
   });
 
   it('should open and submit the add category modal', async () => {

--- a/apps/web/src/pages/admin/AdminJobCategoriesPage.test.tsx
+++ b/apps/web/src/pages/admin/AdminJobCategoriesPage.test.tsx
@@ -61,7 +61,7 @@ describe('AdminJobCategoriesPage', () => {
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'NewCat' } });
     fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Desc' } });
     // By default, staffOnly should be unchecked
-    expect(screen.getByLabelText(/Staff Only/)).not.toBeChecked();
+    expect(screen.getByLabelText(/Only visible to staff/)).not.toBeChecked();
     fireEvent.click(screen.getByText('Add Category'));
     await waitFor(() => {
       expect(createCategory).toHaveBeenCalledWith({ 
@@ -77,7 +77,7 @@ describe('AdminJobCategoriesPage', () => {
     fireEvent.click(screen.getByLabelText('Add job category'));
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'StaffCat' } });
     fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Staff Desc' } });
-    fireEvent.click(screen.getByLabelText(/Staff Only/));
+    fireEvent.click(screen.getByLabelText(/Only visible to staff/));
     fireEvent.click(screen.getByText('Add Category'));
     await waitFor(() => {
       expect(createCategory).toHaveBeenCalledWith({ 
@@ -92,7 +92,7 @@ describe('AdminJobCategoriesPage', () => {
     render(<AdminJobCategoriesPage />);
     // Open the Greeter category (staffOnly: true)
     fireEvent.click(screen.getByLabelText('Edit Greeter'));
-    expect(screen.getByLabelText(/Staff Only/)).toBeChecked();
+    expect(screen.getByLabelText(/Only visible to staff/)).toBeChecked();
   });
 
   it('should open and submit the edit category modal', async () => {
@@ -100,9 +100,9 @@ describe('AdminJobCategoriesPage', () => {
     fireEvent.click(screen.getByLabelText('Edit Kitchen'));
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Updated' } });
     // Checkbox should be unchecked by default for "Kitchen" category
-    expect(screen.getByLabelText(/Staff Only/)).not.toBeChecked();
+    expect(screen.getByLabelText(/Only visible to staff/)).not.toBeChecked();
     // Check the staffOnly checkbox
-    fireEvent.click(screen.getByLabelText(/Staff Only/));
+    fireEvent.click(screen.getByLabelText(/Only visible to staff/));
     fireEvent.click(screen.getByText('Save Changes'));
     await waitFor(() => {
       expect(updateCategory).toHaveBeenCalledWith('1', { 

--- a/apps/web/src/routes/AppRouter.test.tsx
+++ b/apps/web/src/routes/AppRouter.test.tsx
@@ -2,9 +2,16 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import AppRouter from './AppRouter';
-import { useAuth } from '../store/authUtils';
 import { ROUTES } from './index';
 import { ROLES } from '../types/auth';
+
+// Mock the useAuth hook
+vi.mock('../store/authUtils', () => ({
+  useAuth: vi.fn()
+}));
+
+// Import after mocking to get the mocked version
+import { useAuth } from '../store/authUtils';
 
 // Mock the page components to simplify testing
 vi.mock('../pages/HomePage.tsx', () => ({

--- a/apps/web/src/routes/AppRouter.test.tsx
+++ b/apps/web/src/routes/AppRouter.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import AppRouter from './AppRouter';
-import { useAuth } from '../store/AuthContext';
+import { useAuth } from '../store/authUtils';
 import { ROUTES } from './index';
 import { ROLES } from '../types/auth';
 

--- a/apps/web/src/routes/ProtectedRoute.test.tsx
+++ b/apps/web/src/routes/ProtectedRoute.test.tsx
@@ -2,13 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ProtectedRoute from './ProtectedRoute';
-import { useAuth } from '../store/authUtils';
 import { ROLES } from '../types/auth';
 
-// Mock the auth context
-vi.mock('../store/AuthContext', () => ({
+// Mock the useAuth hook from authUtils
+vi.mock('../store/authUtils', () => ({
   useAuth: vi.fn()
 }));
+
+// Import after mocking to get the mocked version
+import { useAuth } from '../store/authUtils';
 
 describe('ProtectedRoute', () => {
   // Test components to simulate different pages

--- a/apps/web/src/routes/ProtectedRoute.test.tsx
+++ b/apps/web/src/routes/ProtectedRoute.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ProtectedRoute from './ProtectedRoute';
-import { useAuth } from '../store/AuthContext';
+import { useAuth } from '../store/authUtils';
 import { ROLES } from '../types/auth';
 
 // Mock the auth context

--- a/apps/web/src/routes/ProtectedRoute.tsx
+++ b/apps/web/src/routes/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { useAuth } from '../store/AuthContext';
+import { useAuth } from '../store/authUtils';
 import { UserRole } from '../types/auth';
 import { PATHS } from './index';
 

--- a/apps/web/src/store/AuthContext.tsx
+++ b/apps/web/src/store/AuthContext.tsx
@@ -176,8 +176,16 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       // Clear any stored email after successful verification
       localStorage.removeItem('pendingLoginEmail');
     } catch (err) {
-      setError('Invalid verification code. Please try again.');
+      // Extract error message from the Error object or use a default message
+      const errorMessage = err instanceof Error 
+        ? err.message 
+        : 'Invalid verification code. Please try again.';
+      
+      setError(errorMessage);
       console.error('Verification failed:', err);
+      
+      // Rethrow the error so it can be caught by the component
+      throw err;
     } finally {
       // Always ensure loading state is reset
       setIsLoading(false);

--- a/apps/web/src/store/AuthContext.tsx
+++ b/apps/web/src/store/AuthContext.tsx
@@ -1,45 +1,10 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { useState, useEffect, ReactNode } from 'react';
 import { User } from '../types';
 import { auth, clearJwtToken } from '../lib/api';
 import cookieService from '../lib/cookieService';
+import { AuthContext, mapApiRoleToClientRole } from './authUtils';
 
-/**
- * Authentication context interface
- */
-interface AuthContextType {
-  user: User | null;
-  requestVerificationCode: (email: string) => Promise<boolean>;
-  verifyCode: (email: string, code: string) => Promise<void>;
-  logout: () => Promise<void>;
-  isLoading: boolean;
-  error: string | null;
-  isAuthenticated: boolean;
-}
 
-/**
- * Create the auth context with default values
- */
-const AuthContext = createContext<AuthContextType>({
-  isAuthenticated: false,
-  isLoading: false,
-  user: null,
-  error: null,
-  requestVerificationCode: async () => false,
-  verifyCode: async () => {},
-  logout: async () => {},
-});
-
-export const useAuth = () => useContext(AuthContext);
-
-/**
- * Maps API role strings to client-side role enum values
- */
-function mapApiRoleToClientRole(apiRole: string): 'admin' | 'staff' | 'user' {
-  const role = apiRole.toUpperCase();
-  if (role === 'ADMIN') return 'admin';
-  if (role === 'STAFF') return 'staff';
-  return 'user';
-}
 
 /**
  * AuthProvider component that manages authentication state

--- a/apps/web/src/store/ProfileContext.tsx
+++ b/apps/web/src/store/ProfileContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useEffect, ReactNode } from 'react';
-import { useAuth } from './AuthContext';
+import { useAuth } from './authUtils';
 import { api, auth } from '../lib/api';
 
 interface UserProfile {

--- a/apps/web/src/store/authUtils.ts
+++ b/apps/web/src/store/authUtils.ts
@@ -1,0 +1,43 @@
+import { createContext, useContext } from 'react';
+import { User } from '../types';
+
+/**
+ * Authentication context interface
+ */
+export interface AuthContextType {
+  user: User | null;
+  requestVerificationCode: (email: string) => Promise<boolean>;
+  verifyCode: (email: string, code: string) => Promise<void>;
+  logout: () => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+  isAuthenticated: boolean;
+}
+
+/**
+ * Create the auth context with default values
+ */
+export const AuthContext = createContext<AuthContextType>({
+  isAuthenticated: false,
+  isLoading: false,
+  user: null,
+  error: null,
+  requestVerificationCode: async () => false,
+  verifyCode: async () => {},
+  logout: async () => {},
+});
+
+/**
+ * Hook to use the authentication context
+ */
+export const useAuth = () => useContext(AuthContext);
+
+/**
+ * Maps API role strings to client-side role enum values
+ */
+export function mapApiRoleToClientRole(apiRole: string): 'admin' | 'staff' | 'user' {
+  const role = apiRole.toUpperCase();
+  if (role === 'ADMIN') return 'admin';
+  if (role === 'STAFF') return 'staff';
+  return 'user';
+}

--- a/docs/frontend-tasks.md
+++ b/docs/frontend-tasks.md
@@ -145,7 +145,7 @@
      - [ ] Fix: Show friendly names for Type in list view
    - [ ] Job/category management
      - [x] Basic CRUD for job categories
-     - [ ] Support for "staff only" job category designation
+     - [x] Support for "staff only" job category designation
      - [ ] Support for "always required" job category functionality
      - [ ] Job management interface for creating and editing jobs
    - [ ] Shift management


### PR DESCRIPTION
- Introduced CategoriesController and CategoriesService tests to validate CRUD operations for job categories, including the new staffOnly field.
- Updated CreateCategoryDto and UpdateCategoryDto to include staffOnly as an optional boolean property.
- Enhanced AdminJobCategoriesPage to manage staff-only categories, including UI updates and form handling.
- Added tests for AdminJobCategoriesPage to ensure proper functionality for staff-only category creation and editing.
- Updated API schema to reflect the staffOnly property in job categories.