### PR TITLE
ci(e2e): fail-fast secret check, job-summary report, and /run-e2e PR slash-command

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -2,7 +2,6 @@ name: E2E Tests
 
 permissions:
   contents: read
-  actions: write
   checks: write
   pull-requests: write
 
@@ -48,6 +47,12 @@ jobs:
     name: End-to-End Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Cancel any older run for the same PR (or for the same triggering ref on
+    # manual dispatch) so the sticky comment + check always reflect the
+    # latest invocation, not whichever happens to finish last.
+    concurrency:
+      group: e2e-ci-${{ inputs.pr_number != '' && format('pr-{0}', inputs.pr_number) || github.ref }}
+      cancel-in-progress: true
 
     services:
       postgres:
@@ -66,6 +71,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    # Fail fast on missing CI secret BEFORE we spend minutes on installs.
+    - name: Validate E2E_SEED_LOCAL secret and stage seed.local.ts
+      env:
+        E2E_SEED_LOCAL: ${{ secrets.E2E_SEED_LOCAL }}
+      run: |
+        if [ -z "$E2E_SEED_LOCAL" ]; then
+          echo "::error::E2E_SEED_LOCAL secret is not set. Stripe-dependent tests would fail with confusing timeouts on the disabled 'Complete Registration' button. Add the secret under repo Settings → Secrets and variables → Actions (use the apps/api/prisma/seeds/seed.local.template.ts as a starting point, with Stripe TEST keys: pk_test_* / sk_test_*)."
+          exit 1
+        fi
+        printf '%s' "$E2E_SEED_LOCAL" > apps/api/prisma/seeds/seed.local.ts
+        echo "Wrote apps/api/prisma/seeds/seed.local.ts ($(wc -c < apps/api/prisma/seeds/seed.local.ts) bytes)"
 
     - name: Create PR check (in-progress)
       id: pr_check
@@ -106,17 +123,6 @@ jobs:
         echo "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/playaplan_test" >> .env
         echo "JWT_SECRET=test-secret-key-for-ci" >> .env
         echo "NODE_ENV=development" >> .env
-
-    - name: Write seed.local.ts from secret
-      env:
-        E2E_SEED_LOCAL: ${{ secrets.E2E_SEED_LOCAL }}
-      run: |
-        if [ -z "$E2E_SEED_LOCAL" ]; then
-          echo "::error::E2E_SEED_LOCAL secret is not set. Stripe-dependent tests would fail with confusing timeouts on the disabled 'Complete Registration' button. Add the secret under repo Settings → Secrets and variables → Actions (use the apps/api/prisma/seeds/seed.local.template.ts as a starting point, with Stripe TEST keys: pk_test_* / sk_test_*)."
-          exit 1
-        fi
-        printf '%s' "$E2E_SEED_LOCAL" > apps/api/prisma/seeds/seed.local.ts
-        echo "Wrote apps/api/prisma/seeds/seed.local.ts ($(wc -c < apps/api/prisma/seeds/seed.local.ts) bytes)"
 
     - name: Setup database (migrate + base seed + e2e personas + local creds)
       run: |
@@ -211,17 +217,27 @@ jobs:
         script: |
           const fs = require('fs');
           const marker = '<!-- e2e-ci-summary -->';
-          const summary = fs.readFileSync('/tmp/e2e/summary.md', 'utf8');
+          let summary;
+          try {
+            summary = fs.readFileSync('/tmp/e2e/summary.md', 'utf8');
+          } catch {
+            summary = '_E2E summary unavailable — the test step may have failed before producing a report._\n';
+          }
           const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           const body = `${marker}\n${summary}\n[View full run](${runUrl})\n`;
           const prNumber = parseInt('${{ inputs.pr_number }}', 10);
-          const { data: comments } = await github.rest.issues.listComments({
+          // Paginate so PRs with >100 comments still find the sticky comment.
+          const comments = await github.paginate(github.rest.issues.listComments, {
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: prNumber,
             per_page: 100,
           });
-          const existing = comments.find(c => c.body && c.body.startsWith(marker));
+          // Only consider our own bot's comments to avoid hijacking human ones.
+          const ours = comments.filter(c =>
+            c.user?.login === 'github-actions[bot]' && c.body?.includes(marker)
+          );
+          const existing = ours[0];
           if (existing) {
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
@@ -229,6 +245,14 @@ jobs:
               comment_id: existing.id,
               body,
             });
+            // Clean up any duplicates left by older bugs.
+            for (const dup of ours.slice(1)) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: dup.id,
+              });
+            }
           } else {
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -237,37 +261,6 @@ jobs:
               body,
             });
           }
