### PR TITLE
Fix: robust CSV export escaping for registration reports (closes #116)

### DIFF
--- a/apps/web/src/utils/__tests__/csv.test.ts
+++ b/apps/web/src/utils/__tests__/csv.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { generateCsv } from '../csv';
+
+/**
+ * This test captures issue #116: multiline and comma-containing fields are not safely quoted,
+ * resulting in row misalignment when opened in spreadsheet applications.
+ */
+describe('generateCsv (issue #116)', () => {
+  it('should quote fields containing commas, quotes, or newlines so rows remain intact', () => {
+  const headers = ['Name', 'Multi Field', 'Notes'];
+    const rows = [
+      [
+    'Sample Person A',
+    'Primary Identifier 12345 - issued by Example Authority\nQualifications: LEVEL1 (alpha, beta), LEVEL2, LEVEL3 (gamma & delta) & LEVELX (special operations - extended cases)',
+    'Has complex multi-line data'
+      ],
+      [
+    'Sample Person B',
+    'Identifier: 98765\nCerts: A,B,C,D,E,F,G\nHistory: 250 Actions (5 years)',
+    'Another multi-line with commas'
+      ],
+    ];
+
+    const csv = generateCsv(headers, rows);
+
+    // Parse logical lines accounting for quoted newlines
+    const logicalLines: string[] = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < csv.length; i++) {
+      const ch = csv[i];
+      if (ch === '"') {
+        // Lookahead for escaped quote
+        if (inQuotes && csv[i + 1] === '"') {
+          current += '"';
+          i++; // skip next
+          continue;
+        }
+        inQuotes = !inQuotes;
+        current += ch; // keep quote if needed
+        continue;
+      }
+      if ((ch === '\n' || ch === '\r') && !inQuotes) {
+        // line boundary (normalize CRLF/CR/LF)
+        if (ch === '\r' && csv[i + 1] === '\n') i++; // swallow LF of CRLF
+        logicalLines.push(current);
+        current = '';
+        continue;
+      }
+      current += ch;
+    }
+    if (current.length) logicalLines.push(current);
+
+    expect(logicalLines.length).toBe(3); // header + 2 rows
+
+    const dataLines = logicalLines.slice(1);
+    dataLines.forEach(line => {
+      // Count top-level commas ignoring those inside quotes by stripping quoted sections
+      const stripped = line.replace(/"(?:[^"]|""|\n|\r)*"/g, 'FIELD');
+      const commaCount = (stripped.match(/,/g) || []).length;
+      expect(commaCount).toBe(2);
+    });
+
+    // Verify that a known multi-line field is quoted and internal quotes escaped if present
+  expect(csv).toMatch(/"Primary Identifier 12345 - issued by Example Authority/);
+    // Ensure second multi-line value is quoted
+  expect(csv).toMatch(/"Identifier: 98765/);
+  });
+});

--- a/apps/web/src/utils/__tests__/csv.test.ts
+++ b/apps/web/src/utils/__tests__/csv.test.ts
@@ -1,69 +1,69 @@
 import { describe, it, expect } from 'vitest';
 import { generateCsv } from '../csv';
 
+// Regex matching a fully quoted CSV field including doubled quote escapes and embedded newlines.
+// Used only in tests to strip out quoted segments so we can count top-level delimiters safely.
+const QUOTED_CSV_FIELD_REGEX = /"(?:[^"]|""|\n|\r)*"/g;
+
 /**
  * This test captures issue #116: multiline and comma-containing fields are not safely quoted,
  * resulting in row misalignment when opened in spreadsheet applications.
  */
 describe('generateCsv (issue #116)', () => {
   it('should quote fields containing commas, quotes, or newlines so rows remain intact', () => {
-  const headers = ['Name', 'Multi Field', 'Notes'];
+    const headers = ['Name', 'Multi Field', 'Notes'];
     const rows = [
       [
-    'Sample Person A',
-    'Primary Identifier 12345 - issued by Example Authority\nQualifications: LEVEL1 (alpha, beta), LEVEL2, LEVEL3 (gamma & delta) & LEVELX (special operations - extended cases)',
-    'Has complex multi-line data'
+        'Sample Person A',
+        'Primary Identifier 12345 - issued by Example Authority\nQualifications: LEVEL1 (alpha, beta), LEVEL2, LEVEL3 (gamma & delta) & LEVELX (special operations - extended cases)',
+        'Has complex multi-line data'
       ],
       [
-    'Sample Person B',
-    'Identifier: 98765\nCerts: A,B,C,D,E,F,G\nHistory: 250 Actions (5 years)',
-    'Another multi-line with commas'
-      ],
+        'Sample Person B',
+        'Identifier: 98765\nCerts: A,B,C,D,E,F,G\nHistory: 250 Actions (5 years)',
+        'Another multi-line with commas'
+      ]
     ];
 
     const csv = generateCsv(headers, rows);
 
-    // Parse logical lines accounting for quoted newlines
+    // Logical line split (header + 2 data rows) by scanning for unquoted line terminators.
     const logicalLines: string[] = [];
-    let current = '';
+    let buffer = '';
     let inQuotes = false;
     for (let i = 0; i < csv.length; i++) {
       const ch = csv[i];
       if (ch === '"') {
-        // Lookahead for escaped quote
-        if (inQuotes && csv[i + 1] === '"') {
-          current += '"';
-          i++; // skip next
-          continue;
+        if (inQuotes && csv[i + 1] === '"') { // escaped quote
+          buffer += '"';
+          i++;
+        } else {
+          inQuotes = !inQuotes;
         }
-        inQuotes = !inQuotes;
-        current += ch; // keep quote if needed
+        buffer += '"';
         continue;
       }
-      if ((ch === '\n' || ch === '\r') && !inQuotes) {
-        // line boundary (normalize CRLF/CR/LF)
-        if (ch === '\r' && csv[i + 1] === '\n') i++; // swallow LF of CRLF
-        logicalLines.push(current);
-        current = '';
+      if (!inQuotes && (ch === '\n' || ch === '\r')) {
+        if (ch === '\r' && csv[i + 1] === '\n') i++; // normalize CRLF
+        logicalLines.push(buffer);
+        buffer = '';
         continue;
       }
-      current += ch;
+      buffer += ch;
     }
-    if (current.length) logicalLines.push(current);
+    if (buffer) logicalLines.push(buffer);
 
     expect(logicalLines.length).toBe(3); // header + 2 rows
 
     const dataLines = logicalLines.slice(1);
     dataLines.forEach(line => {
-      // Count top-level commas ignoring those inside quotes by stripping quoted sections
-      const stripped = line.replace(/"(?:[^"]|""|\n|\r)*"/g, 'FIELD');
+      const stripped = line.replace(QUOTED_CSV_FIELD_REGEX, 'FIELD');
       const commaCount = (stripped.match(/,/g) || []).length;
       expect(commaCount).toBe(2);
     });
 
-    // Verify that a known multi-line field is quoted and internal quotes escaped if present
-  expect(csv).toMatch(/"Primary Identifier 12345 - issued by Example Authority/);
-    // Ensure second multi-line value is quoted
-  expect(csv).toMatch(/"Identifier: 98765/);
+    // Verify known multi-line fields are quoted
+    expect(csv).toMatch(/"Primary Identifier 12345 - issued by Example Authority/);
+    expect(csv).toMatch(/"Identifier: 98765/);
   });
 });

--- a/apps/web/src/utils/csv.ts
+++ b/apps/web/src/utils/csv.ts
@@ -9,7 +9,7 @@ export interface GenerateCsvOptions {
   readonly lineTerminator?: string; // default \n
 }
 
-export function escapeCsvField(value: string | number, alwaysQuote = false): string {
+export function escapeCsvField(value: string | number | null | undefined, alwaysQuote = false): string {
   const str = String(value ?? '');
   const needsQuoting = alwaysQuote || /[",\n\r]/.test(str);
   if (!needsQuoting) return str;

--- a/apps/web/src/utils/csv.ts
+++ b/apps/web/src/utils/csv.ts
@@ -1,0 +1,30 @@
+/**
+ * Generate CSV content from headers and row data.
+ * Properly escapes fields containing commas, quotes, newlines, or carriage returns
+ * according to RFC 4180 rules (double quotes escaped by doubling them and wrapping whole field in quotes).
+ * Optionally can force quoting of all fields for safety/consistency.
+ */
+export interface GenerateCsvOptions {
+  readonly alwaysQuote?: boolean;
+  readonly lineTerminator?: string; // default \n
+}
+
+export function escapeCsvField(value: string | number, alwaysQuote = false): string {
+  const str = String(value ?? '');
+  const needsQuoting = alwaysQuote || /[",\n\r]/.test(str);
+  if (!needsQuoting) return str;
+  const escaped = str.replace(/"/g, '""');
+  return `"${escaped}"`;
+}
+
+export function generateCsv(headers: string[], rows: (string | number)[][], options: GenerateCsvOptions = {}): string {
+  const { alwaysQuote = false, lineTerminator = '\n' } = options;
+  const headerLine = headers.map(h => escapeCsvField(h, alwaysQuote)).join(',');
+  const lines = rows.map(row => row.map(field => escapeCsvField(field, alwaysQuote)).join(','));
+  return [headerLine, ...lines].join(lineTerminator);
+}
+
+/** Convenience wrapper that always quotes every field. */
+export function generateCsvAllQuoted(headers: string[], rows: (string | number)[][], lineTerminator = '\n'): string {
+  return generateCsv(headers, rows, { alwaysQuote: true, lineTerminator });
+}


### PR DESCRIPTION
## Summary
Implements a robust CSV export for the Registration Reports page.

- Extracted CSV generation to `apps/web/src/utils/csv.ts`
- Added comprehensive escaping (quotes, commas, CR/LF, embedded newlines) per RFC 4180
- Updated `RegistrationReportsPage` to use the new util instead of inline logic
- Added unit test (`apps/web/src/utils/__tests__/csv.test.ts`) reproducing issue #116 with generic placeholder multiline/comma data
- Sanitized test data (no real user/license info)

## Motivation
Issue #116 reported that exported CSV rows became misaligned due to embedded commas and newline characters in registration field values (e.g., license / qualification data). The previous implementation only quoted fields containing commas or quotes, allowing newline characters to split logical rows.

## Implementation Notes
- New util provides `escapeCsvField` and `generateCsv` (optionally always-quote if needed later)
- Page export now delegates to util for consistency & reuse
- Test parses logical lines accounting for quoted newlines to assert integrity

## Validation
- All web tests pass (including new test)
- Lint and build succeeded locally

Closes #116.
