### PR TITLE
fix: trim whitespace on name/profile inputs

### DIFF
--- a/apps/api/prisma/migrations/20250821192117_trim_user_profile_whitespace/migration.sql
+++ b/apps/api/prisma/migrations/20250821192117_trim_user_profile_whitespace/migration.sql
@@ -1,0 +1,34 @@
+-- Trim whitespace from user profile fields
+-- This migration addresses existing data that may have trailing/leading spaces
+
+UPDATE "users" SET 
+  "firstName" = TRIM("firstName")
+WHERE "firstName" IS NOT NULL AND "firstName" != TRIM("firstName");
+
+UPDATE "users" SET 
+  "lastName" = TRIM("lastName")
+WHERE "lastName" IS NOT NULL AND "lastName" != TRIM("lastName");
+
+UPDATE "users" SET 
+  "playaName" = TRIM("playaName")
+WHERE "playaName" IS NOT NULL AND "playaName" != TRIM("playaName");
+
+UPDATE "users" SET 
+  "phone" = TRIM("phone")
+WHERE "phone" IS NOT NULL AND "phone" != TRIM("phone");
+
+UPDATE "users" SET 
+  "city" = TRIM("city")
+WHERE "city" IS NOT NULL AND "city" != TRIM("city");
+
+UPDATE "users" SET 
+  "stateProvince" = TRIM("stateProvince")
+WHERE "stateProvince" IS NOT NULL AND "stateProvince" != TRIM("stateProvince");
+
+UPDATE "users" SET 
+  "country" = TRIM("country")
+WHERE "country" IS NOT NULL AND "country" != TRIM("country");
+
+UPDATE "users" SET 
+  "emergencyContact" = TRIM("emergencyContact")
+WHERE "emergencyContact" IS NOT NULL AND "emergencyContact" != TRIM("emergencyContact");

--- a/apps/api/src/users/dto/create-user.dto.ts
+++ b/apps/api/src/users/dto/create-user.dto.ts
@@ -1,4 +1,5 @@
 import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, IsBoolean } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { UserRole } from '@prisma/client';
 
@@ -21,6 +22,7 @@ export class CreateUserDto {
   })
   @IsString()
   @IsNotEmpty({ message: 'First name is required' })
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   firstName!: string;
 
   @ApiProperty({
@@ -29,6 +31,7 @@ export class CreateUserDto {
   })
   @IsString()
   @IsNotEmpty({ message: 'Last name is required' })
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   lastName!: string;
 
   @ApiPropertyOptional({
@@ -36,6 +39,7 @@ export class CreateUserDto {
     example: 'Dusty',
   })
   @IsString()
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   playaName?: string;
 
@@ -44,6 +48,7 @@ export class CreateUserDto {
     example: '+1-555-123-4567',
   })
   @IsString()
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   phone?: string;
 
@@ -52,6 +57,7 @@ export class CreateUserDto {
     example: 'San Francisco',
   })
   @IsString()
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   city?: string;
 
@@ -60,6 +66,7 @@ export class CreateUserDto {
     example: 'California',
   })
   @IsString()
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   stateProvince?: string;
 
@@ -68,6 +75,7 @@ export class CreateUserDto {
     example: 'United States',
   })
   @IsString()
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   country?: string;
 
@@ -76,6 +84,7 @@ export class CreateUserDto {
     example: 'Jane Doe, +1-555-987-6543, relationship: sister',
   })
   @IsString()
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   emergencyContact?: string;
 

--- a/apps/api/src/users/dto/update-user.dto.spec.ts
+++ b/apps/api/src/users/dto/update-user.dto.spec.ts
@@ -251,4 +251,32 @@ describe('UpdateUserDto', () => {
     expect(errors[0].constraints).toHaveProperty('minLength');
     expect(errors[0].constraints?.minLength).toContain('at least 8 characters');
   });
+
+  it('should trim whitespace from string fields', async () => {
+    // Arrange
+    const dto = plainToInstance(UpdateUserDto, {
+      firstName: '  John  ',
+      lastName: '  Doe  ',
+      playaName: '  Dusty  ',
+      phone: '  +1-555-123-4567  ',
+      city: '  San Francisco  ',
+      stateProvince: '  CA  ',
+      country: '  United States  ',
+      emergencyContact: '  Jane Doe, +1-555-987-6543, sister  ',
+    });
+
+    // Act
+    const errors = await validate(dto);
+
+    // Assert
+    expect(errors.length).toBe(0);
+    expect(dto.firstName).toBe('John');
+    expect(dto.lastName).toBe('Doe');
+    expect(dto.playaName).toBe('Dusty');
+    expect(dto.phone).toBe('+1-555-123-4567');
+    expect(dto.city).toBe('San Francisco');
+    expect(dto.stateProvince).toBe('CA');
+    expect(dto.country).toBe('United States');
+    expect(dto.emergencyContact).toBe('Jane Doe, +1-555-987-6543, sister');
+  });
 });

