### PR TITLE
refactor: remove message from registration error notification template

### DIFF
--- a/apps/api/src/notifications/services/notifications.service.spec.ts
+++ b/apps/api/src/notifications/services/notifications.service.spec.ts
@@ -309,7 +309,6 @@ describe('NotificationsService', () => {
 
       const errorDetails = {
         error: 'PAYMENT_FAILED',
-        message: 'Your payment could not be processed',
         suggestions: ['Check your card details', 'Try a different payment method'],
       };
 

--- a/apps/api/src/notifications/services/notifications.service.ts
+++ b/apps/api/src/notifications/services/notifications.service.ts
@@ -57,7 +57,6 @@ export interface TemplateData {
   };
   errorDetails?: {
     error: string;
-    message: string;
     suggestions?: string[];
   };
   testEmailDetails?: {
@@ -312,7 +311,7 @@ export class NotificationsService {
   /**
    * Send registration error notification email
    * @param email User email address
-   * @param errorDetails Error details with message and suggestions
+   * @param errorDetails Error details with suggestions
    * @param userId User ID for audit trail
    * @returns Promise resolving to true if email was sent successfully
    */
@@ -320,7 +319,6 @@ export class NotificationsService {
     email: string,
     errorDetails: {
       error: string;
-      message: string;
       suggestions?: string[];
     },
     userId: string
@@ -864,7 +862,6 @@ The ${campName} Team`;
    */
   private getRegistrationErrorTemplate(errorDetails: {
     error: string;
-    message: string;
     suggestions?: string[];
   }, campName: string): NotificationTemplate {
     const { error, suggestions } = errorDetails;

--- a/apps/api/src/registrations/registrations.service.ts
+++ b/apps/api/src/registrations/registrations.service.ts
@@ -847,7 +847,6 @@ export class RegistrationsService {
     try {
       const errorDetails = {
         error: error.constructor.name,
-        message: error.message,
         suggestions: this.getRegistrationErrorSuggestions(error),
       };
 


### PR DESCRIPTION
- Eliminated the message field from the error notification template to streamline the content.
- Updated the rendering logic to ensure suggestions are displayed correctly without the message field.