-
-    - name: Complete PR check
-      if: always() && steps.pr_check.outputs.id != ''
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const fs = require('fs');
-          const jobStatus = '${{ job.status }}';
-          const conclusion = jobStatus === 'success'
-            ? 'success'
-            : jobStatus === 'cancelled' ? 'cancelled' : 'failure';
-          let summary = '';
-          try {
-            summary = fs.readFileSync('/tmp/e2e/summary.md', 'utf8');
-          } catch {
-            summary = '_Test summary unavailable._';
-          }
-          // Check Run output.summary has a 65535-char limit; truncate defensively.
-          if (summary.length > 60000) summary = summary.slice(0, 60000) + '\n\n_…truncated…_';
-          await github.rest.checks.update({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            check_run_id: parseInt('${{ steps.pr_check.outputs.id }}', 10),
-            status: 'completed',
-            conclusion,
-            completed_at: new Date().toISOString(),
-            output: {
-              title: `E2E ${conclusion}`,
-              summary,
-            },
-          });
 
     - name: Upload Playwright Report
       uses: actions/upload-artifact@v4
@@ -316,3 +309,36 @@ jobs:
           kill $(cat apps/web/web.pid) || echo "Web server already stopped"
           rm apps/web/web.pid
         fi
+
+    # Must be the last step so job.status reflects the outcome of EVERY
+    # preceding step (test run, uploads, cleanup).
+    - name: Complete PR check
+      if: always() && steps.pr_check.outputs.id != ''
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const jobStatus = '${{ job.status }}';
+          const conclusion = jobStatus === 'success'
+            ? 'success'
+            : jobStatus === 'cancelled' ? 'cancelled' : 'failure';
+          let summary = '';
+          try {
+            summary = fs.readFileSync('/tmp/e2e/summary.md', 'utf8');
+          } catch {
+            summary = '_Test summary unavailable._';
+          }
+          // Check Run output.summary has a 65535-char limit; truncate defensively.
+          if (summary.length > 60000) summary = summary.slice(0, 60000) + '\n\n_…truncated…_';
+          await github.rest.checks.update({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            check_run_id: parseInt('${{ steps.pr_check.outputs.id }}', 10),
+            status: 'completed',
+            conclusion,
+            completed_at: new Date().toISOString(),
+            output: {
+              title: `E2E ${conclusion}`,
+              summary,
+            },
+          });

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -88,19 +88,24 @@ jobs:
       id: pr_check
       if: inputs.pr_number != '' && inputs.head_sha != ''
       uses: actions/github-script@v7
+      env:
+        PR_NUMBER: ${{ inputs.pr_number }}
+        HEAD_SHA: ${{ inputs.head_sha }}
       with:
         script: |
+          const { PR_NUMBER, HEAD_SHA } = process.env;
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           const { data: check } = await github.rest.checks.create({
             owner: context.repo.owner,
             repo: context.repo.repo,
             name: 'E2E Tests',
-            head_sha: '${{ inputs.head_sha }}',
+            head_sha: HEAD_SHA,
             status: 'in_progress',
             started_at: new Date().toISOString(),
-            details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            details_url: runUrl,
             output: {
               title: 'E2E Tests running',
-              summary: `Triggered by /run-e2e on PR #${{ inputs.pr_number }}.\n\n[View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+              summary: `Triggered by /run-e2e on PR #${PR_NUMBER}.\n\n[View run](${runUrl})`,
             },
           });
           core.setOutput('id', check.id);
@@ -213,6 +218,8 @@ jobs:
     - name: Post or update PR comment with results
       if: always() && inputs.pr_number != ''
       uses: actions/github-script@v7
+      env:
+        PR_NUMBER: ${{ inputs.pr_number }}
       with:
         script: |
           const fs = require('fs');
