### PR TITLE
feat: add minLength property to CampingOptionField and related DTOs

### DIFF
--- a/apps/api/prisma/migrations/20250607034900_add_min_length_to_camping_option_fields/migration.sql
+++ b/apps/api/prisma/migrations/20250607034900_add_min_length_to_camping_option_fields/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "camping_option_fields" ADD COLUMN     "minLength" INTEGER;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -70,6 +70,7 @@ model CampingOptionField {
   dataType        FieldType
   required        Boolean                   @default(false)
   maxLength       Int?
+  minLength       Int?
   minValue        Float?
   maxValue        Float?
   order           Int                       @default(0)

--- a/apps/api/src/camping-options/dto/camping-option-field-response.dto.ts
+++ b/apps/api/src/camping-options/dto/camping-option-field-response.dto.ts
@@ -63,6 +63,16 @@ export class CampingOptionFieldResponseDto {
   maxLength!: number | null;
   
   /**
+   * Minimum length for string fields
+   */
+  @ApiProperty({
+    description: 'Minimum length for string fields',
+    example: 5,
+    nullable: true
+  })
+  minLength!: number | null;
+  
+  /**
    * Minimum value for numeric fields
    */
   @ApiProperty({

--- a/apps/api/src/camping-options/dto/create-camping-option-field.dto.spec.ts
+++ b/apps/api/src/camping-options/dto/create-camping-option-field.dto.spec.ts
@@ -1,0 +1,119 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateCampingOptionFieldDto } from './create-camping-option-field.dto';
+import { FieldType } from '../entities/camping-option-field.entity';
+
+describe('CreateCampingOptionFieldDto', () => {
+  const validCampingOptionId = '550e8400-e29b-41d4-a716-446655440000';
+
+  describe('minLength validation', () => {
+    it('should pass validation with valid minLength for STRING field', async () => {
+      const dto = plainToInstance(CreateCampingOptionFieldDto, {
+        displayName: 'Test Field',
+        dataType: FieldType.STRING,
+        minLength: 5,
+        campingOptionId: validCampingOptionId,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should pass validation with valid minLength for MULTILINE_STRING field', async () => {
+      const dto = plainToInstance(CreateCampingOptionFieldDto, {
+        displayName: 'Test Field',
+        dataType: FieldType.MULTILINE_STRING,
+        minLength: 10,
+        campingOptionId: validCampingOptionId,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should pass validation with minLength of 0', async () => {
+      const dto = plainToInstance(CreateCampingOptionFieldDto, {
+        displayName: 'Test Field',
+        dataType: FieldType.STRING,
+        minLength: 0,
+        campingOptionId: validCampingOptionId,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should fail validation with negative minLength', async () => {
+      const dto = plainToInstance(CreateCampingOptionFieldDto, {
+        displayName: 'Test Field',
+        dataType: FieldType.STRING,
+        minLength: -1,
+        campingOptionId: validCampingOptionId,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+
+    it('should pass validation when minLength is not provided for STRING field', async () => {
+      const dto = plainToInstance(CreateCampingOptionFieldDto, {
+        displayName: 'Test Field',
+        dataType: FieldType.STRING,
+        campingOptionId: validCampingOptionId,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should pass validation when minLength is provided for non-string field types', async () => {
+      const dto = plainToInstance(CreateCampingOptionFieldDto, {
+        displayName: 'Test Field',
+        dataType: FieldType.NUMBER,
+        minLength: 5, // This should be ignored for non-string types
+        campingOptionId: validCampingOptionId,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should pass validation with both minLength and maxLength', async () => {
+      const dto = plainToInstance(CreateCampingOptionFieldDto, {
+        displayName: 'Test Field',
+        dataType: FieldType.STRING,
+        minLength: 5,
+        maxLength: 100,
+        campingOptionId: validCampingOptionId,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('required field validation', () => {
+    it('should fail validation when displayName is missing', async () => {
+      const dto = plainToInstance(CreateCampingOptionFieldDto, {
+        dataType: FieldType.STRING,
+        campingOptionId: validCampingOptionId,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints).toHaveProperty('isString');
+    });
+
+    it('should fail validation when dataType is missing', async () => {
+      const dto = plainToInstance(CreateCampingOptionFieldDto, {
+        displayName: 'Test Field',
+        campingOptionId: validCampingOptionId,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints).toHaveProperty('isEnum');
+    });
+  });
+}); 

--- a/apps/api/src/camping-options/dto/create-camping-option-field.dto.ts
+++ b/apps/api/src/camping-options/dto/create-camping-option-field.dto.ts
@@ -77,6 +77,21 @@ export class CreateCampingOptionFieldDto {
   maxLength?: number;
   
   /**
+   * Minimum length for string fields
+   */
+  @ApiProperty({
+    description: 'Minimum length for string fields',
+    example: 5,
+    required: false,
+  })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  @ValidateIf(o => o.dataType === FieldType.STRING || o.dataType === FieldType.MULTILINE_STRING)
+  @Type(() => Number)
+  minLength?: number;
+  
+  /**
    * Minimum value for numeric fields
    */
   @ApiProperty({

--- a/apps/api/src/camping-options/dto/update-camping-option-field.dto.ts
+++ b/apps/api/src/camping-options/dto/update-camping-option-field.dto.ts
@@ -80,6 +80,21 @@ export class UpdateCampingOptionFieldDto {
   maxLength?: number;
   
   /**
+   * Minimum length for string fields
+   */
+  @ApiProperty({
+    description: 'Minimum length for string fields',
+    example: 5,
+    required: false,
+  })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  @ValidateIf(o => !o.dataType || o.dataType === FieldType.STRING || o.dataType === FieldType.MULTILINE_STRING)
+  @Type(() => Number)
+  minLength?: number;
+  
+  /**
    * Minimum value for numeric fields
    */
   @ApiProperty({

--- a/apps/api/src/camping-options/entities/camping-option-field-integration.spec.ts
+++ b/apps/api/src/camping-options/entities/camping-option-field-integration.spec.ts
@@ -1,0 +1,145 @@
+import { CampingOptionField, FieldType } from './camping-option-field.entity';
+
+describe('CampingOptionField - Integration Tests for MinLength', () => {
+  describe('Real-world scenarios', () => {
+    it('should validate a bio field with minimum length requirement', () => {
+      const bioField = new CampingOptionField({
+        id: 'bio-field-id',
+        displayName: 'Tell us about yourself',
+        description: 'Please provide a brief bio (minimum 50 characters)',
+        dataType: FieldType.MULTILINE_STRING,
+        required: false,
+        maxLength: 500,
+        minLength: 50,
+        minValue: null,
+        maxValue: null,
+        order: 1,
+        campingOptionId: 'camping-option-id',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // Test cases that match the user requirements
+      
+      // Field not required, text length 0 = ok
+      const emptyResult = bioField.validateValue('');
+      expect(emptyResult.valid).toBe(true);
+      expect(emptyResult.message).toBeUndefined();
+
+      // Field not required, text length >= minLength = ok
+      const validResult = bioField.validateValue('I am a passionate burner who loves art, music, and community. I have been attending regional burns for 5 years.');
+      expect(validResult.valid).toBe(true);
+      expect(validResult.message).toBeUndefined();
+
+      // Field not required, text length < minLength = not ok
+      const tooShortResult = bioField.validateValue('Too short');
+      expect(tooShortResult.valid).toBe(false);
+      expect(tooShortResult.message).toBe('Tell us about yourself must be at least 50 characters');
+    });
+
+    it('should validate a required field with minimum length', () => {
+      const nameField = new CampingOptionField({
+        id: 'name-field-id',
+        displayName: 'Playa Name',
+        description: 'Your playa name (minimum 3 characters)',
+        dataType: FieldType.STRING,
+        required: true,
+        maxLength: 50,
+        minLength: 3,
+        minValue: null,
+        maxValue: null,
+        order: 1,
+        campingOptionId: 'camping-option-id',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // Field required, text length 0 = not ok (required validation takes precedence)
+      const emptyResult = nameField.validateValue('');
+      expect(emptyResult.valid).toBe(false);
+      expect(emptyResult.message).toBe('Playa Name is required');
+
+      // Field required, text length < minLength = not ok (minLength validation)
+      const tooShortResult = nameField.validateValue('Jo');
+      expect(tooShortResult.valid).toBe(false);
+      expect(tooShortResult.message).toBe('Playa Name must be at least 3 characters');
+
+      // Field required, text length >= minLength = ok
+      const validResult = nameField.validateValue('Dusty');
+      expect(validResult.valid).toBe(true);
+      expect(validResult.message).toBeUndefined();
+    });
+
+    it('should work with only minLength constraint (no maxLength)', () => {
+      const commentField = new CampingOptionField({
+        id: 'comment-field-id',
+        displayName: 'Additional Comments',
+        description: 'Any additional comments (minimum 10 characters if provided)',
+        dataType: FieldType.MULTILINE_STRING,
+        required: false,
+        maxLength: null, // No max length limit
+        minLength: 10,
+        minValue: null,
+        maxValue: null,
+        order: 1,
+        campingOptionId: 'camping-option-id',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // Empty is ok since not required
+      const emptyResult = commentField.validateValue('');
+      expect(emptyResult.valid).toBe(true);
+
+      // Below minimum is not ok
+      const tooShortResult = commentField.validateValue('Too short');
+      expect(tooShortResult.valid).toBe(false);
+      expect(tooShortResult.message).toBe('Additional Comments must be at least 10 characters');
+
+      // Meeting minimum is ok
+      const validResult = commentField.validateValue('This is a valid comment that meets the minimum length requirement.');
+      expect(validResult.valid).toBe(true);
+
+      // Very long text is ok (no max length)
+      const longResult = commentField.validateValue('This is a very long comment that goes on and on and on and would normally exceed a maximum length but since there is no maximum length constraint it should be perfectly valid and accepted by the validation system.');
+      expect(longResult.valid).toBe(true);
+    });
+
+    it('should work with both minLength and maxLength constraints', () => {
+      const descriptionField = new CampingOptionField({
+        id: 'description-field-id',
+        displayName: 'Project Description',
+        description: 'Describe your art project (5-100 characters)',
+        dataType: FieldType.STRING,
+        required: false,
+        maxLength: 100,
+        minLength: 5,
+        minValue: null,
+        maxValue: null,
+        order: 1,
+        campingOptionId: 'camping-option-id',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // Empty is ok since not required
+      const emptyResult = descriptionField.validateValue('');
+      expect(emptyResult.valid).toBe(true);
+
+      // Below minimum is not ok
+      const tooShortResult = descriptionField.validateValue('Art');
+      expect(tooShortResult.valid).toBe(false);
+      expect(tooShortResult.message).toBe('Project Description must be at least 5 characters');
+
+      // Above maximum is not ok
+      const tooLongResult = descriptionField.validateValue('This is a very long description that exceeds the maximum allowed length of 100 characters and should be rejected by the validation system');
+      expect(tooLongResult.valid).toBe(false);
+      expect(tooLongResult.message).toBe('Project Description must be at most 100 characters');
+
+      // Within bounds is ok
+      const validResult = descriptionField.validateValue('Interactive LED sculpture with sound');
+      expect(validResult.valid).toBe(true);
+      expect(validResult.message).toBeUndefined();
+    });
+  });
+}); 

--- a/apps/api/src/camping-options/entities/camping-option-field.entity.spec.ts
+++ b/apps/api/src/camping-options/entities/camping-option-field.entity.spec.ts
@@ -1,5 +1,157 @@
 import { CampingOptionField, FieldType } from '../entities/camping-option-field.entity';
 
+describe('CampingOptionField - String Validation', () => {
+  describe('String Field with Min and Max Length Validation', () => {
+    let stringFieldWithLimits: CampingOptionField;
+
+    beforeEach(() => {
+      stringFieldWithLimits = new CampingOptionField({
+        id: 'test-string-id',
+        displayName: 'Bio',
+        description: 'Tell us about yourself',
+        dataType: FieldType.STRING,
+        required: false,
+        maxLength: 10,
+        minLength: 5,
+        minValue: null,
+        maxValue: null,
+        order: 1,
+        campingOptionId: 'camping-option-id',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    });
+
+    it('should be valid when text length is within min and max bounds', () => {
+      const result = stringFieldWithLimits.validateValue('hello');
+      expect(result.valid).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+
+    it('should be valid when text length equals minimum length', () => {
+      const result = stringFieldWithLimits.validateValue('12345');
+      expect(result.valid).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+
+    it('should be valid when text length equals maximum length', () => {
+      const result = stringFieldWithLimits.validateValue('1234567890');
+      expect(result.valid).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+
+    it('should be invalid when text length is below minimum', () => {
+      const result = stringFieldWithLimits.validateValue('hi');
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe('Bio must be at least 5 characters');
+    });
+
+    it('should be invalid when text length exceeds maximum', () => {
+      const result = stringFieldWithLimits.validateValue('this is too long');
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe('Bio must be at most 10 characters');
+    });
+
+    it('should be valid when field is not required and value is empty', () => {
+      const result = stringFieldWithLimits.validateValue('');
+      expect(result.valid).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+
+    it('should be valid when field is not required and value is null', () => {
+      const result = stringFieldWithLimits.validateValue(null);
+      expect(result.valid).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+  });
+
+  describe('Required String Field with Min Length', () => {
+    let requiredStringField: CampingOptionField;
+
+    beforeEach(() => {
+      requiredStringField = new CampingOptionField({
+        id: 'test-required-string-id',
+        displayName: 'Name',
+        description: 'Your full name',
+        dataType: FieldType.STRING,
+        required: true,
+        maxLength: null,
+        minLength: 3,
+        minValue: null,
+        maxValue: null,
+        order: 1,
+        campingOptionId: 'camping-option-id',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    });
+
+    it('should be invalid when required field is empty', () => {
+      const result = requiredStringField.validateValue('');
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe('Name is required');
+    });
+
+    it('should be invalid when required field is null', () => {
+      const result = requiredStringField.validateValue(null);
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe('Name is required');
+    });
+
+    it('should be invalid when required field has value below minimum length', () => {
+      const result = requiredStringField.validateValue('Jo');
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe('Name must be at least 3 characters');
+    });
+
+    it('should be valid when required field has value meeting minimum length', () => {
+      const result = requiredStringField.validateValue('Joe');
+      expect(result.valid).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+  });
+
+  describe('String Field with Only Min Length', () => {
+    let minOnlyField: CampingOptionField;
+
+    beforeEach(() => {
+      minOnlyField = new CampingOptionField({
+        id: 'test-min-only-id',
+        displayName: 'Comment',
+        description: 'Leave a comment',
+        dataType: FieldType.MULTILINE_STRING,
+        required: false,
+        maxLength: null,
+        minLength: 10,
+        minValue: null,
+        maxValue: null,
+        order: 1,
+        campingOptionId: 'camping-option-id',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    });
+
+    it('should be valid when text meets minimum length', () => {
+      const result = minOnlyField.validateValue('This is a valid comment');
+      expect(result.valid).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+
+    it('should be invalid when text is below minimum length', () => {
+      const result = minOnlyField.validateValue('Too short');
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe('Comment must be at least 10 characters');
+    });
+
+    it('should be valid when field is not required and empty', () => {
+      const result = minOnlyField.validateValue('');
+      expect(result.valid).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+  });
+});
+
 describe('CampingOptionField - Boolean Validation', () => {
   describe('Required Boolean Field Validation', () => {
     let requiredBooleanField: CampingOptionField;

--- a/apps/api/src/camping-options/entities/camping-option-field.entity.ts
+++ b/apps/api/src/camping-options/entities/camping-option-field.entity.ts
@@ -76,6 +76,16 @@ export class CampingOptionField {
   maxLength!: number | null;
   
   /**
+   * Minimum length for string fields
+   */
+  @ApiProperty({
+    description: 'Minimum length for string fields',
+    example: 5,
+    nullable: true
+  })
+  minLength!: number | null;
+  
+  /**
    * Minimum value for numeric fields
    */
   @ApiProperty({
@@ -151,7 +161,16 @@ export class CampingOptionField {
     switch (this.dataType) {
       case FieldType.STRING:
       case FieldType.MULTILINE_STRING:
-        if (this.maxLength && value.toString().length > this.maxLength) {
+        const textLength = value.toString().length;
+        
+        if (this.minLength && textLength < this.minLength) {
+          return { 
+            valid: false, 
+            message: `${this.displayName} must be at least ${this.minLength} characters`
+          };
+        }
+        
+        if (this.maxLength && textLength > this.maxLength) {
           return { 
             valid: false, 
             message: `${this.displayName} must be at most ${this.maxLength} characters`

--- a/apps/api/src/camping-options/services/camping-option-fields.service.ts
+++ b/apps/api/src/camping-options/services/camping-option-fields.service.ts
@@ -21,6 +21,7 @@ export class CampingOptionFieldsService {
     dataType: string;
     required: boolean;
     maxLength: number | null;
+    minLength: number | null;
     minValue: number | null;
     maxValue: number | null;
     order: number;
@@ -35,6 +36,7 @@ export class CampingOptionFieldsService {
       dataType: field.dataType as import('../entities/camping-option-field.entity').FieldType,
       required: field.required,
       maxLength: field.maxLength,
+      minLength: field.minLength,
       minValue: field.minValue,
       maxValue: field.maxValue,
       order: field.order,
@@ -75,6 +77,7 @@ export class CampingOptionFieldsService {
           dataType: createCampingOptionFieldDto.dataType,
           required: createCampingOptionFieldDto.required ?? false,
           maxLength: createCampingOptionFieldDto.maxLength ?? null,
+          minLength: createCampingOptionFieldDto.minLength ?? null,
           minValue: createCampingOptionFieldDto.minValue ?? null,
           maxValue: createCampingOptionFieldDto.maxValue ?? null,
           order: order,

--- a/apps/api/test/camping-option-fields.e2e-spec.ts
+++ b/apps/api/test/camping-option-fields.e2e-spec.ts
@@ -5,37 +5,6 @@ import { AppModule } from '../src/app.module';
 import { PrismaService } from '../src/common/prisma/prisma.service';
 import { UserRole, FieldType } from '@prisma/client';
 
-// Interface for raw camping option results
-interface RawCampingOption {
-  id: string;
-  name: string;
-  description: string | null;
-  enabled: boolean;
-  workShiftsRequired: number;
-  participantDues: number;
-  staffDues: number;
-  maxSignups: number;
-  campId: string;
-  jobCategoryIds: string[];
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-// Interface for raw camping option field results
-interface RawCampingOptionField {
-  id: string;
-  displayName: string;
-  description: string | null;
-  dataType: FieldType;
-  required: boolean;
-  maxLength: number | null;
-  minValue: number | null;
-  maxValue: number | null;
-  campingOptionId: string;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
 // Mock SendGrid
 jest.mock('@sendgrid/mail', () => ({
   setApiKey: jest.fn(),
@@ -165,6 +134,33 @@ describe('CampingOptionFieldsController (e2e)', () => {
       expect(response.body.description).toBe(createFieldDto.description);
       expect(response.body.dataType).toBe(createFieldDto.dataType);
       expect(response.body.required).toBe(createFieldDto.required);
+      expect(response.body.maxLength).toBe(createFieldDto.maxLength);
+      expect(response.body.campingOptionId).toBe(createFieldDto.campingOptionId);
+    });
+
+    it('should create a camping option field with minLength (admin)', async () => {
+      const createFieldDto = {
+        displayName: 'Bio',
+        description: 'Tell us about yourself',
+        dataType: FieldType.MULTILINE_STRING,
+        required: false,
+        minLength: 10,
+        maxLength: 500,
+        campingOptionId: testCampingOptionId,
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/camping-option-fields')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(createFieldDto)
+        .expect(201);
+
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.displayName).toBe(createFieldDto.displayName);
+      expect(response.body.description).toBe(createFieldDto.description);
+      expect(response.body.dataType).toBe(createFieldDto.dataType);
+      expect(response.body.required).toBe(createFieldDto.required);
+      expect(response.body.minLength).toBe(createFieldDto.minLength);
       expect(response.body.maxLength).toBe(createFieldDto.maxLength);
       expect(response.body.campingOptionId).toBe(createFieldDto.campingOptionId);
     });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -294,6 +294,7 @@ export const CampingOptionFieldSchema = z.object({
   dataType: z.enum(['STRING', 'MULTILINE_STRING', 'INTEGER', 'NUMBER', 'BOOLEAN', 'DATE']),
   required: z.boolean(),
   maxLength: z.number().nullable().optional(),
+  minLength: z.number().nullable().optional(),
   minValue: z.number().nullable().optional(),
   maxValue: z.number().nullable().optional(),
   order: z.number().optional(),

--- a/apps/web/src/pages/AdminCampingOptionFieldsPage.tsx
+++ b/apps/web/src/pages/AdminCampingOptionFieldsPage.tsx
@@ -18,6 +18,7 @@ interface FieldFormData {
   dataType: 'STRING' | 'MULTILINE_STRING' | 'INTEGER' | 'NUMBER' | 'BOOLEAN' | 'DATE';
   required: boolean;
   maxLength: number | null;
+  minLength: number | null;
   minValue: number | null;
   maxValue: number | null;
   order?: number;
@@ -50,6 +51,7 @@ const AdminCampingOptionFieldsPage: React.FC = () => {
     dataType: 'STRING',
     required: false,
     maxLength: null,
+    minLength: null,
     minValue: null,
     maxValue: null
   });
@@ -78,6 +80,12 @@ const AdminCampingOptionFieldsPage: React.FC = () => {
     if (formData.dataType === 'STRING' || formData.dataType === 'MULTILINE_STRING') {
       if (formData.maxLength && formData.maxLength < 1) {
         errors.maxLength = 'Maximum length must be at least 1';
+      }
+      if (formData.minLength && formData.minLength < 0) {
+        errors.minLength = 'Minimum length cannot be negative';
+      }
+      if (formData.minLength !== null && formData.maxLength !== null && formData.minLength > formData.maxLength) {
+        errors.minLength = 'Minimum length cannot be greater than maximum length';
       }
     }
 
@@ -116,6 +124,7 @@ const AdminCampingOptionFieldsPage: React.FC = () => {
       ...formData,
       dataType,
       maxLength: null,
+      minLength: null,
       minValue: null,
       maxValue: null
     };
@@ -130,6 +139,7 @@ const AdminCampingOptionFieldsPage: React.FC = () => {
       dataType: 'STRING',
       required: false,
       maxLength: null,
+      minLength: null,
       minValue: null,
       maxValue: null
     });
@@ -145,6 +155,7 @@ const AdminCampingOptionFieldsPage: React.FC = () => {
       dataType: field.dataType,
       required: field.required,
       maxLength: field.maxLength ?? null,
+      minLength: field.minLength ?? null,
       minValue: field.minValue ?? null,
       maxValue: field.maxValue ?? null
     });
@@ -552,23 +563,42 @@ const AdminCampingOptionFieldsPage: React.FC = () => {
                 
                 {/* Additional fields based on data type */}
                 {(formData.dataType === 'STRING' || formData.dataType === 'MULTILINE_STRING') && (
-                  <div className="col-span-1">
-                    <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="maxLength">
-                      Maximum Length
-                    </label>
-                    <input
-                      type="number"
-                      id="maxLength"
-                      name="maxLength"
-                      value={formData.maxLength === null ? '' : formData.maxLength}
-                      onChange={handleInputChange}
-                      min={1}
-                      className={`w-full px-3 py-2 border rounded-md ${
-                        formErrors.maxLength ? 'border-red-500' : 'border-gray-300'
-                      }`}
-                    />
-                    {formErrors.maxLength && <p className="text-red-500 text-xs mt-1">{formErrors.maxLength}</p>}
-                  </div>
+                  <>
+                    <div className="col-span-1">
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="minLength">
+                        Minimum Length
+                      </label>
+                      <input
+                        type="number"
+                        id="minLength"
+                        name="minLength"
+                        value={formData.minLength === null ? '' : formData.minLength}
+                        onChange={handleInputChange}
+                        min={0}
+                        className={`w-full px-3 py-2 border rounded-md ${
+                          formErrors.minLength ? 'border-red-500' : 'border-gray-300'
+                        }`}
+                      />
+                      {formErrors.minLength && <p className="text-red-500 text-xs mt-1">{formErrors.minLength}</p>}
+                    </div>
+                    <div className="col-span-1">
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="maxLength">
+                        Maximum Length
+                      </label>
+                      <input
+                        type="number"
+                        id="maxLength"
+                        name="maxLength"
+                        value={formData.maxLength === null ? '' : formData.maxLength}
+                        onChange={handleInputChange}
+                        min={1}
+                        className={`w-full px-3 py-2 border rounded-md ${
+                          formErrors.maxLength ? 'border-red-500' : 'border-gray-300'
+                        }`}
+                      />
+                      {formErrors.maxLength && <p className="text-red-500 text-xs mt-1">{formErrors.maxLength}</p>}
+                    </div>
+                  </>
                 )}
                 
                 {(formData.dataType === 'NUMBER' || formData.dataType === 'INTEGER') && (

--- a/apps/web/src/pages/registration/RegistrationPage.tsx
+++ b/apps/web/src/pages/registration/RegistrationPage.tsx
@@ -341,8 +341,13 @@ export default function RegistrationPage() {
           switch (field.dataType) {
             case 'STRING':
             case 'MULTILINE_STRING': {
-              if (typeof value === 'string' && field.maxLength && value.length > field.maxLength) {
-                errors[`field_${field.id}`] = `${field.displayName} must be less than ${field.maxLength} characters`;
+              if (typeof value === 'string') {
+                if (field.minLength && value.length < field.minLength) {
+                  errors[`field_${field.id}`] = `${field.displayName} must be at least ${field.minLength} characters`;
+                }
+                if (field.maxLength && value.length > field.maxLength) {
+                  errors[`field_${field.id}`] = `${field.displayName} must be less than ${field.maxLength} characters`;
+                }
               }
               break;
             }

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -177,6 +177,7 @@ export interface CampingOptionField {
   dataType: 'STRING' | 'MULTILINE_STRING' | 'INTEGER' | 'NUMBER' | 'BOOLEAN' | 'DATE';
   required: boolean;
   maxLength?: number | null;
+  minLength?: number | null;
   minValue?: number | null;
   maxValue?: number | null;
   order?: number;


### PR DESCRIPTION
- Introduced minLength property to CampingOptionField model and updated the schema.
- Added minLength validation to CreateCampingOptionFieldDto and UpdateCampingOptionFieldDto.
- Implemented integration and unit tests for minLength validation in CampingOptionField.
- Updated API and frontend components to support minLength functionality.
- Ensured proper validation messages for minLength in various scenarios.