### PR TITLE
Fix #90: Display friendly names for data types in admin camping option fields

### DIFF
--- a/apps/web/src/pages/AdminCampingOptionFieldsPage.test.tsx
+++ b/apps/web/src/pages/AdminCampingOptionFieldsPage.test.tsx
@@ -41,7 +41,7 @@ const mockFields = [
     id: 'field-1',
     displayName: 'Test Field 1',
     description: 'A test field',
-    dataType: 'TEXT',
+    dataType: 'STRING',
     required: true,
     maxLength: 100,
     minValue: null,
@@ -154,8 +154,8 @@ describe('AdminCampingOptionFieldsPage', () => {
     renderWithRouter(<AdminCampingOptionFieldsPage />);
     expect(screen.getByText('Test Field 1')).toBeInTheDocument();
     expect(screen.getByText('Test Field 2')).toBeInTheDocument();
-    expect(screen.getByText('TEXT')).toBeInTheDocument();
-    expect(screen.getByText('NUMBER')).toBeInTheDocument();
+    expect(screen.getByText('Text')).toBeInTheDocument();
+    expect(screen.getByText('Number')).toBeInTheDocument();
   });
 
   it('should open the modal when Add Custom Field button is clicked', () => {

--- a/apps/web/src/pages/AdminCampingOptionFieldsPage.tsx
+++ b/apps/web/src/pages/AdminCampingOptionFieldsPage.tsx
@@ -4,6 +4,7 @@ import { useCampingOptions } from '../hooks/useCampingOptions';
 import { CampingOptionField } from '../lib/api';
 import axios, { AxiosError } from 'axios';
 import { PATHS } from '../routes';
+import { getDataTypeFriendlyName } from '../utils/dataTypeMapping';
 
 // Define type for API error response
 interface ApiErrorResponse {
@@ -387,7 +388,7 @@ const AdminCampingOptionFieldsPage: React.FC = () => {
                         </span>
                       </td>
                       <td className="py-2 px-4 border-b">{field.displayName}</td>
-                      <td className="py-2 px-4 border-b">{field.dataType}</td>
+                      <td className="py-2 px-4 border-b">{getDataTypeFriendlyName(field.dataType)}</td>
                       <td className="py-2 px-4 border-b">
                         {field.required ? (
                           <span className="text-green-600">Required</span>

--- a/apps/web/src/utils/dataTypeMapping.test.ts
+++ b/apps/web/src/utils/dataTypeMapping.test.ts
@@ -1,0 +1,16 @@
+import { getDataTypeFriendlyName } from './dataTypeMapping';
+
+describe('getDataTypeFriendlyName', () => {
+  it('should return friendly names for all data types', () => {
+    expect(getDataTypeFriendlyName('STRING')).toBe('Text');
+    expect(getDataTypeFriendlyName('MULTILINE_STRING')).toBe('Multiline Text');
+    expect(getDataTypeFriendlyName('NUMBER')).toBe('Number');
+    expect(getDataTypeFriendlyName('INTEGER')).toBe('Integer');
+    expect(getDataTypeFriendlyName('DATE')).toBe('Date');
+    expect(getDataTypeFriendlyName('BOOLEAN')).toBe('Yes/No');
+  });
+
+  it('should return the original value for unmapped types', () => {
+    expect(getDataTypeFriendlyName('UNKNOWN' as any)).toBe('UNKNOWN');
+  });
+});

--- a/apps/web/src/utils/dataTypeMapping.ts
+++ b/apps/web/src/utils/dataTypeMapping.ts
@@ -1,0 +1,17 @@
+type DataType = 'STRING' | 'MULTILINE_STRING' | 'INTEGER' | 'NUMBER' | 'BOOLEAN' | 'DATE';
+
+/**
+ * Maps data type enum values to user-friendly display names
+ */
+export const getDataTypeFriendlyName = (dataType: DataType): string => {
+  const mappings: Record<DataType, string> = {
+    STRING: 'Text',
+    MULTILINE_STRING: 'Multiline Text',
+    NUMBER: 'Number',
+    INTEGER: 'Integer',
+    DATE: 'Date',
+    BOOLEAN: 'Yes/No'
+  };
+
+  return mappings[dataType] || dataType;
+};


### PR DESCRIPTION
## Summary

Fixes #90 - Display friendly names for data types in the AdminCampingOptionFieldsPage Type column instead of raw enum values.

## Changes Made

### 1. Created Reusable Data Type Mapping Utility
- **New file**: `apps/web/src/utils/dataTypeMapping.ts`
- **Function**: `getDataTypeFriendlyName()` maps enum values to user-friendly display names:
  - `STRING` → "Text"  
  - `MULTILINE_STRING` → "Multiline Text"
  - `NUMBER` → "Number"
  - `INTEGER` → "Integer"
  - `DATE` → "Date"
  - `BOOLEAN` → "Yes/No"

### 2. Updated Table Rendering
- **File**: `apps/web/src/pages/AdminCampingOptionFieldsPage.tsx`
- **Line 391**: Changed `{field.dataType}` to `{getDataTypeFriendlyName(field.dataType)}`
- **Added import** for the utility function

### 3. Test Updates and Fixes
- **Fixed mock data**: Corrected `dataType: 'TEXT'` to `dataType: 'STRING'` to match actual enum values
- **Updated test expectations**: Changed from checking for raw enum values (`'TEXT'`, `'NUMBER'`) to friendly names (`'Text'`, `'Number'`)
- **Added comprehensive tests**: New test file `apps/web/src/utils/dataTypeMapping.test.ts` with full coverage

## Implementation Details

- **Consistency**: Maintains consistency with existing dropdown options in the edit dialog
- **Reusability**: Utility function can be used by other components if needed
- **Type Safety**: Full TypeScript typing with proper enum constraints
- **Fallback**: Returns original value for unmapped types

## Testing

- ✅ All 533 tests pass
- ✅ Build succeeds without TypeScript errors  
- ✅ Linting passes without issues
- ✅ New utility function has 100% test coverage

## Files Changed

- `apps/web/src/pages/AdminCampingOptionFieldsPage.tsx` - Updated table rendering
- `apps/web/src/pages/AdminCampingOptionFieldsPage.test.tsx` - Fixed mock data and test expectations  
- `apps/web/src/utils/dataTypeMapping.ts` - New utility function
- `apps/web/src/utils/dataTypeMapping.test.ts` - New comprehensive tests

🤖 Generated with [Claude Code](https://claude.ai/code)