--- a/apps/api/src/users/dto/update-user.dto.ts
+++ b/apps/api/src/users/dto/update-user.dto.ts
@@ -1,4 +1,5 @@
 import { IsEmail, IsEnum, IsOptional, IsString, MinLength, IsBoolean, MaxLength } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { UserRole } from '@prisma/client';
 
@@ -32,6 +33,7 @@ export class UpdateUserDto {
   })
   @IsString()
   @MaxLength(50, { message: 'First name must be at most 50 characters long' })
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   readonly firstName?: string;
 
@@ -42,6 +44,7 @@ export class UpdateUserDto {
   })
   @IsString()
   @MaxLength(50, { message: 'Last name must be at most 50 characters long' })
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   readonly lastName?: string;
 
@@ -52,6 +55,7 @@ export class UpdateUserDto {
   })
   @IsString()
   @MaxLength(50, { message: 'Playa name must be at most 50 characters long' })
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   readonly playaName?: string;
 
@@ -62,6 +66,7 @@ export class UpdateUserDto {
   })
   @IsString()
   @MaxLength(50, { message: 'Phone number must be at most 50 characters long' })
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   readonly phone?: string;
 
@@ -72,6 +77,7 @@ export class UpdateUserDto {
   })
   @IsString()
   @MaxLength(50, { message: 'City must be at most 50 characters long' })
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   readonly city?: string;
 
@@ -82,6 +88,7 @@ export class UpdateUserDto {
   })
   @IsString()
   @MaxLength(50, { message: 'State/province must be at most 50 characters long' })
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   readonly stateProvince?: string;
 
@@ -92,6 +99,7 @@ export class UpdateUserDto {
   })
   @IsString()
   @MaxLength(50, { message: 'Country must be at most 50 characters long' })
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   readonly country?: string;
 
@@ -102,6 +110,7 @@ export class UpdateUserDto {
   })
   @IsString()
   @MaxLength(1024, { message: 'Emergency contact must be at most 1024 characters long' })
+  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsOptional()
   readonly emergencyContact?: string;
 

