### PR TITLE
Add friendly day name conversion to NotificationsService

### DIFF
--- a/apps/api/src/notifications/services/notifications.service.ts
+++ b/apps/api/src/notifications/services/notifications.service.ts
@@ -668,6 +668,45 @@ export class NotificationsService {
   }
 
   /**
+   * Convert DayOfWeek enum to user-friendly text
+   * @param day Raw day enum value
+   * @returns User-friendly day text
+   */
+  private getFriendlyDayName(day: string): string {
+    if (!day) return '';
+    
+    const dayMap: Record<string, string> = {
+      // Standard days
+      MONDAY: 'Monday',
+      TUESDAY: 'Tuesday',
+      WEDNESDAY: 'Wednesday',
+      THURSDAY: 'Thursday',
+      FRIDAY: 'Friday',
+      SATURDAY: 'Saturday',
+      SUNDAY: 'Sunday',
+      // Special event days
+      PRE_OPENING: 'Pre-Opening',
+      OPENING_SUNDAY: 'Opening Sunday',
+      CLOSING_SUNDAY: 'Closing Sunday',
+      POST_EVENT: 'Post-Event',
+      // Handle lowercase versions too
+      monday: 'Monday',
+      tuesday: 'Tuesday',
+      wednesday: 'Wednesday',
+      thursday: 'Thursday',
+      friday: 'Friday',
+      saturday: 'Saturday',
+      sunday: 'Sunday',
+      pre_opening: 'Pre-Opening',
+      opening_sunday: 'Opening Sunday',
+      closing_sunday: 'Closing Sunday',
+      post_event: 'Post-Event'
+    };
+    
+    return dayMap[day] || day; // Return mapped value or original if not found
+  }
+
+  /**
    * Get appropriate greeting based on available name information
    * @param userName Full name (first + last)
    * @param playaName Playa name
@@ -752,7 +791,7 @@ export class NotificationsService {
       ${campingOptions ? campingOptions.map(option => `- ${option.name}${option.description ? ` (${option.description})` : ''}`).join('\n') : 'N/A'}
       
       Work Shift(s):
-      ${jobs ? jobs.map(job => `- ${job.name} (${job.category}, ${job.shift.name} - ${job.shift.endTime})`).join('\n') : 'N/A'}
+      ${jobs ? jobs.map(job => `- ${job.category}: ${this.getFriendlyDayName(job.shift.dayOfWeek)} ${job.shift.startTime}-${job.shift.endTime}`).join('\n') : 'N/A'}
       
       Thank you for registering with ${campName}!
       
@@ -773,7 +812,7 @@ export class NotificationsService {
         </ul>
         <p><strong>Work Shift(s):</strong></p>
         <ul>
-          ${jobs ? jobs.map(job => `<li>${job.name} (${job.category}, ${job.shift.name} - ${job.shift.endTime})</li>`).join('') : '<li>N/A</li>'}
+          ${jobs ? jobs.map(job => `<li>${job.category}: ${this.getFriendlyDayName(job.shift.dayOfWeek)} ${job.shift.startTime}-${job.shift.endTime}</li>`).join('') : '<li>N/A</li>'}
         </ul>
         <p>Thank you for registering with ${campName}!</p>
         <p>Best regards,<br>The ${campName} Team</p>

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -5,4 +5,7 @@ export * from './enums/registration-status.enum';
 export * from './enums/payment-status.enum';
 export * from './enums/payment-method.enum';
 
+// Export utilities
+export * from './utils/day-utils';
+
 // Export other shared types as needed 

--- a/libs/types/src/utils/day-utils.ts
+++ b/libs/types/src/utils/day-utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared utility functions for day-related formatting
+ */
+
+/**
+ * Convert a day enum value to a friendly display name
+ */
+export const getFriendlyDayName = (day: string): string => {
+  if (!day) return '';
+  
+  const dayMap: Record<string, string> = {
+    // Standard days
+    MONDAY: 'Monday',
+    TUESDAY: 'Tuesday',
+    WEDNESDAY: 'Wednesday',
+    THURSDAY: 'Thursday',
+    FRIDAY: 'Friday',
+    SATURDAY: 'Saturday',
+    SUNDAY: 'Sunday',
+    // Special event days
+    PRE_OPENING: 'Pre-Opening',
+    OPENING_SUNDAY: 'Opening Sunday',
+    CLOSING_SUNDAY: 'Closing Sunday',
+    POST_EVENT: 'Post-Event',
+    // Handle lowercase versions too
+    monday: 'Monday',
+    tuesday: 'Tuesday',
+    wednesday: 'Wednesday',
+    thursday: 'Thursday',
+    friday: 'Friday',
+    saturday: 'Saturday',
+    sunday: 'Sunday',
+    pre_opening: 'Pre-Opening',
+    opening_sunday: 'Opening Sunday',
+    closing_sunday: 'Closing Sunday',
+    post_event: 'Post-Event'
+  };
+  
+  return dayMap[day] || day; // Return mapped value or original if not found
+}; 


### PR DESCRIPTION
- Introduced a private method getFriendlyDayName to convert DayOfWeek enum values to user-friendly text.
- Updated email templates to utilize the new method for displaying work shift days.
- Created a new utility file day-utils.ts to house the day conversion logic for better code organization and reusability.