### PR TITLE
Fix CSV export escaping for newlines and carriage returns

### DIFF
--- a/apps/web/src/pages/RegistrationReportsPage.tsx
+++ b/apps/web/src/pages/RegistrationReportsPage.tsx
@@ -5,6 +5,7 @@ import { DataTable, DataTableColumn } from '../components/common/DataTable/DataT
 import { reports, Registration, RegistrationReportFilters, CampingOptionRegistrationWithFields } from '../lib/api';
 import { PATHS } from '../routes';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import { generateCsv } from '../utils/csv';
 
 /**
  * Registration Reports page
@@ -346,16 +347,8 @@ export function RegistrationReportsPage() {
       return baseData;
     });
 
-    // Create CSV content
-    const csvContent = [
-      headers.join(','),
-      ...csvData.map(row => row.map(field => 
-        // Escape fields that contain commas or quotes
-        typeof field === 'string' && (field.includes(',') || field.includes('"')) 
-          ? `"${field.replace(/"/g, '""')}"` 
-          : field
-      ).join(','))
-    ].join('\n');
+    // Create CSV content using proper escaping
+    const csvContent = generateCsv(headers, csvData);
 
     // Create and download the file
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });

--- a/apps/web/src/utils/__tests__/csv.test.ts
+++ b/apps/web/src/utils/__tests__/csv.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { escapeCsvField, generateCsv, generateCsvAllQuoted } from '../csv';
+
+describe('Proper CSV utility functions', () => {
+  describe('escapeCsvField', () => {
+    it('should not quote simple strings', () => {
+      expect(escapeCsvField('simple')).toBe('simple');
+      expect(escapeCsvField('123')).toBe('123');
+      expect(escapeCsvField(123)).toBe('123');
+    });
+
+    it('should quote strings containing commas', () => {
+      expect(escapeCsvField('hello, world')).toBe('"hello, world"');
+    });
+
+    it('should quote strings containing quotes and escape them', () => {
+      expect(escapeCsvField('say "hello"')).toBe('"say ""hello"""');
+    });
+
+    it('should quote strings containing newlines', () => {
+      expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"');
+    });
+
+    it('should quote strings containing carriage returns', () => {
+      expect(escapeCsvField('line1\r\nline2')).toBe('"line1\r\nline2"');
+    });
+
+    it('should handle null and undefined values', () => {
+      expect(escapeCsvField(null)).toBe('');
+      expect(escapeCsvField(undefined)).toBe('');
+    });
+
+    it('should always quote when alwaysQuote is true', () => {
+      expect(escapeCsvField('simple', true)).toBe('"simple"');
+    });
+  });
+
+  describe('generateCsv', () => {
+    it('should generate proper CSV with headers and data', () => {
+      const headers = ['Name', 'Email'];
+      const rows = [
+        ['John Doe', 'john@example.com'],
+        ['Jane Smith', 'jane@example.com'],
+      ];
+
+      const csv = generateCsv(headers, rows);
+      expect(csv).toBe('Name,Email\nJohn Doe,john@example.com\nJane Smith,jane@example.com');
+    });
+
+    it('should properly escape fields with newlines', () => {
+      const headers = ['Name', 'Description'];
+      const rows = [
+        ['John Doe', 'License A-123\nCoach rating'],
+        ['Jane Smith', 'License B-456\r\nInstructor'],
+      ];
+
+      const csv = generateCsv(headers, rows);
+
+      // The CSV should contain the properly escaped content
+      const expectedCsv =
+        'Name,Description\nJohn Doe,"License A-123\nCoach rating"\nJane Smith,"License B-456\r\nInstructor"';
+      expect(csv).toBe(expectedCsv);
+
+      // When parsed properly, it should represent exactly 2 data rows
+      // We can verify this by checking that the quoted newlines don't break the structure
+      expect(csv.startsWith('Name,Description\n')).toBe(true);
+      expect(csv.includes('John Doe,"License A-123\nCoach rating"')).toBe(true);
+      expect(csv.includes('Jane Smith,"License B-456\r\nInstructor"')).toBe(true);
+    });
+
+    it('should handle complex data with mixed escaping needs', () => {
+      const headers = ['Name', 'Notes'];
+      const rows = [
+        ['John "Johnny" Doe', 'Has license A-123, very experienced\nCoach rating: excellent'],
+        ['Jane Smith', 'Normal entry'],
+      ];
+
+      const csv = generateCsv(headers, rows);
+
+      // Verify the structure contains properly escaped content
+      expect(
+        csv.includes(
+          '"John ""Johnny"" Doe","Has license A-123, very experienced\nCoach rating: excellent"'
+        )
+      ).toBe(true);
+      expect(csv.includes('Jane Smith,Normal entry')).toBe(true);
+      expect(csv.startsWith('Name,Notes\n')).toBe(true);
+    });
+  });
+
+  describe('generateCsvAllQuoted', () => {
+    it('should quote all fields even simple ones', () => {
+      const headers = ['Name', 'Email'];
+      const rows = [['John', 'john@example.com']];
+
+      const csv = generateCsvAllQuoted(headers, rows);
+      expect(csv).toBe('"Name","Email"\n"John","john@example.com"');
+    });
+  });
+});

--- a/apps/web/src/utils/__tests__/csv.test.ts
+++ b/apps/web/src/utils/__tests__/csv.test.ts
@@ -47,6 +47,17 @@ describe('Proper CSV utility functions', () => {
       expect(csv).toBe('Name,Email\nJohn Doe,john@example.com\nJane Smith,jane@example.com');
     });
 
+    it('should handle null and undefined values in rows', () => {
+      const headers = ['Name', 'Email', 'Phone'];
+      const rows = [
+        ['John Doe', null, '555-1234'],
+        ['Jane Smith', 'jane@example.com', undefined],
+      ];
+
+      const csv = generateCsv(headers, rows);
+      expect(csv).toBe('Name,Email,Phone\nJohn Doe,,555-1234\nJane Smith,jane@example.com,');
+    });
+
     it('should properly escape fields with newlines', () => {
       const headers = ['Name', 'Description'];
       const rows = [

--- a/apps/web/src/utils/csv.ts
+++ b/apps/web/src/utils/csv.ts
@@ -1,0 +1,58 @@
+/**
+ * CSV utility functions for properly escaping and generating CSV content
+ * according to RFC 4180 specification.
+ */
+
+export interface GenerateCsvOptions {
+  readonly alwaysQuote?: boolean;
+  readonly lineTerminator?: string; // default \n
+}
+
+/**
+ * Escapes a CSV field value according to RFC 4180 rules:
+ * - Fields containing commas, quotes, newlines, or carriage returns must be quoted
+ * - Quotes within fields are escaped by doubling them
+ * - The entire field is wrapped in quotes if it needs escaping
+ */
+export function escapeCsvField(
+  value: string | number | null | undefined,
+  alwaysQuote = false
+): string {
+  const str = String(value ?? '');
+  const needsQuoting = alwaysQuote || /[",\n\r]/.test(str);
+
+  if (!needsQuoting) {
+    return str;
+  }
+
+  // Escape quotes by doubling them and wrap the entire field in quotes
+  const escaped = str.replace(/"/g, '""');
+  return `"${escaped}"`;
+}
+
+/**
+ * Generates CSV content from headers and row data with proper escaping
+ */
+export function generateCsv(
+  headers: string[],
+  rows: (string | number)[][],
+  options: GenerateCsvOptions = {}
+): string {
+  const { alwaysQuote = false, lineTerminator = '\n' } = options;
+
+  const headerLine = headers.map(h => escapeCsvField(h, alwaysQuote)).join(',');
+  const dataLines = rows.map(row => row.map(field => escapeCsvField(field, alwaysQuote)).join(','));
+
+  return [headerLine, ...dataLines].join(lineTerminator);
+}
+
+/**
+ * Convenience wrapper that always quotes every field for maximum compatibility
+ */
+export function generateCsvAllQuoted(
+  headers: string[],
+  rows: (string | number)[][],
+  lineTerminator = '\n'
+): string {
+  return generateCsv(headers, rows, { alwaysQuote: true, lineTerminator });
+}

--- a/apps/web/src/utils/csv.ts
+++ b/apps/web/src/utils/csv.ts
@@ -35,7 +35,7 @@ export function escapeCsvField(
  */
 export function generateCsv(
   headers: string[],
-  rows: (string | number)[][],
+  rows: (string | number | null | undefined)[][],
   options: GenerateCsvOptions = {}
 ): string {
   const { alwaysQuote = false, lineTerminator = '\n' } = options;
@@ -51,7 +51,7 @@ export function generateCsv(
  */
 export function generateCsvAllQuoted(
   headers: string[],
-  rows: (string | number)[][],
+  rows: (string | number | null | undefined)[][],
   lineTerminator = '\n'
 ): string {
   return generateCsv(headers, rows, { alwaysQuote: true, lineTerminator });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3738,14 +3738,14 @@
             }
         },
         "node_modules/@inquirer/core": {
-            "version": "10.1.13",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
-            "integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
+            "version": "10.1.15",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+            "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/figures": "^1.0.12",
-                "@inquirer/type": "^3.0.7",
+                "@inquirer/figures": "^1.0.13",
+                "@inquirer/type": "^3.0.8",
                 "ansi-escapes": "^4.3.2",
                 "cli-width": "^4.1.0",
                 "mute-stream": "^2.0.0",
@@ -3794,15 +3794,15 @@
             }
         },
         "node_modules/@inquirer/editor": {
-            "version": "4.2.13",
-            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.13.tgz",
-            "integrity": "sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==",
+            "version": "4.2.17",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.17.tgz",
+            "integrity": "sha512-r6bQLsyPSzbWrZZ9ufoWL+CztkSatnJ6uSxqd6N+o41EZC51sQeWOzI6s5jLb+xxTWxl7PlUppqm8/sow241gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.13",
-                "@inquirer/type": "^3.0.7",
-                "external-editor": "^3.1.0"
+                "@inquirer/core": "^10.1.15",
+                "@inquirer/external-editor": "^1.0.1",
+                "@inquirer/type": "^3.0.8"
             },
             "engines": {
                 "node": ">=18"
@@ -3839,10 +3839,32 @@
                 }
             }
         },
+        "node_modules/@inquirer/external-editor": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
+            "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^2.1.0",
+                "iconv-lite": "^0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@inquirer/figures": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
-            "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+            "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4019,9 +4041,9 @@
             }
         },
         "node_modules/@inquirer/type": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