--- a/apps/web/src/components/profile/ProfileForm.test.tsx
+++ b/apps/web/src/components/profile/ProfileForm.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import ProfileForm from './ProfileForm';
+import { useProfile } from '../../hooks/useProfile';
+import { useNavigate } from 'react-router-dom';
+
+// Mock dependencies
+vi.mock('../../hooks/useProfile');
+vi.mock('react-router-dom');
+
+const mockUseProfile = vi.mocked(useProfile);
+const mockUseNavigate = vi.mocked(useNavigate);
+const mockNavigate = vi.fn();
+
+describe('ProfileForm', () => {
+  beforeEach(() => {
+    mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseProfile.mockReturnValue({
+      profile: {
+        id: 'test-id',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        phone: '555-1234',
+        city: 'San Francisco',
+        stateProvince: 'CA',
+        country: 'United States',
+        playaName: 'Dusty',
+        emergencyContact: 'Jane Doe, 555-5678, Sister',
+        profilePicture: null,
+        role: 'PARTICIPANT' as const,
+        isEmailVerified: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        allowRegistration: true,
+        allowEarlyRegistration: false,
+        allowDeferredDuesPayment: false,
+        allowNoJob: false,
+        internalNotes: null,
+      },
+      updateProfile: vi.fn(),
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should trim whitespace from form fields before submitting', async () => {
+    const mockUpdateProfile = vi.fn().mockResolvedValue(undefined);
+    mockUseProfile.mockReturnValue({
+      profile: null,
+      updateProfile: mockUpdateProfile,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ProfileForm />);
+
+    // Fill form with whitespace-padded values
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: '  John  ' }
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: '  Doe  ' }
+    });
+    fireEvent.change(screen.getByLabelText(/playa name/i), {
+      target: { value: '  Dusty  ' }
+    });
+    fireEvent.change(screen.getByLabelText(/phone number/i), {
+      target: { value: '  555-1234  ' }
+    });
+    fireEvent.change(screen.getByLabelText(/city/i), {
+      target: { value: '  San Francisco  ' }
+    });
+    fireEvent.change(screen.getByLabelText(/state/i), {
+      target: { value: '  CA  ' }
+    });
+    fireEvent.change(screen.getByLabelText(/country/i), {
+      target: { value: '  United States  ' }
+    });
+    fireEvent.change(screen.getByLabelText(/emergency contact/i), {
+      target: { value: '  Jane Doe, 555-5678, Sister  ' }
+    });
+
+    // Submit the form
+    fireEvent.click(screen.getByRole('button', { name: /save profile/i }));
+
+    // Verify updateProfile was called with trimmed values
+    await waitFor(() => {
+      expect(mockUpdateProfile).toHaveBeenCalledWith({
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '555-1234',
+        city: 'San Francisco',
+        stateProvince: 'CA',
+        country: 'United States',
+        playaName: 'Dusty',
+        emergencyContact: 'Jane Doe, 555-5678, Sister',
+      });
+    });
+  });
+
+  it('should handle empty strings correctly when trimming', async () => {
+    const mockUpdateProfile = vi.fn().mockResolvedValue(undefined);
+    mockUseProfile.mockReturnValue({
+      profile: null,
+      updateProfile: mockUpdateProfile,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ProfileForm />);
+
+    // Fill required fields and leave optional fields as whitespace
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: 'John' }
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: 'Doe' }
+    });
+    fireEvent.change(screen.getByLabelText(/phone number/i), {
+      target: { value: '555-1234' }
+    });
+    fireEvent.change(screen.getByLabelText(/emergency contact/i), {
+      target: { value: 'Jane Doe, 555-5678, Sister' }
+    });
+
+    // Set optional fields to whitespace
+    fireEvent.change(screen.getByLabelText(/playa name/i), {
+      target: { value: '   ' }
+    });
+    fireEvent.change(screen.getByLabelText(/city/i), {
+      target: { value: '   ' }
+    });
+
+    // Submit the form
+    fireEvent.click(screen.getByRole('button', { name: /save profile/i }));
+
+    // Verify updateProfile was called with empty strings for whitespace-only fields
+    await waitFor(() => {
+      expect(mockUpdateProfile).toHaveBeenCalledWith({
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '555-1234',
+        city: '',
+        stateProvince: '',
+        country: '',
+        playaName: '',
+        emergencyContact: 'Jane Doe, 555-5678, Sister',
+      });
+    });
+  });
+});

--- a/apps/web/src/components/profile/ProfileForm.tsx
+++ b/apps/web/src/components/profile/ProfileForm.tsx
@@ -66,14 +66,14 @@ const ProfileForm: React.FC = () => {
     
     try {
       await updateProfile({
-        firstName: formData.firstName,
-        lastName: formData.lastName,
-        phone: formData.phone,
-        city: formData.city,
-        stateProvince: formData.stateProvince,
-        country: formData.country,
-        playaName: formData.playaName,
-        emergencyContact: formData.emergencyContact,
+        firstName: formData.firstName.trim(),
+        lastName: formData.lastName.trim(),
+        phone: formData.phone.trim(),
+        city: formData.city.trim(),
+        stateProvince: formData.stateProvince.trim(),
+        country: formData.country.trim(),
+        playaName: formData.playaName.trim(),
+        emergencyContact: formData.emergencyContact.trim(),
       });
       
       // Redirect to dashboard after successful save


### PR DESCRIPTION
## Summary
- Trim whitespace from user profile input fields on both frontend and backend
- Clean up existing database records with trailing/leading spaces
- Add comprehensive test coverage

## Changes Made
- **Frontend**: Add `.trim()` to ProfileForm submission for all name/profile fields
- **Backend**: Add `@Transform` decorator to DTOs for automatic whitespace trimming
- **Database**: Create Prisma migration to clean existing data with SQL TRIM operations
- **Tests**: Add frontend ProfileForm test and backend DTO test for trimming functionality

## Fields Affected
- firstName, lastName, playaName
- phone, city, stateProvince, country
- emergencyContact

## Test Plan
- [x] Backend DTO validation tests pass
- [x] Frontend ProfileForm tests pass
- [x] Database migration applied successfully
- [x] All existing tests continue to pass

Fixes #125

🤖 Generated with [Claude Code](https://claude.ai/code)