### PR TITLE
fix(web): propagate per-user flags from API profile to client user (#154)

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -331,6 +331,12 @@ export const CampingOptionSchema = z.object({
 
 // API Types
 export type User = z.infer<typeof UserSchema>;
+/**
+ * Backend user profile shape returned from `/auth/profile`. Alias for the
+ * Zod-parsed `User` schema to make import sites read more clearly when the
+ * client also has its own `User` type (apps/web/src/types/index.ts).
+ */
+export type UserProfile = User;
 export type AuthResponse = z.infer<typeof AuthResponseSchema>;
 export type CoreConfig = z.infer<typeof CoreConfigSchema>;
 export type CampingOption = z.infer<typeof CampingOptionSchema>;

--- a/apps/web/src/store/AuthContext.tsx
+++ b/apps/web/src/store/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, ReactNode } from 'react';
 import { User } from '../types';
-import { auth, clearJwtToken, JWT_TOKEN_STORAGE_KEY, type AuthResponse } from '../lib/api';
+import { auth, clearJwtToken, JWT_TOKEN_STORAGE_KEY, type UserProfile } from '../lib/api';
 import { passkeysApi, isPasskeySupported } from '../lib/api/passkeys';
 import { startAuthentication } from '@simplewebauthn/browser';
 import cookieService from '../lib/cookieService';
@@ -18,7 +18,52 @@ const isPasskeyCancellation = (err: unknown): boolean => {
   return e.name === 'NotAllowedError' || e.code === 'ERROR_CEREMONY_ABORTED';
 };
 
-
+/**
+ * Build the client-side `User` from a parsed API user profile.
+ *
+ * Spreads the backend profile through to the store and overlays only the
+ * derived/client-shaped fields below. Compared with the pre-#154 hand-rolled
+ * whitelist, this collapses the field list to a single source of truth —
+ * `UserSchema` in `apps/web/src/lib/api.ts` — so adding a new safe profile
+ * field is a one-place change rather than two.
+ *
+ * Note: Zod's default object parsing strips unknown keys, so this is NOT a
+ * blanket pass-through. A new backend field still needs to be added to
+ * `UserSchema` to reach the client; that is deliberate.
+ *
+ * Overlaid fields:
+ *
+ * - `name`                       — composed from firstName + lastName.
+ * - `role`                       — mapped from the backend's uppercase enum
+ *                                  (`ADMIN`/`STAFF`/`PARTICIPANT`) to the
+ *                                  client's lowercase enum.
+ * - `isAuthenticated`            — always true at this point in the flow.
+ * - `isEarlyRegistrationEnabled` — backward-compatible alias of
+ *                                  `allowEarlyRegistration`. The raw flag is
+ *                                  also surfaced by the spread above.
+ * - `hasRegisteredForCurrentYear`— placeholder; would come from registration
+ *                                  data fetched elsewhere.
+ *
+ * Excluded fields:
+ *
+ * - `internalNotes` — admin-only field about the user. Even though the
+ *                    `/auth/profile` endpoint returns it for the user
+ *                    themselves, it has no current-user use case on the
+ *                    client and should not become part of global auth state.
+ */
+const buildClientUser = (userProfile: UserProfile): User => {
+  // Intentionally drop internalNotes — see docstring above.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { internalNotes, ...safe } = userProfile;
+  return {
+    ...safe,
+    name: `${userProfile.firstName} ${userProfile.lastName}`,
+    role: mapApiRoleToClientRole(userProfile.role),
+    isAuthenticated: true,
+    isEarlyRegistrationEnabled: userProfile.allowEarlyRegistration || false,
+    hasRegisteredForCurrentYear: false,
+  };
+};
 
 /**
  * AuthProvider component that manages authentication state
@@ -87,15 +132,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             const userProfile = await auth.getProfile();
             
             // Transform API user data to our client User type
-            setUser({
-              id: userProfile.id,
-              name: `${userProfile.firstName} ${userProfile.lastName}`,
-              email: userProfile.email,
-              role: mapApiRoleToClientRole(userProfile.role),
-              isAuthenticated: true,
-              isEarlyRegistrationEnabled: userProfile.allowEarlyRegistration || false,
-              hasRegisteredForCurrentYear: false // This would come from registration data
-            });
+            setUser(buildClientUser(userProfile));
             
             // Set the client-side auth state cookie for UI state
             await cookieService.setAuthenticatedState();
@@ -156,19 +193,11 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
    * profile-fetch failure the partial auth artifacts can be rolled
    * back before flipping isAuthenticated/user state.
    */
-  const completeLogin = async (authResponse: AuthResponse): Promise<void> => {
+  const completeLogin = async (): Promise<void> => {
     try {
       await cookieService.setAuthenticatedState();
       const userProfile = await auth.getProfile();
-      setUser({
-        id: authResponse.userId,
-        email: authResponse.email,
-        name: `${authResponse.firstName} ${authResponse.lastName}`,
-        role: mapApiRoleToClientRole(authResponse.role),
-        isAuthenticated: true,
-        isEarlyRegistrationEnabled: userProfile.allowEarlyRegistration || false,
-        hasRegisteredForCurrentYear: false,
-      });
+      setUser(buildClientUser(userProfile));
       setIsAuthenticated(true);
       localStorage.removeItem('pendingLoginEmail');
     } catch (err) {
@@ -189,8 +218,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     setError(null);
     setIsLoading(true);
     try {
-      const authResponse = await auth.verifyCode(email, code);
-      await completeLogin(authResponse);
+      await auth.verifyCode(email, code);
+      await completeLogin();
     } catch (err) {
       const errorMessage = err instanceof Error
         ? err.message
@@ -228,8 +257,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         typeof startAuthentication
       >[0]['optionsJSON'];
       const assertion = await startAuthentication({ optionsJSON });
-      const authResponse = await passkeysApi.authenticationVerify(assertion);
-      await completeLogin(authResponse);
+      await passkeysApi.authenticationVerify(assertion);
+      await completeLogin();
     } catch (err) {
       if (isPasskeyCancellation(err)) {
         // Don't surface cancellations to the UI.

--- a/apps/web/src/store/__tests__/AuthContext.test.tsx
+++ b/apps/web/src/store/__tests__/AuthContext.test.tsx
@@ -417,4 +417,116 @@ describe('AuthContext', () => {
       expect(screen.getByTestId('user').textContent).toBe('no user');
     });
   });
+
+  /**
+   * Regression coverage for issue #154: the client user object must surface
+   * per-user permission flags from the API profile so registration and other
+   * flows can gate on them. Before the fix, AuthContext hand-rolled the user
+   * object and dropped these fields, so e.g. `user.allowDeferredDuesPayment`
+   * was always undefined and the "Pay Dues Later" path was unreachable.
+   *
+   * Both authentication entry points must propagate the flags:
+   *   - bootstrap (`checkAuthStatus` runs on mount when a JWT is present)
+   *   - login completion (`completeLogin`, used by `verifyCode` and passkey)
+   */
+  describe('per-user permission flags from API profile (issue #154)', () => {
+    const profileWithFlags = {
+      id: 'user-123',
+      email: 'test@example.playaplan.app',
+      firstName: 'Test',
+      lastName: 'User',
+      playaName: null,
+      profilePicture: null,
+      role: 'PARTICIPANT',
+      isEmailVerified: true,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      phone: null,
+      city: null,
+      stateProvince: null,
+      country: null,
+      emergencyContact: null,
+      allowRegistration: true,
+      allowEarlyRegistration: true,
+      allowDeferredDuesPayment: true,
+      allowNoJob: true,
+      // Admin-only — must NOT be spread onto the client auth user.
+      internalNotes: 'admin-only note about this user',
+    };
+
+    it('should surface allowDeferredDuesPayment and other flags on bootstrap when a JWT is present', async () => {
+      const cookieService = (await import('../../lib/cookieService')).default;
+      (localStorage.getItem as Mock).mockReturnValue('mock-jwt-token');
+      (cookieService.isAuthenticated as Mock).mockReturnValue(false);
+      (authApi.checkAuth as Mock).mockResolvedValue(true);
+      (authApi.getProfile as Mock).mockResolvedValue(profileWithFlags);
+
+      await act(async () => {
+        render(
+          <AuthProvider>
+            <TestComponent />
+          </AuthProvider>
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('authenticated').textContent).toBe('true');
+      });
+
+      const userJson = screen.getByTestId('user').textContent ?? '';
+      const actualUser = JSON.parse(userJson);
+      expect(actualUser.allowDeferredDuesPayment).toBe(true);
+      expect(actualUser.allowEarlyRegistration).toBe(true);
+      expect(actualUser.allowRegistration).toBe(true);
+      expect(actualUser.allowNoJob).toBe(true);
+      // Derived alias must still be present for back-compat with existing consumers.
+      expect(actualUser.isEarlyRegistrationEnabled).toBe(true);
+      // Role must be mapped to the lowercase client enum, not the raw API value.
+      expect(actualUser.role).toBe('user');
+      // internalNotes is admin-only and must not bleed into the auth user.
+      expect(actualUser).not.toHaveProperty('internalNotes');
+    });
+
+    it('should surface allowDeferredDuesPayment and other flags after verifyCode → completeLogin', async () => {
+      (authApi.verifyCode as Mock).mockResolvedValue({
+        userId: 'user-123',
+        email: 'test@example.playaplan.app',
+        firstName: 'Test',
+        lastName: 'User',
+        role: 'PARTICIPANT',
+        accessToken: 'mock-token',
+      });
+      (authApi.getProfile as Mock).mockResolvedValue(profileWithFlags);
+
+      await act(async () => {
+        render(
+          <AuthProvider>
+            <TestComponent />
+          </AuthProvider>
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading').textContent).toBe('false');
+      });
+
+      await act(async () => {
+        screen.getByTestId('verify-code-btn').click();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('authenticated').textContent).toBe('true');
+      });
+
+      const userJson = screen.getByTestId('user').textContent ?? '';
+      const actualUser = JSON.parse(userJson);
+      expect(actualUser.allowDeferredDuesPayment).toBe(true);
+      expect(actualUser.allowEarlyRegistration).toBe(true);
+      expect(actualUser.allowRegistration).toBe(true);
+      expect(actualUser.allowNoJob).toBe(true);
+      expect(actualUser.isEarlyRegistrationEnabled).toBe(true);
+      expect(actualUser.role).toBe('user');
+      expect(actualUser).not.toHaveProperty('internalNotes');
+    });
+  });
 });

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -8,8 +8,37 @@ export interface User {
   isAuthenticated: boolean;
   isEarlyRegistrationEnabled: boolean;
   hasRegisteredForCurrentYear: boolean;
+
+  /**
+   * Raw per-user permission flags, surfaced from the backend user profile
+   * via AuthContext. These are optional so existing test fixtures that
+   * construct a minimal User stay valid.
+   *
+   * Note: `isEarlyRegistrationEnabled` above is a derived alias of
+   * `allowEarlyRegistration` retained for backward compatibility with
+   * existing consumers.
+   */
+  allowRegistration?: boolean;
+  allowEarlyRegistration?: boolean;
   allowDeferredDuesPayment?: boolean;
-  
+  allowNoJob?: boolean;
+
+  /**
+   * Whether the user has verified their email address.
+   */
+  isEmailVerified?: boolean;
+
+  /**
+   * URL to the user's profile picture.
+   */
+  profilePicture?: string | null;
+
+  /**
+   * ISO timestamps from the backend user record.
+   */
+  createdAt?: string;
+  updatedAt?: string;
+
   /**
    * The user's first name, as provided in the backend user profile.
    */
@@ -23,32 +52,32 @@ export interface User {
   /**
    * The user's "playa name" (nickname or alias), as provided in the backend user profile.
    */
-  playaName?: string;
+  playaName?: string | null;
   
   /**
    * The user's phone number, as provided in the backend user profile.
    */
-  phone?: string;
+  phone?: string | null;
   
   /**
    * The city where the user resides, as provided in the backend user profile.
    */
-  city?: string;
+  city?: string | null;
   
   /**
    * The state or province where the user resides, as provided in the backend user profile.
    */
-  stateProvince?: string;
+  stateProvince?: string | null;
   
   /**
    * The country where the user resides, as provided in the backend user profile.
    */
-  country?: string;
+  country?: string | null;
   
   /**
    * The user's emergency contact information, as provided in the backend user profile.
    */
-  emergencyContact?: string;
+  emergencyContact?: string | null;
 }
 
 export interface CampConfig {

--- a/tests/helpers/registration.ts
+++ b/tests/helpers/registration.ts
@@ -4,9 +4,11 @@ import { waitForRegistrationProfileHydrated } from './hydration';
 
 /**
  * Walk a logged-in participant through the full multi-step registration flow up to
- * the Payment step. Stops at "Complete Registration" — the caller is responsible
- * for clicking that button (or calling `payViaStripeCheckout` from stripe.ts) so
- * different specs can compose payment vs. deferred vs. failure paths.
+ * the Payment step. Stops on the Payment step's CTA — which may be either
+ * "Complete Registration" (paid path) or "Pay Dues Later" (deferred path).
+ * Callers are responsible for asserting which CTA they expected and clicking
+ * it (or invoking `payViaStripeCheckout` from stripe.ts) so different specs
+ * can compose payment vs. deferred vs. failure paths.
  *
  * Assumes the seed.ts fixture (Skydiving camping option, 4 work-shift categories,
  * and Teardown as the always-required category). Picks shifts by capacity rather
@@ -89,9 +91,15 @@ export async function walkRegistrationToPayment(
   await page.getByRole('checkbox', { name: /i accept the terms/i }).check();
   await page.getByRole('button', { name: /Review & Pay|Submit/ }).click();
 
-  // Step 6 — Payment.
+  // Step 6 — Payment. The page renders either a "Complete Registration"
+  // payment button (Stripe / PayPal path) or a "Pay Dues Later" button
+  // (deferred path, when both config and user flags allow). Match either so
+  // both payment and deferred specs can share this helper; the caller
+  // asserts which one it actually expected.
   await expect(page.getByRole('heading', { name: 'Payment' })).toBeVisible({ timeout: 10_000 });
-  await expect(page.getByRole('button', { name: /Complete Registration/ })).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /Complete Registration|Pay Dues Later/ }),
+  ).toBeVisible();
 }
 
 /**

--- a/tests/registration/register-deferred.spec.ts
+++ b/tests/registration/register-deferred.spec.ts
@@ -3,20 +3,14 @@
  *  - End-to-end deferred-dues path: a participant with allowDeferredDuesPayment
  *    set both at config and user level should see "Pay Dues Later" instead of
  *    Stripe Checkout, complete registration without paying, and land on the
- *    dashboard with a CONFIRMED registration and no completed payment.
+ *    dashboard with a PENDING registration and no completed payment.
  *
- * KNOWN APP BUG (skipped, not deleted): apps/web/src/store/AuthContext.tsx
- * builds the in-app `user` object as `{id, name, email, role,
- * isAuthenticated}` and drops `allowDeferredDuesPayment` (and the other
- * per-user flags) when it stores the auth response. The registration page's
- * deferred-path check is `config?.allowDeferredDuesPayment &&
- * user?.allowDeferredDuesPayment`, so the user-side condition is *always*
- * false and the deferred path is unreachable through the real UI even when
- * the database says the user is allowed.
- *
- * Until the app exposes the per-user flag on the client `user` object, this
- * spec is a `test.fixme` documenting the bug — kept in source so it lights
- * up green automatically the moment the bug is fixed.
+ * Note on status: the registration is created by `createCampRegistration`
+ * which calls `create()` with the user's chosen jobs. That sets the row to
+ * PENDING (or WAITLISTED if a chosen job is full); the only path that today
+ * transitions a registration to CONFIRMED is a successful payment in
+ * `payments.service.ts`. Server-side promotion of deferred registrations is
+ * tracked as a separate follow-up to issue #154.
  */
 import { test, expect } from '../helpers/fixtures';
 import { walkRegistrationToPayment } from '../helpers/registration';
@@ -28,7 +22,7 @@ test.describe(
   () => {
     test.use({ storageState: { cookies: [], origins: [] } });
 
-    test.fixme(
+    test(
       'deferred-payment participant completes registration without paying',
       async ({ page, freshDeferredParticipant }) => {
         test.setTimeout(60_000);
@@ -50,7 +44,7 @@ test.describe(
           orderBy: { createdAt: 'desc' },
         });
         expect(reg).not.toBeNull();
-        expect(reg!.status).toBe('CONFIRMED');
+        expect(reg!.status).toBe('PENDING');
         expect(reg!.year).toBe(new Date().getFullYear());
         expect(reg!.jobs.length).toBeGreaterThanOrEqual(2);
         const completed = reg!.payments.filter((p) => p.status === 'COMPLETED');


### PR DESCRIPTION
## Summary

Fix `AuthContext` so per-user permission flags (notably `allowDeferredDuesPayment`) actually reach the client `user` object, unblocking the "Pay Dues Later" registration path for eligible users.

### What it does

- Replaces the hand-rolled field whitelists in `checkAuthStatus` and `completeLogin` with a single `buildClientUser(userProfile)` helper that spreads the parsed API profile and overlays only the derived/client-shaped fields (`name`, mapped `role`, `isAuthenticated`, back-compat `isEarlyRegistrationEnabled`, `hasRegisteredForCurrentYear`). Future safe profile fields now need only one whitelist update (`UserSchema`) instead of two.
- Destructures-and-discards `internalNotes` so the admin-only field never reaches client auth state, even though `/auth/profile` returns it for the user themselves.
- Drops the now-unused `authResponse` parameter from `completeLogin`. Both `auth.verifyCode` and `passkeysApi.authenticationVerify` already call `setJwtToken(parsed.accessToken)` as a side effect before returning, so the token is stored before `completeLogin` runs.
- Re-exports the Zod-parsed user type as `UserProfile` to disambiguate at import sites from the client `User` shape.
- Extends the client `User` type with the newly-surfaced optional fields (`allowRegistration`, `allowEarlyRegistration`, `allowNoJob`, `isEmailVerified`, `profilePicture`, `createdAt`, `updatedAt`) and widens the optional string fields from `string` to `string | null` to match the API's `.nullable().optional()` shape.
- Un-fixme's `tests/registration/register-deferred.spec.ts` and adjusts the post-defer status assertion from `CONFIRMED` to `PENDING` (today only a completed payment transitions a registration to `CONFIRMED`; server-side promotion of deferred registrations is a separate follow-up — see [#160](https://github.com/ChrisRomp/playa-plan/issues/160)).
- Relaxes `tests/helpers/registration.ts`'s final CTA assertion to match either "Complete Registration" or "Pay Dues Later" so the shared helper works for both paid and deferred specs; each caller asserts the specific CTA it expects.
- Adds AuthContext regression tests covering both the bootstrap (token-in-storage) path and the `verifyCode → completeLogin` path. Both assert the four per-user flags propagate, the derived `isEarlyRegistrationEnabled` alias is set, `role` is mapped to the lowercase client enum, and `internalNotes` is NOT present on the auth user.

### Key changes

- `apps/web/src/store/AuthContext.tsx`: introduce `buildClientUser`, use it in both `setUser` sites, drop the `authResponse` parameter from `completeLogin`.
- `apps/web/src/lib/api.ts`: re-export `UserProfile = User`.
- `apps/web/src/types/index.ts`: extend `User` with optional API fields; widen nullable string fields.
- `apps/web/src/store/__tests__/AuthContext.test.tsx`: add regression coverage for both auth paths.
- `tests/registration/register-deferred.spec.ts`: un-`fixme`, assert `PENDING`.
- `tests/helpers/registration.ts`: accept either CTA on the Payment step.

### Security

- `internalNotes` (admin-only) is explicitly excluded from the spread to avoid bleeding admin context into global frontend auth state.
- Per-user permission flags are now correctly carried client-side, but those flags are still **not** enforced server-side on `POST /registrations/camp`. That gap is real but out of scope for this PR — filed as [#158](https://github.com/ChrisRomp/playa-plan/issues/158), [#159](https://github.com/ChrisRomp/playa-plan/issues/159), and [#160](https://github.com/ChrisRomp/playa-plan/issues/160).

### Verification

- `npm run lint` ✅
- `npm run build:api` ✅
- `npm run build:web` ✅
- `npm run test:api` ✅ 856 pass (no delta)
- `npm run test:web` ✅ 611 pass (+2 new regression tests)
- Two-reviewer (Opus + GPT-5.5) code review: no significant issues found.

Fixes [#154](https://github.com/ChrisRomp/playa-plan/issues/154)
