### PR TITLE
chore: dependency updates, CI fixes, and uuid removal

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -50,10 +50,10 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -36,5 +36,5 @@ jobs:
         with:
           comment-summary-in-pr: always
         #   fail-on-severity: moderate
-          deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
+          allow-licenses: MIT, ISC, Apache-2.0, BSD-2-Clause, BSD-3-Clause, BlueOak-1.0.0, MIT-0, Unlicense, 0BSD, CC0-1.0, CC-BY-4.0, Python-2.0
         #   retry-on-snapshot-warnings: true

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -47,10 +47,10 @@ jobs:
           - 5432:5432
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 22.x
         cache: 'npm'

--- a/.github/workflows/e2e-docker-ci.yml
+++ b/.github/workflows/e2e-docker-ci.yml
@@ -35,10 +35,10 @@ jobs:
     timeout-minutes: 20
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 22.x
         cache: 'npm'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -35,10 +35,10 @@ jobs:
         node-version: [22.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -72,8 +72,7 @@
     "rxjs": "^7.8.2",
     "sanitize-html": "^2.17.3",
     "stripe": "^14.25.0",
-    "uid": "^2.0.2",
-    "uuid": "^9.0.1"
+    "uid": "^2.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.27.4",
@@ -91,7 +90,6 @@
     "@types/passport-local": "^1.0.38",
     "@types/sanitize-html": "^2.15.0",
     "@types/supertest": "^6.0.3",
-    "@types/uuid": "^9.0.8",
     "dotenv-cli": "^7.4.4",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",

--- a/apps/api/src/admin-audit/services/admin-audit.service.ts
+++ b/apps/api/src/admin-audit/services/admin-audit.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { AdminAudit, AdminAuditActionType, AdminAuditTargetType, Prisma } from '@prisma/client';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 export interface CreateAuditRecordDto {
   adminUserId: string;
@@ -88,7 +88,7 @@ export class AdminAuditService {
     records: CreateAuditRecordDto[],
     transactionId?: string,
   ): Promise<AdminAudit[]> {
-    const txId = transactionId || uuidv4();
+    const txId = transactionId || randomUUID();
     
     try {
       return await this.prisma.$transaction(

--- a/apps/api/src/auth/services/auth.service.spec.ts
+++ b/apps/api/src/auth/services/auth.service.spec.ts
@@ -6,11 +6,14 @@ import { PrismaService } from '../../common/prisma/prisma.service';
 import { RegisterDto } from '../dto/register.dto';
 import { User, UserRole } from '@prisma/client';
 import { NotificationsService } from '../../notifications/services/notifications.service';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { BadRequestException, ConflictException } from '@nestjs/common';
 
-// Mock external dependencies
-jest.mock('uuid');
+// Mock crypto.randomUUID
+jest.mock('crypto', () => ({
+  ...jest.requireActual('crypto'),
+  randomUUID: jest.fn(),
+}));
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -103,8 +106,8 @@ describe('AuthService', () => {
     jwtService = module.get<JwtService>(JwtService);
     notificationsService = module.get<NotificationsService>(NotificationsService);
     
-    // Setup uuid mock to return predictable values
-    (uuidv4 as jest.Mock).mockReturnValue('mocked-uuid-token');
+    // Setup randomUUID mock to return predictable values
+    (randomUUID as jest.Mock).mockReturnValue('mocked-uuid-token');
   });
 
   it('should be defined', () => {

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -4,9 +4,8 @@ import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { RegisterDto } from '../dto/register.dto';
 import { User, UserRole } from '@prisma/client';
-import { randomUUID } from 'crypto';
+import { randomUUID, randomInt } from 'crypto';
 import { NotificationsService } from '../../notifications/services/notifications.service';
-import { randomInt } from 'crypto';
 import { normalizeEmail } from '../../common/utils/email.utils';
 
 /**

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -4,7 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { RegisterDto } from '../dto/register.dto';
 import { User, UserRole } from '@prisma/client';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { NotificationsService } from '../../notifications/services/notifications.service';
 import { randomInt } from 'crypto';
 import { normalizeEmail } from '../../common/utils/email.utils';
@@ -58,7 +58,7 @@ export class AuthService {
       }
 
       // Generate email verification token
-      const verificationToken = uuidv4();
+      const verificationToken = randomUUID();
 
       // Create new user (always as PARTICIPANT initially - admin promotion happens on first authentication)
       const newUser = await this.prisma.user.create({

--- a/apps/api/src/registrations/services/registration-admin.service.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.ts
@@ -25,7 +25,7 @@ import {
   AdminRegistrationResponseDto,
   AdminRegistrationQueryDto
 } from '../dto/admin-registration.dto';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 export interface RefundInfo {
   hasPayments: boolean;
@@ -219,7 +219,7 @@ export class RegistrationAdminService {
     editData: AdminEditRegistrationDto,
     adminUserId: string,
   ): Promise<AdminRegistrationResponseDto> {
-    const transactionId = uuidv4();
+    const transactionId = randomUUID();
     this.logger.log(`Admin ${adminUserId} editing registration ${registrationId}`);
 
     try {
@@ -530,7 +530,7 @@ export class RegistrationAdminService {
     cancelData: AdminCancelRegistrationDto,
     adminUserId: string,
   ): Promise<AdminRegistrationResponseDto> {
-    const transactionId = uuidv4();
+    const transactionId = randomUUID();
     this.logger.log(`Admin ${adminUserId} cancelling registration ${registrationId}`);
 
     try {

--- a/apps/api/src/registrations/services/registration-cleanup.service.ts
+++ b/apps/api/src/registrations/services/registration-cleanup.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { AdminAuditService, CreateAuditRecordDto } from '../../admin-audit/services/admin-audit.service';
 import { AdminAuditActionType, AdminAuditTargetType } from '@prisma/client';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 export interface CleanupResult {
   workShiftsRemoved: number;
@@ -36,7 +36,7 @@ export class RegistrationCleanupService {
     reason: string,
     transactionId?: string,
   ): Promise<CleanupResult> {
-    const txId = transactionId || uuidv4();
+    const txId = transactionId || randomUUID();
     this.logger.log(`Starting cleanup for registration ${registrationId} by admin ${adminUserId}`);
 
     try {
@@ -177,7 +177,7 @@ export class RegistrationCleanupService {
     reason: string,
     transactionId?: string,
   ): Promise<number> {
-    const txId = transactionId || uuidv4();
+    const txId = transactionId || randomUUID();
 
     try {
       return await this.prisma.$transaction(async (prisma) => {
@@ -239,7 +239,7 @@ export class RegistrationCleanupService {
     reason: string,
     transactionId?: string,
   ): Promise<number> {
-    const txId = transactionId || uuidv4();
+    const txId = transactionId || randomUUID();
 
     try {
       return await this.prisma.$transaction(async (prisma) => {

--- a/apps/api/test/core-config.e2e-spec.ts
+++ b/apps/api/test/core-config.e2e-spec.ts
@@ -5,7 +5,7 @@ import { AppModule } from '../src/app.module';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from '../src/common/prisma/prisma.service';
 import { UserRole } from '@prisma/client';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 describe('CoreConfigController (e2e)', () => {
   let app: INestApplication;
@@ -37,7 +37,7 @@ describe('CoreConfigController (e2e)', () => {
       where: { email: 'admin-test@example.playaplan.app' },
       update: { role: UserRole.ADMIN },
       create: {
-        id: uuidv4(),
+        id: randomUUID(),
         email: 'admin-test@example.playaplan.app',
         firstName: 'Admin',
         lastName: 'User',
@@ -51,7 +51,7 @@ describe('CoreConfigController (e2e)', () => {
       where: { email: 'user-test@example.playaplan.app' },
       update: { role: UserRole.PARTICIPANT },
       create: {
-        id: uuidv4(),
+        id: randomUUID(),
         email: 'user-test@example.playaplan.app',
         firstName: 'Regular',
         lastName: 'User',

--- a/apps/api/test/email-notifications.e2e-spec.ts
+++ b/apps/api/test/email-notifications.e2e-spec.ts
@@ -5,7 +5,7 @@ import { AppModule } from '../src/app.module';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from '../src/common/prisma/prisma.service';
 import { UserRole, NotificationType, EmailAuditStatus } from '@prisma/client';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { NotificationsService } from '../src/notifications/services/notifications.service';
 import { EmailService } from '../src/notifications/services/email.service';
 import * as nodemailer from 'nodemailer';
@@ -71,7 +71,7 @@ describe('Email Notifications (e2e)', () => {
     // Create test admin user
     const adminUser = await prismaService.user.create({
       data: {
-        id: uuidv4(),
+        id: randomUUID(),
         email: 'admin-test@example.playaplan.app',
         firstName: 'Admin',
         lastName: 'User',
@@ -83,7 +83,7 @@ describe('Email Notifications (e2e)', () => {
     // Create test regular user
     const testUser = await prismaService.user.create({
       data: {
-        id: uuidv4(),
+        id: randomUUID(),
         email: 'test-user@example.playaplan.app',
         firstName: 'Test',
         lastName: 'User',
@@ -106,7 +106,7 @@ describe('Email Notifications (e2e)', () => {
     // Create test core configuration with email enabled
     const config = await prismaService.coreConfig.create({
       data: {
-        id: uuidv4(),
+        id: randomUUID(),
         campName: 'Test Camp',
         registrationYear: 2024,
         emailEnabled: true,
@@ -421,7 +421,7 @@ describe('Email Notifications (e2e)', () => {
       for (const audit of testAudits) {
         await prismaService.emailAudit.create({
           data: {
-            id: uuidv4(),
+            id: randomUUID(),
             ...audit,
             createdAt: new Date(),
           },
@@ -458,7 +458,7 @@ describe('Email Notifications (e2e)', () => {
       // Create audit records with different dates
       await prismaService.emailAudit.create({
         data: {
-          id: uuidv4(),
+          id: randomUUID(),
           recipientEmail: 'old@example.com',
           subject: 'Old Email',
           notificationType: NotificationType.EMAIL_VERIFICATION,
@@ -471,7 +471,7 @@ describe('Email Notifications (e2e)', () => {
 
       await prismaService.emailAudit.create({
         data: {
-          id: uuidv4(),
+          id: randomUUID(),
           recipientEmail: 'recent@example.com',
           subject: 'Recent Email',
           notificationType: NotificationType.EMAIL_VERIFICATION,

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@playa-plan/types",
   "version": "0.1.0",
+  "license": "MIT",
   "description": "Shared types for PlayaPlan",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,8 +69,7 @@
                 "rxjs": "^7.8.2",
                 "sanitize-html": "^2.17.3",
                 "stripe": "^14.25.0",
-                "uid": "^2.0.2",
-                "uuid": "^9.0.1"
+                "uid": "^2.0.2"
             },
             "devDependencies": {
                 "@babel/core": "^7.27.4",
@@ -88,7 +87,6 @@
                 "@types/passport-local": "^1.0.38",
                 "@types/sanitize-html": "^2.15.0",
                 "@types/supertest": "^6.0.3",
-                "@types/uuid": "^9.0.8",
                 "dotenv-cli": "^7.4.4",
                 "jest": "^29.7.0",
                 "prettier": "^3.5.3",
@@ -5838,13 +5836,6 @@
                 "@types/superagent": "^8.1.0"
             }
         },
-        "node_modules/@types/uuid": {
-            "version": "9.0.8",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-            "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/validator": {
             "version": "13.15.10",
             "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
@@ -6806,9 +6797,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
@@ -9304,9 +9295,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
@@ -13104,9 +13095,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -15746,19 +15737,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache-lib": {


### PR DESCRIPTION
## Summary

Housekeeping branch addressing dependency vulnerabilities, deprecated CI config, and outdated action versions.

 0)
 1.15.2 (fixes [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653))
 8.5.12 (fixes [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93))
- **uuid**: Replaced `uuid@9` with Node.js built-in `crypto.randomUUID()` to resolve [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq). uuid v14 (the fix version) dropped CommonJS support, incompatible with NestJS  using the built-in eliminates the dependency entirely.build 

### CI fixes
 allow-licenses**: Replaced deprecated `deny-licenses` config ([actions/dependency-review-action#997](https://github.com/actions/dependency-review-action/issues/997)) with an allowlist of permissive licenses compatible with distributing under MIT (MIT, ISC, Apache-2.0, BSD-2-Clause, BSD-3-Clause, BlueOak-1.0.0, MIT-0, Unlicense, 0BSD, CC0-1.0, CC-BY-4.0, Python-2.0)
 v4**: Updated `actions/checkout` and `actions/setup-node` from v3 to v4 in api-ci, e2e-ci, e2e-docker-ci, and frontend-ci workflows
- **Missing license field**: Added `"license": "MIT"` to `libs/types/package.json`

### Verification
- `npm audit`: 0 vulnerabilities
- API build: 
- API tests: 770 passed
- Web tests: 595 passed
- Lint: clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>