### PR TITLE
Require names for passkeys

### DIFF
--- a/apps/api/prisma/migrations/20260515213910_require_passkey_nickname/migration.sql
+++ b/apps/api/prisma/migrations/20260515213910_require_passkey_nickname/migration.sql
@@ -1,0 +1,9 @@
+UPDATE "passkeys"
+SET "nickname" = 'Passkey'
+WHERE "nickname" IS NULL OR length(btrim("nickname")) = 0;
+
+ALTER TABLE "passkeys" ALTER COLUMN "nickname" SET NOT NULL;
+
+ALTER TABLE "passkeys"
+ADD CONSTRAINT "passkeys_nickname_not_blank"
+CHECK (length(btrim("nickname")) > 0);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -406,7 +406,7 @@ model Passkey {
   transports     String[]  @default([])
   deviceType     String?
   backedUp       Boolean   @default(false)
-  nickname       String?
+  nickname       String
   lastUsedAt     DateTime?
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt

--- a/apps/api/src/passkeys/dto/passkey-response.dto.ts
+++ b/apps/api/src/passkeys/dto/passkey-response.dto.ts
@@ -10,8 +10,8 @@ export class PasskeyResponseDto {
   @ApiProperty({ description: 'Passkey database ID' })
   id!: string;
 
-  @ApiProperty({ description: 'User-supplied label', nullable: true })
-  nickname!: string | null;
+  @ApiProperty({ description: 'User-supplied label' })
+  nickname!: string;
 
   @ApiProperty({ description: 'Authenticator transports (e.g., internal, hybrid, usb)' })
   transports!: string[];

--- a/apps/api/src/passkeys/dto/update-passkey.dto.ts
+++ b/apps/api/src/passkeys/dto/update-passkey.dto.ts
@@ -1,12 +1,13 @@
-import { IsString, MaxLength } from 'class-validator';
+import { IsString, Matches, MaxLength } from 'class-validator';
 
 /**
  * Payload for renaming a passkey. Nickname is plaintext only,
- * capped at 20 characters. Same constraint enforced client-side
+ * capped at 40 characters. Same constraint enforced client-side
  * in the profile UI.
  */
 export class UpdatePasskeyDto {
   @IsString()
-  @MaxLength(20, { message: 'Nickname must be 20 characters or fewer' })
+  @Matches(/\S/, { message: 'Nickname is required' })
+  @MaxLength(40, { message: 'Nickname must be 40 characters or fewer' })
   nickname!: string;
 }

--- a/apps/api/src/passkeys/dto/verify-passkey.dto.ts
+++ b/apps/api/src/passkeys/dto/verify-passkey.dto.ts
@@ -1,4 +1,4 @@
-import { IsObject, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsObject, IsString, Matches, MaxLength } from 'class-validator';
 import type {
   RegistrationResponseJSON,
   AuthenticationResponseJSON,
@@ -15,10 +15,10 @@ export class VerifyRegistrationDto {
   @IsObject()
   response!: RegistrationResponseJSON;
 
-  @IsOptional()
   @IsString()
-  @MaxLength(20, { message: 'Nickname must be 20 characters or fewer' })
-  nickname?: string;
+  @Matches(/\S/, { message: 'Nickname is required' })
+  @MaxLength(40, { message: 'Nickname must be 40 characters or fewer' })
+  nickname!: string;
 }
 
 /**

--- a/apps/api/src/passkeys/services/passkeys.service.spec.ts
+++ b/apps/api/src/passkeys/services/passkeys.service.spec.ts
@@ -283,7 +283,7 @@ describe('PasskeysService', () => {
     });
 
     it('atomically consumes the challenge by delete-on-read', async () => {
-      await service.verifyRegistration(user, response);
+      await service.verifyRegistration(user, response, 'My iPhone');
       expect(prisma.webAuthnChallenge.delete).toHaveBeenCalledWith({
         where: { challenge },
       });
@@ -296,7 +296,7 @@ describe('PasskeysService', () => {
           clientVersion: 'test',
         }),
       );
-      await expect(service.verifyRegistration(user, response)).rejects.toBeInstanceOf(
+      await expect(service.verifyRegistration(user, response, 'My iPhone')).rejects.toBeInstanceOf(
         BadRequestException,
       );
     });
@@ -307,7 +307,7 @@ describe('PasskeysService', () => {
         clientVersion: 'test',
       });
       prisma.webAuthnChallenge.delete.mockRejectedValueOnce(dbErr);
-      await expect(service.verifyRegistration(user, response)).rejects.toBe(dbErr);
+      await expect(service.verifyRegistration(user, response, 'My iPhone')).rejects.toBe(dbErr);
     });
 
     it('dispatches PASSKEY_ADDED notification', async () => {
@@ -323,9 +323,23 @@ describe('PasskeysService', () => {
       );
     });
 
-    it('rejects nicknames longer than 20 chars', async () => {
+    it('rejects missing nicknames', async () => {
       await expect(
-        service.verifyRegistration(user, response, 'a'.repeat(21)),
+        service.verifyRegistration(user, response, undefined as unknown as string),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(prisma.webAuthnChallenge.delete).not.toHaveBeenCalled();
+    });
+
+    it('rejects blank nicknames', async () => {
+      await expect(
+        service.verifyRegistration(user, response, '   '),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(prisma.webAuthnChallenge.delete).not.toHaveBeenCalled();
+    });
+
+    it('rejects nicknames longer than 40 chars', async () => {
+      await expect(
+        service.verifyRegistration(user, response, 'a'.repeat(41)),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
@@ -337,7 +351,7 @@ describe('PasskeysService', () => {
         type: WebAuthnChallengeType.REGISTRATION,
         expiresAt: new Date(Date.now() - 10),
       });
-      await expect(service.verifyRegistration(user, response)).rejects.toBeInstanceOf(
+      await expect(service.verifyRegistration(user, response, 'My iPhone')).rejects.toBeInstanceOf(
         BadRequestException,
       );
     });
@@ -350,14 +364,14 @@ describe('PasskeysService', () => {
         type: WebAuthnChallengeType.REGISTRATION,
         expiresAt: new Date(Date.now() + 60_000),
       });
-      await expect(service.verifyRegistration(user, response)).rejects.toBeInstanceOf(
+      await expect(service.verifyRegistration(user, response, 'My iPhone')).rejects.toBeInstanceOf(
         BadRequestException,
       );
     });
 
     it('rejects when verification fails', async () => {
       mockedVerifyRegistrationResponse.mockResolvedValueOnce({ verified: false } as never);
-      await expect(service.verifyRegistration(user, response)).rejects.toBeInstanceOf(
+      await expect(service.verifyRegistration(user, response, 'My iPhone')).rejects.toBeInstanceOf(
         BadRequestException,
       );
     });
@@ -366,14 +380,14 @@ describe('PasskeysService', () => {
       mockedVerifyRegistrationResponse.mockRejectedValueOnce(
         new Error('Unexpected origin foo.com'),
       );
-      await expect(service.verifyRegistration(user, response)).rejects.toBeInstanceOf(
+      await expect(service.verifyRegistration(user, response, 'My iPhone')).rejects.toBeInstanceOf(
         BadRequestException,
       );
     });
 
     it('rejects malformed registration shape', async () => {
       const badResponse = { id: 'x', type: 'public-key', response: {} } as never;
-      await expect(service.verifyRegistration(user, badResponse)).rejects.toBeInstanceOf(
+      await expect(service.verifyRegistration(user, badResponse, 'My iPhone')).rejects.toBeInstanceOf(
         BadRequestException,
       );
     });
@@ -388,7 +402,7 @@ describe('PasskeysService', () => {
           attestationObject: 'attestation-bytes',
         },
       } as never;
-      await expect(service.verifyRegistration(user, badResponse)).rejects.toBeInstanceOf(
+      await expect(service.verifyRegistration(user, badResponse, 'My iPhone')).rejects.toBeInstanceOf(
         BadRequestException,
       );
     });
@@ -400,7 +414,7 @@ describe('PasskeysService', () => {
           clientVersion: 'test',
         }),
       );
-      await expect(service.verifyRegistration(user, response)).rejects.toBeInstanceOf(
+      await expect(service.verifyRegistration(user, response, 'My iPhone')).rejects.toBeInstanceOf(
         BadRequestException,
       );
     });
@@ -738,9 +752,16 @@ describe('PasskeysService', () => {
       expect(out.nickname).toBe('New');
     });
 
-    it('rejects nicknames over 20 chars', async () => {
+    it('rejects blank nicknames', async () => {
       await expect(
-        service.updateNickname(user.id, 'pk-1', 'x'.repeat(21)),
+        service.updateNickname(user.id, 'pk-1', '   '),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(prisma.passkey.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('rejects nicknames over 40 chars', async () => {
+      await expect(
+        service.updateNickname(user.id, 'pk-1', 'x'.repeat(41)),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 

--- a/apps/api/src/passkeys/services/passkeys.service.ts
+++ b/apps/api/src/passkeys/services/passkeys.service.ts
@@ -36,7 +36,7 @@ export const MAX_PASSKEYS_PER_USER = 5;
 /**
  * Maximum length of a user-supplied passkey nickname (plaintext).
  */
-export const MAX_NICKNAME_LENGTH = 20;
+export const MAX_NICKNAME_LENGTH = 40;
 
 /**
  * How long an issued challenge remains valid. Five minutes is plenty for
@@ -128,9 +128,9 @@ export class PasskeysService {
   async verifyRegistration(
     user: Pick<User, 'id' | 'email' | 'firstName' | 'lastName'>,
     response: RegistrationResponseJSON,
-    nickname?: string,
+    nickname: string,
   ): Promise<Passkey> {
-    const trimmedNickname = this.normalizeNickname(nickname);
+    const trimmedNickname = this.normalizeRequiredNickname(nickname);
     this.assertRegistrationShape(response);
     const challengeRow = await this.consumeChallenge(
       this.extractChallenge(response.response.clientDataJSON),
@@ -410,7 +410,7 @@ export class PasskeysService {
     passkeyId: string,
     nickname: string,
   ): Promise<Passkey> {
-    const trimmed = this.normalizeNickname(nickname);
+    const trimmed = this.normalizeRequiredNickname(nickname);
     const passkey = await this.prisma.passkey.findFirst({
       where: { id: passkeyId, userId },
     });
@@ -444,10 +444,14 @@ export class PasskeysService {
     }
   }
 
-  private normalizeNickname(nickname: string | undefined | null): string | null {
-    if (nickname === undefined || nickname === null) return null;
+  private normalizeRequiredNickname(nickname: string | undefined | null): string {
+    if (nickname === undefined || nickname === null) {
+      throw new BadRequestException('Nickname is required');
+    }
     const trimmed = nickname.trim();
-    if (trimmed.length === 0) return null;
+    if (trimmed.length === 0) {
+      throw new BadRequestException('Nickname is required');
+    }
     if (trimmed.length > MAX_NICKNAME_LENGTH) {
       throw new BadRequestException(
         `Nickname must be ${MAX_NICKNAME_LENGTH} characters or fewer`,

--- a/apps/web/src/components/profile/PasskeysSection.test.tsx
+++ b/apps/web/src/components/profile/PasskeysSection.test.tsx
@@ -1,0 +1,151 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import PasskeysSection from './PasskeysSection';
+import { usePasskeys } from '../../hooks/usePasskeys';
+import type { Passkey } from '../../lib/api/passkeys';
+
+vi.mock('../../hooks/usePasskeys');
+
+const mockUsePasskeys = vi.mocked(usePasskeys);
+
+const samplePasskey: Passkey = {
+  id: 'pk-1',
+  nickname: 'My Phone',
+  transports: ['internal'],
+  backedUp: true,
+  deviceType: 'multiDevice',
+  lastUsedAt: null,
+  createdAt: new Date('2026-04-01T12:00:00'),
+};
+
+const defaultHookValue = {
+  passkeys: [] as Passkey[],
+  isLoading: false,
+  error: null,
+  supported: true,
+  refresh: vi.fn(),
+  register: vi.fn(),
+  rename: vi.fn(),
+  remove: vi.fn(),
+};
+
+const setNavigatorHints = (): void => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15',
+    configurable: true,
+  });
+  Object.defineProperty(window.navigator, 'platform', {
+    value: 'MacIntel',
+    configurable: true,
+  });
+};
+
+describe('PasskeysSection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T12:00:00'));
+    setNavigatorHints();
+    mockUsePasskeys.mockReturnValue(defaultHookValue);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('prefills a required editable default passkey name', () => {
+    render(<PasskeysSection />);
+
+    const input = screen.getByLabelText(/passkey name/i) as HTMLInputElement;
+
+    expect(input).toBeRequired();
+    expect(input.value).toBe(`Safari on macOS - ${new Date().toLocaleDateString()}`);
+  });
+
+  it('selects the default passkey name when focused', () => {
+    render(<PasskeysSection />);
+
+    const input = screen.getByLabelText(/passkey name/i) as HTMLInputElement;
+    fireEvent.focus(input);
+
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+
+  it('submits the trimmed passkey name', () => {
+    const register = vi.fn().mockImplementation(() => new Promise<Passkey>(() => undefined));
+    mockUsePasskeys.mockReturnValue({ ...defaultHookValue, register });
+
+    render(<PasskeysSection />);
+    fireEvent.change(screen.getByLabelText(/passkey name/i), {
+      target: { value: '  My laptop  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create passkey/i }));
+
+    expect(register).toHaveBeenCalledWith('My laptop');
+  });
+
+  it('requires a non-blank passkey name before adding', () => {
+    render(<PasskeysSection />);
+
+    fireEvent.change(screen.getByLabelText(/passkey name/i), {
+      target: { value: '   ' },
+    });
+
+    expect(screen.getByRole('button', { name: /create passkey/i })).toBeDisabled();
+  });
+
+  it('hides the add passkey form when passkeys already exist', () => {
+    mockUsePasskeys.mockReturnValue({
+      ...defaultHookValue,
+      passkeys: [samplePasskey],
+    });
+
+    render(<PasskeysSection />);
+
+    expect(screen.queryByLabelText(/passkey name/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^add passkey$/i })).toBeInTheDocument();
+  });
+
+  it('shows the add passkey form after clicking Add passkey', () => {
+    mockUsePasskeys.mockReturnValue({
+      ...defaultHookValue,
+      passkeys: [samplePasskey],
+    });
+
+    render(<PasskeysSection />);
+    fireEvent.click(screen.getByRole('button', { name: /^add passkey$/i }));
+
+    expect(screen.getByLabelText(/passkey name/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create passkey/i })).toBeInTheDocument();
+  });
+
+  it('requires a non-blank name when renaming', () => {
+    const rename = vi.fn();
+    mockUsePasskeys.mockReturnValue({
+      ...defaultHookValue,
+      passkeys: [samplePasskey],
+      rename,
+    });
+
+    render(<PasskeysSection />);
+    fireEvent.click(screen.getByRole('button', { name: /rename/i }));
+    fireEvent.change(screen.getByDisplayValue('My Phone'), {
+      target: { value: '   ' },
+    });
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+    expect(rename).not.toHaveBeenCalled();
+  });
+
+  it('does not show synced status text for backed-up passkeys', () => {
+    mockUsePasskeys.mockReturnValue({
+      ...defaultHookValue,
+      passkeys: [samplePasskey],
+    });
+
+    render(<PasskeysSection />);
+
+    expect(screen.getByText('My Phone')).toBeInTheDocument();
+    expect(screen.queryByText(/synced/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/profile/PasskeysSection.tsx
+++ b/apps/web/src/components/profile/PasskeysSection.tsx
@@ -2,10 +2,45 @@ import { useState } from 'react';
 import { usePasskeys } from '../../hooks/usePasskeys';
 import type { Passkey } from '../../lib/api/passkeys';
 
-const NICKNAME_MAX_LENGTH = 20;
+const NICKNAME_MAX_LENGTH = 40;
 
 const formatDate = (d: Date | null): string =>
   d ? d.toLocaleDateString() : 'never';
+
+interface NavigatorWithUserAgentData extends Navigator {
+  readonly userAgentData?: {
+    readonly platform?: string;
+  };
+}
+
+const browserName = (userAgent: string): string => {
+  if (/Edg\//.test(userAgent)) return 'Edge';
+  if (/Firefox\//.test(userAgent)) return 'Firefox';
+  if (/Chrome\//.test(userAgent) || /CriOS\//.test(userAgent)) return 'Chrome';
+  if (/Safari\//.test(userAgent)) return 'Safari';
+  return 'Browser';
+};
+
+const platformName = (nav: NavigatorWithUserAgentData): string => {
+  const platform = nav.userAgentData?.platform || nav.platform || '';
+  const userAgent = nav.userAgent || '';
+  const source = `${platform} ${userAgent}`;
+
+  if (/iPhone|iPad|iPod/i.test(source)) return 'iOS';
+  if (/Mac/i.test(source)) return 'macOS';
+  if (/Win/i.test(source)) return 'Windows';
+  if (/Android/i.test(source)) return 'Android';
+  if (/Linux/i.test(source)) return 'Linux';
+  return 'this device';
+};
+
+const defaultPasskeyName = (): string => {
+  if (typeof navigator === 'undefined') {
+    return `Browser on this device - ${new Date().toLocaleDateString()}`;
+  }
+  const nav = navigator as NavigatorWithUserAgentData;
+  return `${browserName(nav.userAgent)} on ${platformName(nav)} - ${new Date().toLocaleDateString()}`;
+};
 
 /**
  * "Sign-in passkeys" section for the user profile page. Lists all
@@ -16,37 +51,49 @@ const PasskeysSection: React.FC = () => {
   const { passkeys, isLoading, error, supported, register, rename, remove } =
     usePasskeys();
 
-  const [newNickname, setNewNickname] = useState('');
+  const [newNickname, setNewNickname] = useState(defaultPasskeyName);
   const [busy, setBusy] = useState(false);
+  const [showAddForm, setShowAddForm] = useState(false);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
 
   if (!supported) return null;
 
+  const newNicknameTrimmed = newNickname.trim();
+  const renameValueTrimmed = renameValue.trim();
+  const isNewNicknameInvalid =
+    newNicknameTrimmed.length === 0 || newNicknameTrimmed.length > NICKNAME_MAX_LENGTH;
+  const isRenameValueInvalid =
+    renameValueTrimmed.length === 0 || renameValueTrimmed.length > NICKNAME_MAX_LENGTH;
+  const shouldShowAddForm = showAddForm || (!isLoading && passkeys.length === 0);
+
   const handleAdd = async () => {
-    if (newNickname.length > NICKNAME_MAX_LENGTH) return;
+    if (isNewNicknameInvalid) return;
     setBusy(true);
-    const created = await register(newNickname.trim() || undefined);
+    const created = await register(newNicknameTrimmed);
     setBusy(false);
-    if (created) setNewNickname('');
+    if (created) {
+      setNewNickname(defaultPasskeyName());
+      setShowAddForm(false);
+    }
   };
 
   const startRename = (p: Passkey) => {
     setRenamingId(p.id);
-    setRenameValue(p.nickname ?? '');
+    setRenameValue(p.nickname);
   };
 
   const submitRename = async () => {
     if (!renamingId) return;
-    if (renameValue.length > NICKNAME_MAX_LENGTH) return;
+    if (isRenameValueInvalid) return;
     setBusy(true);
-    const updated = await rename(renamingId, renameValue.trim());
+    const updated = await rename(renamingId, renameValueTrimmed);
     setBusy(false);
     if (updated) setRenamingId(null);
   };
 
   const confirmRemove = async (p: Passkey) => {
-    const label = p.nickname || 'this passkey';
+    const label = p.nickname;
     if (!window.confirm(`Remove ${label}? You will no longer be able to sign in with it.`)) {
       return;
     }
@@ -74,30 +121,46 @@ const PasskeysSection: React.FC = () => {
         </div>
       )}
 
-      <div className="mb-6 flex flex-col sm:flex-row gap-2 sm:items-end">
-        <label className="flex-1">
-          <span className="block text-sm font-medium text-gray-700 mb-1">
-            Nickname (optional, up to {NICKNAME_MAX_LENGTH} chars)
-          </span>
-          <input
-            type="text"
-            value={newNickname}
-            onChange={(e) => setNewNickname(e.target.value)}
-            maxLength={NICKNAME_MAX_LENGTH}
-            placeholder="e.g. My laptop"
-            className="w-full border rounded px-3 py-2"
-            disabled={busy}
-          />
-        </label>
+      {!shouldShowAddForm && (
         <button
           type="button"
-          onClick={handleAdd}
-          disabled={busy || newNickname.length > NICKNAME_MAX_LENGTH}
-          className="bg-blue-600 text-white rounded px-4 py-2 disabled:opacity-50"
+          onClick={() => setShowAddForm(true)}
+          disabled={busy}
+          className="mb-6 bg-blue-600 text-white rounded px-4 py-2 disabled:opacity-50"
         >
-          {busy ? 'Working…' : 'Add passkey'}
+          Add passkey
         </button>
-      </div>
+      )}
+
+      {shouldShowAddForm && (
+        <div className="mb-6 flex flex-col sm:flex-row gap-2 sm:items-end">
+          <label className="flex-1">
+            <span className="block text-sm font-medium text-gray-700 mb-1">
+              Passkey Name (required, up to {NICKNAME_MAX_LENGTH} chars)
+            </span>
+            <input
+              type="text"
+              value={newNickname}
+              onChange={(e) => setNewNickname(e.target.value)}
+              onFocus={(e) => e.target.select()}
+              maxLength={NICKNAME_MAX_LENGTH}
+              placeholder="e.g. Safari on macOS - 5/15/2026"
+              className="w-full border rounded px-3 py-2"
+              disabled={busy}
+              required
+              aria-invalid={isNewNicknameInvalid}
+            />
+          </label>
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={busy || isNewNicknameInvalid}
+            className="bg-blue-600 text-white rounded px-4 py-2 disabled:opacity-50"
+          >
+            {busy ? 'Working…' : 'Create passkey'}
+          </button>
+        </div>
+      )}
 
       {isLoading ? (
         <div>Loading…</div>
@@ -117,11 +180,13 @@ const PasskeysSection: React.FC = () => {
                       maxLength={NICKNAME_MAX_LENGTH}
                       className="flex-1 border rounded px-2 py-1"
                       autoFocus
+                      required
+                      aria-invalid={isRenameValueInvalid}
                     />
                     <button
                       type="button"
                       onClick={submitRename}
-                      disabled={busy || renameValue.length > NICKNAME_MAX_LENGTH}
+                      disabled={busy || isRenameValueInvalid}
                       className="text-blue-600 hover:underline"
                     >
                       Save
@@ -136,12 +201,9 @@ const PasskeysSection: React.FC = () => {
                   </div>
                 ) : (
                   <>
-                    <div className="font-medium truncate">
-                      {p.nickname || <em className="text-gray-500">Unnamed passkey</em>}
-                    </div>
+                    <div className="font-medium truncate">{p.nickname}</div>
                     <div className="text-xs text-gray-500">
                       Added {formatDate(p.createdAt)} · Last used {formatDate(p.lastUsedAt)}
-                      {p.backedUp && ' · Synced'}
                     </div>
                   </>
                 )}

--- a/apps/web/src/hooks/__tests__/usePasskeys.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePasskeys.test.tsx
@@ -86,7 +86,7 @@ describe('usePasskeys', () => {
 
     let returned;
     await act(async () => {
-      returned = await result.current.register();
+      returned = await result.current.register('My Phone');
     });
 
     expect(returned).toBeNull();

--- a/apps/web/src/hooks/usePasskeys.ts
+++ b/apps/web/src/hooks/usePasskeys.ts
@@ -37,7 +37,7 @@ export const usePasskeys = () => {
   }, [load]);
 
   const register = useCallback(
-    async (nickname?: string): Promise<Passkey | null> => {
+    async (nickname: string): Promise<Passkey | null> => {
       if (!supported) {
         setError('This browser does not support passkeys.');
         return null;

--- a/apps/web/src/lib/api/passkeys.ts
+++ b/apps/web/src/lib/api/passkeys.ts
@@ -8,7 +8,7 @@ import { api, setJwtToken, AuthResponseSchema, type AuthResponse } from '../api'
  */
 export const PasskeySchema = z.object({
   id: z.string(),
-  nickname: z.string().nullable(),
+  nickname: z.string(),
   transports: z.array(z.string()).default([]),
   backedUp: z.boolean(),
   deviceType: z.string().nullable(),
@@ -45,7 +45,7 @@ export const passkeysApi = {
   },
 
   /** Submit the browser-supplied attestation back for verification. */
-  registrationVerify: async (response: unknown, nickname?: string): Promise<Passkey> => {
+  registrationVerify: async (response: unknown, nickname: string): Promise<Passkey> => {
     const res = await api.post('/passkeys/registration/verify', { response, nickname });
     return PasskeySchema.parse(res.data);
   },


### PR DESCRIPTION
Passkeys could be created without a useful label, which made the profile list hard to understand once multiple credentials exist. This change makes the passkey name required end-to-end while keeping the add flow quick with an editable browser/platform/date default.

## Summary

- Require non-blank passkey nicknames in API DTOs, service normalization, and the Prisma schema with a migration constraint.
- Prefill new passkey names using browser/platform/date hints, select the default on focus, and collapse the add form behind an `Add passkey` button when passkeys already exist.
- Remove the user-facing `Synced` status from the passkey list while retaining the `backedUp` field in API data.
- Add API service and frontend component/hook coverage for required names, collapsed add UI, default naming, and status display.

## Validation

- `npm run test --workspace=api -- passkeys --runInBand`
- `npm run test --workspace=web -- usePasskeys PasskeysSection`
- `npm run test --workspace=api -- --runInBand`
- `npm run test --workspace=web`
- `npm run lint`
- `npm run build`