### PR TITLE
fix(deps): bump sanitize-html to 2.17.4 (GHSA-rpr9-rxv7-x643)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -70,7 +70,7 @@
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "sanitize-html": "^2.17.3",
+    "sanitize-html": "^2.17.4",
     "stripe": "^14.25.0",
     "uid": "^2.0.2"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
                 "prom-client": "^15.1.3",
                 "reflect-metadata": "^0.2.2",
                 "rxjs": "^7.8.2",
-                "sanitize-html": "^2.17.3",
+                "sanitize-html": "^2.17.4",
                 "stripe": "^14.25.0",
                 "uid": "^2.0.2"
             },
@@ -415,6 +415,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -717,7 +718,7 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -727,7 +728,7 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -776,7 +777,7 @@
             "version": "7.29.2",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
             "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.0"
@@ -2243,7 +2244,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
             "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -2396,6 +2397,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -2419,6 +2421,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -4280,6 +4283,7 @@
             "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.18.tgz",
             "integrity": "sha512-0sLq8Z+TIjLnz1Tqp0C/x9BpLbqpt1qEu0VcH4/fkE0y3F5JxhfK1AdKQ/SPbKhKgwqVDoY4gS8GQr2G6ujaWg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "file-type": "21.3.4",
                 "iterare": "1.2.1",
@@ -4339,6 +4343,7 @@
             "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@nuxt/opencollective": "0.4.1",
                 "fast-safe-stringify": "2.1.1",
@@ -4422,6 +4427,7 @@
             "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.18.tgz",
             "integrity": "sha512-s6GdHMTa3qx0fJewR74Xa30ysPHfBEqxIwZ7BGSTLoAEQ1vTP24urNl+b6+s49NFLEIOyeNho5fN/9/I17QlOw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cors": "2.8.6",
                 "express": "5.2.1",
@@ -5261,6 +5267,7 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -5668,6 +5675,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
             "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -5753,6 +5761,7 @@
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -5764,6 +5773,7 @@
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -5895,6 +5905,7 @@
             "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.58.0",
                 "@typescript-eslint/types": "8.58.0",
@@ -6467,6 +6478,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -6526,6 +6538,7 @@
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -7213,6 +7226,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -7581,13 +7595,15 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
             "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/class-validator": {
             "version": "0.14.4",
             "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
             "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/validator": "^13.15.3",
                 "libphonenumber-js": "^1.11.1",
@@ -8064,6 +8080,12 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/dayjs": {
+            "version": "1.11.20",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+            "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
@@ -8634,6 +8656,7 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -10330,6 +10353,7 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -11565,6 +11589,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/launder": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+            "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+            "license": "MIT",
+            "dependencies": {
+                "dayjs": "^1.11.7"
+            }
+        },
         "node_modules/leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -11913,8 +11946,9 @@
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
             "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.25.4",
                 "@babel/types": "^7.25.4",
@@ -12763,6 +12797,7 @@
             "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
             "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "passport-strategy": "1.x.x",
                 "pause": "0.0.1",
@@ -13114,6 +13149,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -13390,6 +13426,7 @@
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@prisma/config": "6.19.3",
                 "@prisma/engines": "6.19.3"
@@ -13414,6 +13451,7 @@
             "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
             "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/api": "^1.4.0",
                 "tdigest": "^0.1.1"
@@ -13561,6 +13599,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -13573,6 +13612,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -13686,7 +13726,8 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
             "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
@@ -13993,6 +14034,7 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
             "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -14024,15 +14066,16 @@
             "license": "MIT"
         },
         "node_modules/sanitize-html": {
-            "version": "2.17.3",
-            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-            "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+            "version": "2.17.4",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+            "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
             "license": "MIT",
             "dependencies": {
                 "deepmerge": "^4.2.2",
                 "escape-string-regexp": "^4.0.0",
                 "htmlparser2": "^10.1.0",
                 "is-plain-object": "^5.0.0",
+                "launder": "^1.7.1",
                 "parse-srcset": "^1.0.2",
                 "postcss": "^8.3.11"
             }
@@ -14893,6 +14936,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -15381,6 +15425,7 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -15535,6 +15580,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -15786,6 +15832,7 @@
             "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -16062,6 +16109,7 @@
             "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -16131,6 +16179,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",


### PR DESCRIPTION
Resolves Dependabot alert [#102](https://github.com/ChrisRomp/playa-plan/security/dependabot/102) (CVE-2026-44990 / GHSA-rpr9-rxv7-x643), a critical XSS in `sanitize-html` <= 2.17.3 where attacker-controlled content inside a disallowed `<xmp>` element was passed through unescaped, allowing markup like `<xmp><script>alert(1)</script></xmp>` to survive sanitization as live HTML.

## Change

Bumps `sanitize-html` in `apps/api` from `^2.17.3` to `^2.17.4`. The 2.17.4 release adds `xmp` to the default `nonTextTags` list and special-cases the raw-text handling in `ontext`, so disallowed `<xmp>` wrappers can no longer smuggle live markup through the sanitizer.

Only `apps/api` depends on `sanitize-html` (used in `src/common/pipes/validation.pipe.ts`). No call-site changes were needed; the fix is entirely in the upstream defaults.

## Validation

- `npm install` in `apps/api` (0 vulnerabilities reported)
- `npm run build` in `apps/api` passes
- `npm test` in `apps/api`: 770/770 tests pass across 53 suites