@@ -225,7 +232,7 @@ jobs:
           }
           const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           const body = `${marker}\n${summary}\n[View full run](${runUrl})\n`;
-          const prNumber = parseInt('${{ inputs.pr_number }}', 10);
+          const prNumber = parseInt(process.env.PR_NUMBER, 10);
           // Paginate so PRs with >100 comments still find the sticky comment.
           const comments = await github.paginate(github.rest.issues.listComments, {
             owner: context.repo.owner,
@@ -315,10 +322,13 @@ jobs:
     - name: Complete PR check
       if: always() && steps.pr_check.outputs.id != ''
       uses: actions/github-script@v7
+      env:
+        JOB_STATUS: ${{ job.status }}
+        CHECK_RUN_ID: ${{ steps.pr_check.outputs.id }}
       with:
         script: |
           const fs = require('fs');
-          const jobStatus = '${{ job.status }}';
+          const jobStatus = process.env.JOB_STATUS;
           const conclusion = jobStatus === 'success'
             ? 'success'
             : jobStatus === 'cancelled' ? 'cancelled' : 'failure';
@@ -333,7 +343,7 @@ jobs:
           await github.rest.checks.update({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            check_run_id: parseInt('${{ steps.pr_check.outputs.id }}', 10),
+            check_run_id: parseInt(process.env.CHECK_RUN_ID, 10),
             status: 'completed',
             conclusion,
             completed_at: new Date().toISOString(),

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -3,12 +3,22 @@ name: E2E Tests
 permissions:
   contents: read
   actions: write
+  checks: write
+  pull-requests: write
 
 on:
   workflow_dispatch:
     inputs:
       tags:
         description: 'Playwright --grep filter (e.g. "@smoke|@auth"). Empty = run all.'
+        required: false
+        default: ''
+      pr_number:
+        description: 'PR number — when set, post results as a sticky PR comment. (Set automatically by the /run-e2e slash-command dispatcher.)'
+        required: false
+        default: ''
+      head_sha:
+        description: 'PR head commit SHA — when set, create a check run on that commit so the PR shows the result. (Set automatically by the /run-e2e dispatcher.)'
         required: false
         default: ''
   # NOTE: PR/push triggers intentionally disabled until E2E timings are stable.
@@ -56,6 +66,27 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Create PR check (in-progress)
+      id: pr_check
+      if: inputs.pr_number != '' && inputs.head_sha != ''
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { data: check } = await github.rest.checks.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: 'E2E Tests',
+            head_sha: '${{ inputs.head_sha }}',
+            status: 'in_progress',
+            started_at: new Date().toISOString(),
+            details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            output: {
+              title: 'E2E Tests running',
+              summary: `Triggered by /run-e2e on PR #${{ inputs.pr_number }}.\n\n[View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+            },
+          });
+          core.setOutput('id', check.id);
 
     - name: Use Node.js 22.x
       uses: actions/setup-node@v4
@@ -166,9 +197,77 @@ jobs:
           npx --yes playwright test
         fi
 
-    - name: Publish Playwright summary to job summary
+    - name: Generate Playwright summary markdown
       if: always()
-      run: node scripts/playwright-summary.mjs playwright-report/results.json
+      run: |
+        mkdir -p /tmp/e2e
+        node scripts/playwright-summary.mjs playwright-report/results.json > /tmp/e2e/summary.md
+        cat /tmp/e2e/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Post or update PR comment with results
+      if: always() && inputs.pr_number != ''
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const marker = '<!-- e2e-ci-summary -->';
+          const summary = fs.readFileSync('/tmp/e2e/summary.md', 'utf8');
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const body = `${marker}\n${summary}\n[View full run](${runUrl})\n`;
+          const prNumber = parseInt('${{ inputs.pr_number }}', 10);
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            per_page: 100,
+          });
+          const existing = comments.find(c => c.body && c.body.startsWith(marker));
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+          }
+
+    - name: Complete PR check
+      if: always() && steps.pr_check.outputs.id != ''
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const jobStatus = '${{ job.status }}';
+          const conclusion = jobStatus === 'success'
+            ? 'success'
+            : jobStatus === 'cancelled' ? 'cancelled' : 'failure';
+          let summary = '';
+          try {
+            summary = fs.readFileSync('/tmp/e2e/summary.md', 'utf8');
+          } catch {
+            summary = '_Test summary unavailable._';
+          }
+          // Check Run output.summary has a 65535-char limit; truncate defensively.
+          if (summary.length > 60000) summary = summary.slice(0, 60000) + '\n\n_…truncated…_';
+          await github.rest.checks.update({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            check_run_id: parseInt('${{ steps.pr_check.outputs.id }}', 10),
+            status: 'completed',
+            conclusion,
+            completed_at: new Date().toISOString(),
+            output: {
+              title: `E2E ${conclusion}`,
+              summary,
+            },
+          });
 
     - name: Upload Playwright Report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -81,11 +81,11 @@ jobs:
         E2E_SEED_LOCAL: ${{ secrets.E2E_SEED_LOCAL }}
       run: |
         if [ -z "$E2E_SEED_LOCAL" ]; then
-          echo "::warning::E2E_SEED_LOCAL secret is not set; Stripe-dependent tests will fail. Add it under repo Settings → Secrets → Actions."
-        else
-          printf '%s' "$E2E_SEED_LOCAL" > apps/api/prisma/seeds/seed.local.ts
-          echo "Wrote apps/api/prisma/seeds/seed.local.ts ($(wc -c < apps/api/prisma/seeds/seed.local.ts) bytes)"
+          echo "::error::E2E_SEED_LOCAL secret is not set. Stripe-dependent tests would fail with confusing timeouts on the disabled 'Complete Registration' button. Add the secret under repo Settings → Secrets and variables → Actions (use the apps/api/prisma/seeds/seed.local.template.ts as a starting point, with Stripe TEST keys: pk_test_* / sk_test_*)."
+          exit 1
         fi
+        printf '%s' "$E2E_SEED_LOCAL" > apps/api/prisma/seeds/seed.local.ts
+        echo "Wrote apps/api/prisma/seeds/seed.local.ts ($(wc -c < apps/api/prisma/seeds/seed.local.ts) bytes)"
 
     - name: Setup database (migrate + base seed + e2e personas + local creds)
       run: |
@@ -165,6 +165,10 @@ jobs:
         else
           npx --yes playwright test
         fi
+
+    - name: Publish Playwright summary to job summary
+      if: always()
+      run: node scripts/playwright-summary.mjs playwright-report/results.json
 
     - name: Upload Playwright Report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-slash-command.yml
+++ b/.github/workflows/e2e-slash-command.yml
@@ -89,11 +89,15 @@ jobs:
       - name: Dispatch e2e-ci.yml
         if: steps.parse.outputs.matched == 'true'
         uses: actions/github-script@v7
+        env:
+          PR_HEAD_REF: ${{ steps.parse.outputs.ref }}
+          PR_HEAD_SHA: ${{ steps.parse.outputs.sha }}
+          PR_TAGS: ${{ steps.parse.outputs.tags }}
         with:
           script: |
-            const ref = '${{ steps.parse.outputs.ref }}';
-            const sha = '${{ steps.parse.outputs.sha }}';
-            const tags = '${{ steps.parse.outputs.tags }}';
+            const ref = process.env.PR_HEAD_REF;
+            const sha = process.env.PR_HEAD_SHA;
+            const tags = process.env.PR_TAGS;
             core.info(`Dispatching e2e-ci.yml on ref=${ref} sha=${sha} tags="${tags}"`);
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,

--- a/.github/workflows/e2e-slash-command.yml
+++ b/.github/workflows/e2e-slash-command.yml
@@ -1,0 +1,77 @@
+name: E2E Slash Command
+
+# Listens for `/run-e2e` comments on PRs and dispatches the E2E Tests workflow
+# against the PR's head branch. The dispatched run posts results back as a
+# sticky PR comment and as a check run on the PR head commit (see e2e-ci.yml).
+#
+# Usage examples in a PR comment:
+#   /run-e2e
+#   /run-e2e @smoke|@auth   (passed as the --grep filter)
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  actions: write          # dispatch e2e-ci.yml
+  pull-requests: write    # add reaction to triggering comment
+
+jobs:
+  dispatch:
+    # Only fire for PR comments that start with /run-e2e, and only from
+    # trusted authors. Random read-only users must not be able to burn CI.
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/run-e2e') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    steps:
+      - name: React to triggering comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Fetch PR head info and dispatch workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            // Anything on the comment line after `/run-e2e` becomes the --grep filter.
+            const body = (context.payload.comment.body || '').trim();
+            const match = body.match(/^\/run-e2e\s*(.*)$/);
+            const tags = (match && match[1] ? match[1] : '').trim();
+
+            core.info(`Dispatching e2e-ci.yml on ref=${pr.head.ref} sha=${pr.head.sha} tags="${tags}"`);
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'e2e-ci.yml',
+              ref: pr.head.ref,
+              inputs: {
+                tags,
+                pr_number: String(context.issue.number),
+                head_sha: pr.head.sha,
+              },
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `E2E workflow dispatched against \`${pr.head.ref}\`${tags ? ` with grep \`${tags}\`` : ''}. The "E2E Tests" check will appear on this PR shortly. [View Actions](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/e2e-ci.yml).`,
+            });

--- a/.github/workflows/e2e-slash-command.yml
+++ b/.github/workflows/e2e-slash-command.yml
@@ -23,13 +23,59 @@ jobs:
     # trusted authors. Random read-only users must not be able to burn CI.
     if: >-
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/run-e2e') &&
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     steps:
+      - name: Parse command and validate PR
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Parse ONLY the first line of the comment. Require `/run-e2e` at
+            // the very start, followed by end-of-line or whitespace. This
+            // rejects things like "/run-e2evil" or "please /run-e2e" while
+            // still allowing trailing tag args.
+            const body = context.payload.comment.body || '';
+            const firstLine = body.split(/\r?\n/, 1)[0].trim();
+            const match = firstLine.match(/^\/run-e2e(?:\s+(.*))?$/);
+            if (!match) {
+              core.info(`Comment did not match /run-e2e on first line: ${JSON.stringify(firstLine)}`);
+              core.setOutput('matched', 'false');
+              return;
+            }
+            const tags = (match[1] || '').trim();
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            // Reject fork PRs. workflow_dispatch can't target a ref that
+            // doesn't live in the base repo, and we don't want to run
+            // privileged secrets-bearing CI against fork-owned code anyway.
+            const baseRepo = `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
+            const headRepo = (pr.head.repo?.full_name || '').toLowerCase();
+            if (headRepo !== baseRepo) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `❌ \`/run-e2e\` is only supported for PRs from branches in this repo (got head repo \`${pr.head.repo?.full_name || 'unknown'}\`). For fork PRs, push the branch to this repo or run the workflow manually via Actions → "E2E Tests".`,
+              });
+              core.setOutput('matched', 'false');
+              return;
+            }
+
+            core.setOutput('matched', 'true');
+            core.setOutput('ref', pr.head.ref);
+            core.setOutput('sha', pr.head.sha);
+            core.setOutput('tags', tags);
+
       - name: React to triggering comment
+        if: steps.parse.outputs.matched == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -40,38 +86,23 @@ jobs:
               content: 'eyes',
             });
 