-            "integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+            "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7751,9 +7773,9 @@
             }
         },
         "node_modules/chardet": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+            "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
             "dev": true,
             "license": "MIT"
         },
@@ -9342,34 +9364,6 @@
             },
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/external-editor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/external-editor/node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -12626,16 +12620,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/outvariant": {
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -15513,19 +15497,6 @@
             "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
         },
         "node_modules/tmpl": {
             "version": "1.0.5",


### PR DESCRIPTION
## Summary
- Fixes CSV export escaping to properly handle newlines and carriage returns in registration fields
- Implements RFC 4180 compliant CSV utility with comprehensive escaping
- Resolves malformed CSV files when custom fields contain multi-line content

## Problem
The CSV export functionality was generating malformed files when registration fields contained newlines or carriage returns. The existing escaping logic only handled commas and quotes, causing rows with multi-line field content to be split incorrectly across multiple CSV rows.

## Solution
- Created new `csv.ts` utility with RFC 4180 compliant escaping
- Added `escapeCsvField()` function that properly quotes fields containing commas, quotes, newlines, or carriage returns
- Added `generateCsv()` function for creating well-formed CSV content
- Updated `RegistrationReportsPage.tsx` to use the new CSV utility
- Added comprehensive tests covering all escaping scenarios

## Test plan
- [x] Unit tests pass for all CSV escaping scenarios
- [x] Build and lint checks pass
- [x] Manual testing shows properly formatted CSV exports with multi-line fields

🤖 Generated with [Claude Code](https://claude.ai/code)