-      - name: Fetch PR head info and dispatch workflow
+      - name: Dispatch e2e-ci.yml
+        if: steps.parse.outputs.matched == 'true'
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
-
-            // Anything on the comment line after `/run-e2e` becomes the --grep filter.
-            const body = (context.payload.comment.body || '').trim();
-            const match = body.match(/^\/run-e2e\s*(.*)$/);
-            const tags = (match && match[1] ? match[1] : '').trim();
-
-            core.info(`Dispatching e2e-ci.yml on ref=${pr.head.ref} sha=${pr.head.sha} tags="${tags}"`);
-
+            const ref = '${{ steps.parse.outputs.ref }}';
+            const sha = '${{ steps.parse.outputs.sha }}';
+            const tags = '${{ steps.parse.outputs.tags }}';
+            core.info(`Dispatching e2e-ci.yml on ref=${ref} sha=${sha} tags="${tags}"`);
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'e2e-ci.yml',
-              ref: pr.head.ref,
+              ref,
               inputs: {
                 tags,
                 pr_number: String(context.issue.number),
-                head_sha: pr.head.sha,
+                head_sha: sha,
               },
-            });
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `E2E workflow dispatched against \`${pr.head.ref}\`${tags ? ` with grep \`${tags}\`` : ''}. The "E2E Tests" check will appear on this PR shortly. [View Actions](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/e2e-ci.yml).`,
             });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,13 @@ export default defineConfig({
   /* Tests are namespaced per-run, so two workers are safe in CI. */
   workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [['html'], ['github']] : 'html',
+  reporter: process.env.CI
+    ? [
+        ['html'],
+        ['github'],
+        ['json', { outputFile: 'playwright-report/results.json' }],
+      ]
+    : 'html',
   /* Tag-driven filter: `E2E_TAGS=@auth npm run test:e2e` */
   grep: TAGS ? new RegExp(TAGS) : undefined,
   /* Global timeout for each test */

--- a/scripts/playwright-summary.mjs
+++ b/scripts/playwright-summary.mjs
@@ -1,23 +1,22 @@
 #!/usr/bin/env node
 /**
- * Read the Playwright JSON report and write a Markdown summary to
- * $GITHUB_STEP_SUMMARY (or stdout when run locally).
+ * Read the Playwright JSON report and print a Markdown summary to stdout.
  *
  * Usage:
  *   node scripts/playwright-summary.mjs [path/to/results.json]
  *
  * Defaults to playwright-report/results.json. Exits 0 even when tests
- * failed — the summary step should not mask the test step's exit code.
+ * failed — callers append the output to $GITHUB_STEP_SUMMARY and/or use
+ * it as a PR comment body; they should not depend on this exit code.
  */
-import { readFileSync, appendFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 
 const reportPath = process.argv[2] ?? 'playwright-report/results.json';
-const outPath = process.env.GITHUB_STEP_SUMMARY;
 
 if (!existsSync(reportPath)) {
-  const msg = `No Playwright JSON report at ${reportPath}; skipping summary.`;
-  console.warn(msg);
-  if (outPath) appendFileSync(outPath, `### Playwright\n\n${msg}\n`);
+  process.stdout.write(
+    `### Playwright\n\n_No Playwright JSON report at \`${reportPath}\`; the test step likely failed before producing one._\n`,
+  );
   process.exit(0);
 }
 
@@ -87,14 +86,6 @@ if (allPassed && totals.flaky === 0) {
   lines.push('_All tests passed._');
   lines.push('');
 }
-lines.push(
-  '_Full HTML report is uploaded as the `playwright-report` artifact._',
-);
+lines.push('_Full HTML report is uploaded as the `playwright-report` artifact._');
 
-const md = lines.join('\n') + '\n';
-if (outPath) {
-  appendFileSync(outPath, md);
-  console.log(`Wrote Playwright summary (${md.length} bytes) to $GITHUB_STEP_SUMMARY`);
-} else {
-  process.stdout.write(md);
-}
+process.stdout.write(lines.join('\n') + '\n');

--- a/scripts/playwright-summary.mjs
+++ b/scripts/playwright-summary.mjs
@@ -20,7 +20,15 @@ if (!existsSync(reportPath)) {
   process.exit(0);
 }
 
-const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+let report;
+try {
+  report = JSON.parse(readFileSync(reportPath, 'utf8'));
+} catch (err) {
+  process.stdout.write(
+    `### Playwright\n\n_Failed to parse Playwright JSON report at \`${reportPath}\`: ${err.message}_\n`,
+  );
+  process.exit(0);
+}
 const stats = report.stats ?? {};
 const durationSec = Math.round(((stats.duration ?? 0) / 1000) * 10) / 10;
 

--- a/scripts/playwright-summary.mjs
+++ b/scripts/playwright-summary.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Read the Playwright JSON report and write a Markdown summary to
+ * $GITHUB_STEP_SUMMARY (or stdout when run locally).
+ *
+ * Usage:
+ *   node scripts/playwright-summary.mjs [path/to/results.json]
+ *
+ * Defaults to playwright-report/results.json. Exits 0 even when tests
+ * failed — the summary step should not mask the test step's exit code.
+ */
+import { readFileSync, appendFileSync, existsSync } from 'node:fs';
+
+const reportPath = process.argv[2] ?? 'playwright-report/results.json';
+const outPath = process.env.GITHUB_STEP_SUMMARY;
+
+if (!existsSync(reportPath)) {
+  const msg = `No Playwright JSON report at ${reportPath}; skipping summary.`;
+  console.warn(msg);
+  if (outPath) appendFileSync(outPath, `### Playwright\n\n${msg}\n`);
+  process.exit(0);
+}
+
+const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+const stats = report.stats ?? {};
+const durationSec = Math.round(((stats.duration ?? 0) / 1000) * 10) / 10;
+
+const failures = [];
+const flaky = [];
+
+const walkSuite = (suite, trail = []) => {
+  const title = suite.title ? [...trail, suite.title] : trail;
+  for (const spec of suite.specs ?? []) {
+    for (const test of spec.tests ?? []) {
+      const status = test.status; // 'expected' | 'unexpected' | 'flaky' | 'skipped'
+      if (status === 'unexpected' || status === 'flaky') {
+        const file = spec.file ?? suite.file ?? '';
+        const line = spec.line ?? '';
+        const fullTitle = [...title, spec.title].filter(Boolean).join(' › ');
+        const lastResult = test.results?.[test.results.length - 1];
+        const failingResult = test.results?.find((r) => (r.errors?.length ?? 0) > 0 || r.error) ?? lastResult;
+        const firstError = failingResult?.errors?.[0]?.message ?? failingResult?.error?.message ?? '';
+        const oneLine = firstError.split('\n')[0].slice(0, 240);
+        const entry = { file, line, fullTitle, oneLine, retries: test.results?.length ?? 0 };
+        (status === 'flaky' ? flaky : failures).push(entry);
+      }
+    }
+  }
+  for (const child of suite.suites ?? []) walkSuite(child, title);
+};
+for (const suite of report.suites ?? []) walkSuite(suite);
+
+const totals = {
+  expected: stats.expected ?? 0,
+  unexpected: stats.unexpected ?? 0,
+  flaky: stats.flaky ?? 0,
+  skipped: stats.skipped ?? 0,
+};
+const allPassed = totals.unexpected === 0;
+const emoji = allPassed ? (totals.flaky ? '⚠️' : '✅') : '❌';
+
+const lines = [];
+lines.push(`## ${emoji} Playwright E2E results`);
+lines.push('');
+lines.push('| Passed | Failed | Flaky | Skipped | Duration |');
+lines.push('| ---: | ---: | ---: | ---: | ---: |');
+lines.push(
+  `| ${totals.expected} | ${totals.unexpected} | ${totals.flaky} | ${totals.skipped} | ${durationSec}s |`,
+);
+lines.push('');
+
+const renderList = (label, items) => {
+  if (items.length === 0) return;
+  lines.push(`### ${label} (${items.length})`);
+  lines.push('');
+  for (const f of items) {
+    const loc = f.file ? ` — \`${f.file}${f.line ? `:${f.line}` : ''}\`` : '';
+    lines.push(`- **${f.fullTitle}**${loc}`);
+    if (f.oneLine) lines.push(`  - \`${f.oneLine.replace(/`/g, "'")}\``);
+  }
+  lines.push('');
+};
+renderList('Failures', failures);
+renderList('Flaky', flaky);
+
+if (allPassed && totals.flaky === 0) {
+  lines.push('_All tests passed._');
+  lines.push('');
+}
+lines.push(
+  '_Full HTML report is uploaded as the `playwright-report` artifact._',
+);
+
+const md = lines.join('\n') + '\n';
+if (outPath) {
+  appendFileSync(outPath, md);
+  console.log(`Wrote Playwright summary (${md.length} bytes) to $GITHUB_STEP_SUMMARY`);
+} else {
+  process.stdout.write(md);
+}


### PR DESCRIPTION
## Summary

E2E CI hardening + a `/run-e2e` PR slash-command. Originally motivated by [run 25951674204](https://github.com/ChrisRomp/playa-plan/actions/runs/25951674204) failing with cryptic timeouts on the disabled "Complete Registration" button — the underlying cause was a missing `E2E_SEED_LOCAL` secret, but the workflow logged only a warning and ran for ~25 min before failing. This PR makes that class of failure obvious and fast, and adds a way to run E2E on-demand against a PR.

## What changed

### Fail fast on missing secret (`.github/workflows/e2e-ci.yml`)
- `Validate E2E_SEED_LOCAL secret and stage seed.local.ts` now runs **immediately after checkout**, before any installs. Missing secret → `exit 1` with an actionable `::error::` message instead of a `::warning::` followed by 25 min of mysterious Playwright timeouts.
- Removed `actions: write` (workflow doesn't dispatch anything).
- Added `concurrency:` group keyed per-PR (or per-ref for manual dispatch) with `cancel-in-progress: true` so superseded runs stop wasting compute.

### Playwright results in the job summary
- `playwright.config.ts` now emits a JSON report on CI.
- New `scripts/playwright-summary.mjs` parses it into Markdown (passed/failed/flaky/skipped counts, per-failure file:line + first error line truncated to 240 chars).
- Workflow generates summary once and appends it to `$GITHUB_STEP_SUMMARY`. No more "download the artifact and open index.html" round-trip just to see what failed.

### `/run-e2e` slash command (`.github/workflows/e2e-slash-command.yml`)
- New workflow listens for `issue_comment` and dispatches `e2e-ci.yml` against the PR's head branch.
- Gated by `author_association in {OWNER, MEMBER, COLLABORATOR}` so drive-by commenters can't burn CI.
- Strict parser: matches `/run-e2e` on the **first line only**, with optional trailing args used as `--grep` filter. Rejects `/run-e2evil`, `please /run-e2e`, etc.
- Rejects fork PRs explicitly — `workflow_dispatch` can't target external refs anyway, and we don't want secret-bearing CI running against fork-owned code.
- 👀 reaction on the triggering comment as acknowledgement.

### PR check + sticky comment (when triggered via slash command)
- New `pr_number` and `head_sha` inputs on `e2e-ci.yml`.
- When set, the workflow:
  1. Creates an in-progress `E2E Tests` Check Run on the PR head SHA (early — gives immediate feedback that the request was accepted).
  2. After tests, posts the Markdown summary as a **sticky** PR comment (marker `<!-- e2e-ci-summary -->`). Comment lookup paginates and filters to `github-actions[bot]` so it can't hijack human comments; any duplicates are cleaned up.
  3. Updates the Check Run to `success` / `failure` / `cancelled` with the summary in `output.summary` (truncated to 60 000 chars defensively; API limit is 65 535). This step runs **last** so its conclusion reflects every preceding step (uploads, log capture, cleanup).
- Comment-write step is robust to a missing/unreadable summary file (try/catch with fallback message).
- Manual dispatch via the Actions UI still works as before — without `pr_number`/`head_sha`, no comment or check is posted, just the job summary.

## How to use

**Manual:** Actions → "E2E Tests" → "Run workflow". `tags` is optional Playwright `--grep` filter. Leave `pr_number`/`head_sha` empty.

**Per-PR (after merge):** Comment `/run-e2e` on any PR. Optional grep: `/run-e2e @smoke|@auth`. An "E2E Tests" check appears within seconds; a sticky comment lands when the run finishes.

> Note: The `issue_comment` trigger only takes effect after these workflow files land on `main` (workflows run from the default branch for that event).

## Tested

- `playwright-summary.mjs` smoke-tested with: missing report, valid report (all pass), malformed JSON. All three produce sensible Markdown without throwing.
- Workflow YAML validated.
- The fail-fast change was de-risked end-to-end by setting the secret and re-running the original failing run — it now passes 65/1/0 in ~1.3 min.

## Follow-up bug filed separately

The one `test.fixme` (`tests/registration/register-deferred.spec.ts:31`) is an intentional documented bug, not flake: `AuthContext.completeLogin` drops `allowDeferredDuesPayment` from the client `user` object. Tracked in #154.

## Rubber-duck review

Plan + implementation were both critiqued before push; findings applied in commit `e87883c`.
