### PR TITLE
feat(registrations): enforce policy + add deferred-payment server semantics (#158, #159, #160)

### DIFF
--- a/apps/api/prisma/migrations/20260518023418_add_payment_deferred_to_registration/migration.sql
+++ b/apps/api/prisma/migrations/20260518023418_add_payment_deferred_to_registration/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "registrations" ADD COLUMN "paymentDeferred" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -173,15 +173,16 @@ model Shift {
 }
 
 model Registration {
-  id        String             @id @default(uuid())
-  status    RegistrationStatus @default(PENDING)
-  year      Int
-  createdAt DateTime           @default(now())
-  updatedAt DateTime           @updatedAt
-  userId    String
-  user      User               @relation(fields: [userId], references: [id])
-  jobs      RegistrationJob[]
-  payments  Payment[]
+  id              String             @id @default(uuid())
+  status          RegistrationStatus @default(PENDING)
+  paymentDeferred Boolean            @default(false)
+  year            Int
+  createdAt       DateTime           @default(now())
+  updatedAt       DateTime           @updatedAt
+  userId          String
+  user            User               @relation(fields: [userId], references: [id])
+  jobs            RegistrationJob[]
+  payments        Payment[]
 
   @@map("registrations")
 }

--- a/apps/api/src/notifications/services/notifications.service.ts
+++ b/apps/api/src/notifications/services/notifications.service.ts
@@ -54,6 +54,8 @@ export interface TemplateData {
     }>;
     totalCost?: number;
     currency?: string;
+    /** True when the participant opted to defer dues payment. */
+    paymentDeferred?: boolean;
   };
   errorDetails?: {
     error: string;
@@ -301,6 +303,14 @@ export class NotificationsService {
       }>;
       totalCost?: number;
       currency?: string;
+      /**
+       * Whether the participant has opted to defer dues payment. When true
+       * the registration was created CONFIRMED with no associated payment;
+       * the template should render a "Payment deferred — please complete
+       * payment later from your dashboard" line so the participant knows
+       * to circle back.
+       */
+      paymentDeferred?: boolean;
     },
     userId: string,
     userName?: string,
@@ -796,8 +806,9 @@ export class NotificationsService {
     }>;
     totalCost?: number;
     currency?: string;
+    paymentDeferred?: boolean;
   }, campName: string, data?: TemplateData): NotificationTemplate {
-    const { status, campingOptions, jobs, totalCost, currency } = registrationDetails;
+    const { status, campingOptions, jobs, totalCost, currency, paymentDeferred } = registrationDetails;
     const formattedDate = new Date().toLocaleDateString();
     const formattedAmount = totalCost ? new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(totalCost / 100) : 'N/A';
     
@@ -816,6 +827,9 @@ export class NotificationsService {
       : this.getRegistrationStatusMessage(status);
     
     const duesLine = isAdminModification ? '' : `Total Dues: ${formattedAmount}\n`;
+    const deferredLine = paymentDeferred
+      ? `Payment Deferred: Yes — please complete dues payment later from your dashboard.\n`
+      : '';
     
     const text = `${greeting}
       
@@ -823,7 +837,7 @@ ${statusMessage}
       
 Status: ${friendlyStatus}
 Date: ${formattedDate}
-${duesLine}      
+${duesLine}${deferredLine}      
 Selected Options:
 ${campingOptions ? campingOptions.map(option => `- ${option.name}`).join('\n') : 'N/A'}
       
@@ -836,6 +850,9 @@ Best regards,
 The ${campName} Team`;
 
     const duesHtml = isAdminModification ? '' : `<p><strong>Total Dues:</strong> ${formattedAmount}</p>`;
+    const deferredHtml = paymentDeferred
+      ? `<p style="color: #b45309;"><strong>Payment Deferred:</strong> Please complete dues payment later from your dashboard.</p>`
+      : '';
 
     const html = `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
@@ -848,6 +865,7 @@ The ${campName} Team`;
           <p><strong>Status:</strong> ${friendlyStatus}</p>
           <p><strong>Date:</strong> ${formattedDate}</p>
           ${duesHtml}
+          ${deferredHtml}
         </div>
         
         <div style="background-color: #f0f9ff; padding: 15px; border-radius: 5px; margin: 20px 0;">

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -79,6 +79,7 @@ const mockPaypalService = {
 
 const mockNotificationsService = {
   sendNotification: jest.fn().mockResolvedValue(undefined),
+  sendRegistrationConfirmationEmail: jest.fn().mockResolvedValue(true),
 };
 
 describe('PaymentsService', () => {
@@ -2081,7 +2082,334 @@ describe('PaymentsService', () => {
         expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
       });
     });
-  });
 
   // Additional tests would follow the same pattern for other methods
+
+  /**
+   * Coverage for the deferred-payment side effects introduced with
+   * issues #158/#159/#160:
+   *
+   *  - `verifyStripeSession` now clears `paymentDeferred` on the
+   *    registration when the payment completes, even if status was
+   *    already CONFIRMED (which is the deferred case).
+   *  - `recordManualPayment` now marks the registration CONFIRMED +
+   *    paymentDeferred=false when the manual payment lands COMPLETED.
+   */
+  describe('deferred-payment side effects', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('clears paymentDeferred when verifyStripeSession lands a paid session on a deferred registration', async () => {
+      // Deferred registration: CONFIRMED + paymentDeferred=true,
+      // payment row still PENDING (it was created when the user clicked
+      // Pay Now from the dashboard, then this verification runs after
+      // checkout success).
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+        id: 'payment-id',
+        status: PaymentStatus.PENDING,
+        providerRefId: 'cs_deferred_session',
+        userId: 'user-id',
+        registrationId: 'registration-id',
+        registration: {
+          id: 'registration-id',
+          status: 'CONFIRMED',
+          paymentDeferred: true,
+        },
+      });
+      mockStripeService.getCheckoutSession.mockResolvedValueOnce({
+        id: 'cs_deferred_session',
+        status: 'complete',
+        payment_status: 'paid',
+      });
+
+      await service.verifyStripeSession('cs_deferred_session');
+
+      // The transaction body issues two prisma update calls; assert the
+      // registration update sets both status and clears paymentDeferred.
+      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'registration-id' },
+          data: { status: 'CONFIRMED', paymentDeferred: false },
+        }),
+      );
+    });
+
+    it('skips the post-payment confirmation email when paying off a deferred registration (already emailed at creation)', async () => {
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+        id: 'payment-id',
+        status: PaymentStatus.PENDING,
+        providerRefId: 'cs_deferred_pay',
+        userId: 'user-id',
+        registrationId: 'registration-id',
+        registration: {
+          id: 'registration-id',
+          status: 'CONFIRMED',
+          paymentDeferred: true,
+        },
+      });
+      mockStripeService.getCheckoutSession.mockResolvedValueOnce({
+        id: 'cs_deferred_pay',
+        status: 'complete',
+        payment_status: 'paid',
+      });
+      mockPrismaService.payment.findUnique.mockResolvedValue({
+        id: 'payment-id',
+        status: PaymentStatus.COMPLETED,
+        registration: { id: 'registration-id' },
+      });
+
+      await service.verifyStripeSession('cs_deferred_pay');
+
+      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'registration-id' },
+          data: { status: 'CONFIRMED', paymentDeferred: false },
+        }),
+      );
+      expect(
+        mockNotificationsService.sendRegistrationConfirmationEmail,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('still clears paymentDeferred on retry when payment is already COMPLETED but registration is still flagged deferred', async () => {
+      // Edge case: previous run completed the payment update but the
+      // registration update failed and is being retried. Without the
+      // widened condition, this case would skip the update and leave
+      // paymentDeferred=true forever.
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+        id: 'payment-id',
+        status: PaymentStatus.COMPLETED,
+        providerRefId: 'cs_deferred_retry',
+        userId: 'user-id',
+        registrationId: 'registration-id',
+        registration: {
+          id: 'registration-id',
+          status: 'CONFIRMED',
+          paymentDeferred: true,
+        },
+      });
+      mockStripeService.getCheckoutSession.mockResolvedValueOnce({
+        id: 'cs_deferred_retry',
+        status: 'complete',
+        payment_status: 'paid',
+      });
+
+      await service.verifyStripeSession('cs_deferred_retry');
+
+      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'registration-id' },
+          data: { status: 'CONFIRMED', paymentDeferred: false },
+        }),
+      );
+    });
+
+    it('still clears paymentDeferred on retry when payment is already COMPLETED but registration is still flagged deferred', async () => {
+      // Edge case: previous run completed the payment update but the
+      // registration update failed and is being retried. Without the
+      // widened condition, this case would skip the update and leave
+      // paymentDeferred=true forever.
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+        id: 'payment-id',
+        status: PaymentStatus.COMPLETED,
+        providerRefId: 'cs_deferred_retry',
+        userId: 'user-id',
+        registrationId: 'registration-id',
+        registration: {
+          id: 'registration-id',
+          status: 'CONFIRMED',
+          paymentDeferred: true,
+        },
+      });
+      mockStripeService.getCheckoutSession.mockResolvedValueOnce({
+        id: 'cs_deferred_retry',
+        status: 'complete',
+        payment_status: 'paid',
+      });
+
+      await service.verifyStripeSession('cs_deferred_retry');
+
+      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'registration-id' },
+          data: { status: 'CONFIRMED', paymentDeferred: false },
+        }),
+      );
+    });
+
+    it('skips the update only when payment is COMPLETED AND registration is CONFIRMED AND paymentDeferred is false', async () => {
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+        id: 'payment-id',
+        status: PaymentStatus.COMPLETED,
+        providerRefId: 'cs_already_done',
+        userId: 'user-id',
+        registrationId: 'registration-id',
+        registration: {
+          id: 'registration-id',
+          status: 'CONFIRMED',
+          paymentDeferred: false,
+        },
+      });
+      mockStripeService.getCheckoutSession.mockResolvedValueOnce({
+        id: 'cs_already_done',
+        status: 'complete',
+        payment_status: 'paid',
+      });
+
+      await service.verifyStripeSession('cs_already_done');
+
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('does NOT promote a WAITLISTED deferred registration to CONFIRMED on payment — capacity wins', async () => {
+      // Deferred + WAITLISTED participant pays via Pay Now CTA. The
+      // payment must record + clear paymentDeferred, but the status
+      // must stay WAITLISTED (admin / capacity-opens-up is the only path
+      // to CONFIRMED for waitlisted registrations).
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+        id: 'payment-id',
+        status: PaymentStatus.PENDING,
+        providerRefId: 'cs_waitlisted_pay',
+        userId: 'user-id',
+        registrationId: 'registration-id',
+        registration: {
+          id: 'registration-id',
+          status: 'WAITLISTED',
+          paymentDeferred: true,
+        },
+      });
+      mockStripeService.getCheckoutSession.mockResolvedValueOnce({
+        id: 'cs_waitlisted_pay',
+        status: 'complete',
+        payment_status: 'paid',
+      });
+
+      await service.verifyStripeSession('cs_waitlisted_pay');
+
+      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'registration-id' },
+          data: { status: 'WAITLISTED', paymentDeferred: false },
+        }),
+      );
+    });
+
+    it('recordManualPayment marks the registration CONFIRMED and clears paymentDeferred when status COMPLETED', async () => {
+      const created = {
+        id: 'payment-manual',
+        status: PaymentStatus.PENDING,
+        amount: 100,
+        currency: 'USD',
+        provider: PaymentProvider.STRIPE,
+        userId: 'user-id',
+        registrationId: 'registration-id',
+        providerRefId: 'manual:check-123',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockPrismaService.registration.findUnique.mockResolvedValue({
+        id: 'registration-id',
+        userId: 'user-id',
+        status: 'CONFIRMED',
+        paymentDeferred: true,
+      });
+      mockPrismaService.payment.create.mockResolvedValueOnce(created);
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(created);
+      mockPrismaService.payment.update.mockResolvedValueOnce({
+        ...created,
+        status: PaymentStatus.COMPLETED,
+      });
+      mockPrismaService.registration.update.mockResolvedValueOnce({
+        id: 'registration-id',
+        status: 'CONFIRMED',
+        paymentDeferred: false,
+      });
+
+      await service.recordManualPayment({
+        amount: 100,
+        currency: 'USD',
+        userId: 'user-id',
+        registrationId: 'registration-id',
+        reference: 'check-123',
+      });
+
+      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'registration-id' },
+          data: { status: 'CONFIRMED', paymentDeferred: false },
+        }),
+      );
+    });
+
+    it('recordManualPayment does NOT touch the registration when status is not COMPLETED', async () => {
+      const created = {
+        id: 'payment-manual',
+        status: PaymentStatus.PENDING,
+        amount: 100,
+        currency: 'USD',
+        provider: PaymentProvider.STRIPE,
+        userId: 'user-id',
+        registrationId: 'registration-id',
+        providerRefId: 'manual',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockPrismaService.registration.findUnique.mockResolvedValue({
+        id: 'registration-id',
+        userId: 'user-id',
+        status: 'PENDING',
+        paymentDeferred: false,
+      });
+      mockPrismaService.payment.create.mockResolvedValueOnce(created);
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(created);
+      mockPrismaService.payment.update.mockResolvedValueOnce({
+        ...created,
+        status: PaymentStatus.FAILED,
+      });
+
+      await service.recordManualPayment({
+        amount: 100,
+        currency: 'USD',
+        userId: 'user-id',
+        registrationId: 'registration-id',
+        reference: undefined,
+        status: PaymentStatus.FAILED,
+      });
+
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+    });
+
+    it('recordManualPayment does NOT touch the registration when registrationId is absent', async () => {
+      const created = {
+        id: 'payment-manual',
+        status: PaymentStatus.PENDING,
+        amount: 100,
+        currency: 'USD',
+        provider: PaymentProvider.STRIPE,
+        userId: 'user-id',
+        registrationId: null,
+        providerRefId: 'manual',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockPrismaService.payment.create.mockResolvedValueOnce(created);
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(created);
+      mockPrismaService.payment.update.mockResolvedValueOnce({
+        ...created,
+        status: PaymentStatus.COMPLETED,
+      });
+
+      await service.recordManualPayment({
+        amount: 100,
+        currency: 'USD',
+        userId: 'user-id',
+        reference: undefined,
+      });
+
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+    });
+  });
+});
 });

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -2082,6 +2082,7 @@ describe('PaymentsService', () => {
         expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
       });
     });
+  });
 
   // Additional tests would follow the same pattern for other methods
 
@@ -2170,39 +2171,6 @@ describe('PaymentsService', () => {
       expect(
         mockNotificationsService.sendRegistrationConfirmationEmail,
       ).not.toHaveBeenCalled();
-    });
-
-    it('still clears paymentDeferred on retry when payment is already COMPLETED but registration is still flagged deferred', async () => {
-      // Edge case: previous run completed the payment update but the
-      // registration update failed and is being retried. Without the
-      // widened condition, this case would skip the update and leave
-      // paymentDeferred=true forever.
-      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
-        id: 'payment-id',
-        status: PaymentStatus.COMPLETED,
-        providerRefId: 'cs_deferred_retry',
-        userId: 'user-id',
-        registrationId: 'registration-id',
-        registration: {
-          id: 'registration-id',
-          status: 'CONFIRMED',
-          paymentDeferred: true,
-        },
-      });
-      mockStripeService.getCheckoutSession.mockResolvedValueOnce({
-        id: 'cs_deferred_retry',
-        status: 'complete',
-        payment_status: 'paid',
-      });
-
-      await service.verifyStripeSession('cs_deferred_retry');
-
-      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 'registration-id' },
-          data: { status: 'CONFIRMED', paymentDeferred: false },
-        }),
-      );
     });
 
     it('still clears paymentDeferred on retry when payment is already COMPLETED but registration is still flagged deferred', async () => {
@@ -2411,5 +2379,4 @@ describe('PaymentsService', () => {
       expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
     });
   });
-});
 });

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -343,12 +343,16 @@ export class PaymentsService {
    * Mark a registration as paid: clear `paymentDeferred` and set status
    * to CONFIRMED — UNLESS the registration is currently WAITLISTED, in
    * which case status stays WAITLISTED (capacity beats payment). Payment
-   * does not buy a slot the user can't have.
+   * does not buy a slot the user can't have. The WAITLISTED case is
+   * unreachable for participants through normal UI but possible via
+   * direct API call or a TOCTOU race against capacity; mirrors the same
+   * guard in `verifyStripeSession`.
    *
    * Idempotent — safe to call multiple times. Called from every
-   * successful payment-completion path (Stripe verification, manual
-   * payment, and any future payment provider) so the registration is
-   * always brought to a consistent paid state when a payment lands.
+   * successful payment-completion path (today: Stripe verification path
+   * and `recordManualPayment`; any future payment provider should call
+   * this too) so the registration is always brought to a consistent
+   * paid state when a payment lands.
    */
   private async markRegistrationPaid(registrationId: string): Promise<void> {
     const current = await this.prisma.registration.findUnique({
@@ -580,6 +584,16 @@ export class PaymentsService {
           // We still record the payment as COMPLETED and clear
           // `paymentDeferred` so the row reflects the paid state, but
           // the status stays WAITLISTED.
+          //
+          // This is the only WAITLISTED-deferred interaction that is
+          // actually reachable via this PR's new UI: the dashboard's
+          // "Pay Now" CTA hides itself for WAITLISTED registrations
+          // (DashboardPage.tsx), but a direct API call or a TOCTOU race
+          // that produced a WAITLISTED + paymentDeferred=true row would
+          // expose the bug this guard prevents. Pre-#160, this method
+          // always set the registration to CONFIRMED on paid sessions
+          // — a latent issue that became reachable once dashboard
+          // "Pay Now" was added.
           const isWaitlisted = payment.registration.status === 'WAITLISTED';
           updatedRegistrationStatus = isWaitlisted ? 'WAITLISTED' : 'CONFIRMED';
           const targetStatus = updatedRegistrationStatus;

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -316,7 +316,51 @@ export class PaymentsService {
     //   updateDto.notes = data.reference;
     // }
     
-    return this.update(payment.id, updateDto);
+    const updatedPayment = await this.update(payment.id, updateDto);
+
+    // When a manual payment is recorded as COMPLETED against a registration,
+    // mark the registration paid: status CONFIRMED, paymentDeferred=false.
+    // This also closes out any deferred registrations that an admin records
+    // a manual payment for.
+    if (
+      data.registrationId &&
+      (data.status ?? PaymentStatus.COMPLETED) === PaymentStatus.COMPLETED
+    ) {
+      try {
+        await this.markRegistrationPaid(data.registrationId);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        this.logger.warn(
+          `Manual payment ${payment.id} recorded, but failed to mark registration ${data.registrationId} paid: ${message}`,
+        );
+      }
+    }
+
+    return updatedPayment;
+  }
+
+  /**
+   * Mark a registration as paid: clear `paymentDeferred` and set status
+   * to CONFIRMED — UNLESS the registration is currently WAITLISTED, in
+   * which case status stays WAITLISTED (capacity beats payment). Payment
+   * does not buy a slot the user can't have.
+   *
+   * Idempotent — safe to call multiple times. Called from every
+   * successful payment-completion path (Stripe verification, manual
+   * payment, and any future payment provider) so the registration is
+   * always brought to a consistent paid state when a payment lands.
+   */
+  private async markRegistrationPaid(registrationId: string): Promise<void> {
+    const current = await this.prisma.registration.findUnique({
+      where: { id: registrationId },
+      select: { status: true },
+    });
+    if (!current) return;
+    const targetStatus = current.status === 'WAITLISTED' ? 'WAITLISTED' : 'CONFIRMED';
+    await this.prisma.registration.update({
+      where: { id: registrationId },
+      data: { status: targetStatus, paymentDeferred: false },
+    });
   }
 
   /**
@@ -529,12 +573,31 @@ export class PaymentsService {
         updatedPaymentStatus = PaymentStatus.COMPLETED;
         
         if (payment.registration) {
-          updatedRegistrationStatus = 'CONFIRMED';
+          // Capacity beats payment: a WAITLISTED registration must NOT be
+          // promoted to CONFIRMED just because the user paid. The
+          // standard waitlist flow (admin or capacity-opens-up) is the
+          // only path that should transition WAITLISTED → CONFIRMED.
+          // We still record the payment as COMPLETED and clear
+          // `paymentDeferred` so the row reflects the paid state, but
+          // the status stays WAITLISTED.
+          const isWaitlisted = payment.registration.status === 'WAITLISTED';
+          updatedRegistrationStatus = isWaitlisted ? 'WAITLISTED' : 'CONFIRMED';
+          const targetStatus = updatedRegistrationStatus;
 
-          // If either the payment or registration status needs updating
-          if (payment.status !== PaymentStatus.COMPLETED || payment.registration.status !== 'CONFIRMED') {
+          // Update path fires when ANY of (a) payment not yet COMPLETED,
+          // (b) registration not at its target status (CONFIRMED unless
+          // WAITLISTED, in which case it stays WAITLISTED), (c) registration
+          // still flagged paymentDeferred=true. The third clause matters
+          // for deferred registrations: a deferred row starts as CONFIRMED
+          // + paymentDeferred=true, so without this clause a retry after
+          // payment would skip the update and leave paymentDeferred true.
+          if (
+            payment.status !== PaymentStatus.COMPLETED ||
+            payment.registration.status !== targetStatus ||
+            payment.registration.paymentDeferred
+          ) {
             try {
-              this.logger.log(`Updating payment ${payment.id} to COMPLETED and registration ${payment.registration.id} to CONFIRMED`);
+              this.logger.log(`Updating payment ${payment.id} to COMPLETED and registration ${payment.registration.id} to ${targetStatus} (paymentDeferred cleared)`);
               
               try {
                 // Use transaction to ensure atomicity between payment and registration updates
@@ -545,7 +608,7 @@ export class PaymentsService {
                   }),
                   this.prisma.registration.update({
                     where: { id: payment.registration.id },
-                    data: { status: 'CONFIRMED' },
+                    data: { status: targetStatus, paymentDeferred: false },
                   }),
                 ]);
                 
@@ -555,11 +618,18 @@ export class PaymentsService {
                   registration: transactionResults[1].id
                 })}`);
 
-                // Send registration confirmation email with the updated status
-                this.sendRegistrationConfirmationEmailAfterPayment(payment.registration.id)
-                  .catch(emailError => {
-                    this.logger.warn(`Failed to send registration confirmation email: ${emailError instanceof Error ? emailError.message : 'Unknown error'}`);
-                  });
+                // Send registration confirmation email with the updated
+                // status — but skip it for a deferred → paid transition,
+                // because the participant already received a confirmation
+                // email at registration creation time (with a "payment
+                // deferred" notice). Sending it again would duplicate.
+                const wasDeferred = payment.registration.paymentDeferred === true;
+                if (!wasDeferred) {
+                  this.sendRegistrationConfirmationEmailAfterPayment(payment.registration.id)
+                    .catch(emailError => {
+                      this.logger.warn(`Failed to send registration confirmation email: ${emailError instanceof Error ? emailError.message : 'Unknown error'}`);
+                    });
+                }
               } catch (transactionError) {
                 // If the transaction fails, at least try to update the payment status
                 // This ensures we record the successful Stripe payment even if registration update fails

--- a/apps/api/src/registrations/controllers/admin-registrations.controller.spec.ts
+++ b/apps/api/src/registrations/controllers/admin-registrations.controller.spec.ts
@@ -37,6 +37,7 @@ describe('AdminRegistrationsController', () => {
     userId: 'user-123',
     year: 2024,
     status: RegistrationStatus.CONFIRMED,
+    paymentDeferred: false,
     createdAt: new Date('2024-01-01'),
     updatedAt: new Date('2024-01-01'),
     user: {

--- a/apps/api/src/registrations/dto/create-camp-registration.dto.ts
+++ b/apps/api/src/registrations/dto/create-camp-registration.dto.ts
@@ -33,11 +33,12 @@ export class CreateCampRegistrationDto {
   customFields?: Record<string, unknown>;
 
   @ApiProperty({
-    description: 'Array of job IDs being registered for',
+    description:
+      'Array of job IDs being registered for. May be empty when the user is ' +
+      'flagged with allowNoJob=true (server enforces this).',
     example: ['8089a3d6-8c57-43ea-a2c3-037ff0c99546', '4bbb66ab-fcea-40bc-bdf6-9f813cf2d48f'],
     type: [String],
   })
-  @IsNotEmpty()
   @IsArray()
   @IsString({ each: true })
   @IsUUID(4, { each: true })
@@ -50,4 +51,18 @@ export class CreateCampRegistrationDto {
   @IsNotEmpty()
   @IsBoolean()
   acceptedTerms!: boolean;
-} 
+
+  @ApiProperty({
+    description:
+      'Whether the participant is opting to defer dues payment. Requires ' +
+      'both coreConfig.allowDeferredDuesPayment and user.allowDeferredDuesPayment ' +
+      'to be true; otherwise the server rejects with 403. When true (and the ' +
+      'resulting registration is not waitlisted), the registration is created ' +
+      'as CONFIRMED with paymentDeferred=true.',
+    required: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  deferPayment?: boolean = false;
+}

--- a/apps/api/src/registrations/registrations.module.ts
+++ b/apps/api/src/registrations/registrations.module.ts
@@ -3,16 +3,34 @@ import { RegistrationsService } from './registrations.service';
 import { RegistrationsController } from './registrations.controller';
 import { RegistrationAdminService } from './services/registration-admin.service';
 import { RegistrationCleanupService } from './services/registration-cleanup.service';
+import { RegistrationPolicyService } from './services/registration-policy.service';
 import { AdminRegistrationsController } from './controllers/admin-registrations.controller';
 import { PrismaModule } from '../common/prisma/prisma.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { AdminAuditModule } from '../admin-audit/admin-audit.module';
 import { PaymentsModule } from '../payments/payments.module';
+import { CoreConfigModule } from '../core-config/core-config.module';
 
 @Module({
-  imports: [PrismaModule, NotificationsModule, AdminAuditModule, PaymentsModule],
+  imports: [
+    PrismaModule,
+    NotificationsModule,
+    AdminAuditModule,
+    PaymentsModule,
+    CoreConfigModule,
+  ],
   controllers: [RegistrationsController, AdminRegistrationsController],
-  providers: [RegistrationsService, RegistrationAdminService, RegistrationCleanupService],
-  exports: [RegistrationsService, RegistrationAdminService, RegistrationCleanupService],
+  providers: [
+    RegistrationsService,
+    RegistrationAdminService,
+    RegistrationCleanupService,
+    RegistrationPolicyService,
+  ],
+  exports: [
+    RegistrationsService,
+    RegistrationAdminService,
+    RegistrationCleanupService,
+    RegistrationPolicyService,
+  ],
 })
 export class RegistrationsModule {}

--- a/apps/api/src/registrations/registrations.service.spec.ts
+++ b/apps/api/src/registrations/registrations.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { RegistrationsService } from './registrations.service';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { NotificationsService } from '../notifications/services/notifications.service';
+import { RegistrationPolicyService } from './services/registration-policy.service';
 import { NotFoundException, ConflictException, ForbiddenException } from '@nestjs/common';
 import { RegistrationStatus, UserRole } from '@prisma/client';
 import { CreateRegistrationDto } from './dto';
@@ -10,7 +11,19 @@ describe('RegistrationsService', () => {
   let service: RegistrationsService;
   // PrismaService is mocked and not directly used in tests
 
-  const mockPrismaService = {
+  type MockPrismaService = {
+    registration: { create: jest.Mock; findMany: jest.Mock; findUnique: jest.Mock; findFirst: jest.Mock; update: jest.Mock; delete: jest.Mock };
+    registrationJob: { create: jest.Mock; findMany: jest.Mock; findFirst: jest.Mock; delete: jest.Mock };
+    job: { findUnique: jest.Mock; findMany: jest.Mock };
+    user: { findUnique: jest.Mock };
+    payment: { findUnique: jest.Mock };
+    campingOption: { findUnique: jest.Mock };
+    campingOptionRegistration: { findMany: jest.Mock; findFirst: jest.Mock; create: jest.Mock };
+    campingOptionFieldValue: { create: jest.Mock };
+    $transaction: jest.Mock;
+  };
+
+  const mockPrismaService: MockPrismaService = {
     registration: {
       create: jest.fn(),
       findMany: jest.fn(),
@@ -35,9 +48,31 @@ describe('RegistrationsService', () => {
     payment: {
       findUnique: jest.fn(),
     },
+    campingOption: {
+      findUnique: jest.fn(),
+    },
     campingOptionRegistration: {
       findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
     },
+    campingOptionFieldValue: {
+      create: jest.fn(),
+    },
+    // Default: run the callback with the mockPrismaService itself as the
+    // `tx` client. Per-test overrides can replace this to simulate
+    // rollback by throwing instead of running the callback.
+    $transaction: jest.fn(async (callback: (tx: MockPrismaService) => unknown) =>
+      callback(mockPrismaService),
+    ),
+  };
+
+  const mockPolicyService = {
+    // Default to a no-op (permissive) policy so existing tests of create()
+    // (which does not exercise the policy gate) continue to pass without
+    // wiring per-test stubs. Tests of createCampRegistration explicitly
+    // set this mock to reject when they want to assert policy failures.
+    assertCanCreateCampRegistration: jest.fn().mockResolvedValue(undefined),
   };
 
   beforeEach(async () => {
@@ -54,6 +89,10 @@ describe('RegistrationsService', () => {
             sendRegistrationConfirmationEmail: jest.fn().mockResolvedValue(true),
             sendRegistrationErrorEmail: jest.fn().mockResolvedValue(true),
           },
+        },
+        {
+          provide: RegistrationPolicyService,
+          useValue: mockPolicyService,
         },
       ],
     }).compile();
@@ -598,25 +637,6 @@ describe('RegistrationsService', () => {
   });
 
   describe('createCampRegistration', () => {
-    it('should throw ForbiddenException when user.allowRegistration is false', async () => {
-      mockPrismaService.user.findUnique.mockResolvedValue({
-        id: 'user-id',
-        email: 'test@example.playaplan.app',
-        allowRegistration: false,
-      });
-
-      const call = service.createCampRegistration('user-id', {
-        acceptedTerms: true,
-        jobs: ['job-id-1'],
-        campingOptions: [],
-      });
-
-      await expect(call).rejects.toBeInstanceOf(ForbiddenException);
-      await expect(call).rejects.toThrow(
-        'Registration is not available for your account. Please contact an administrator.',
-      );
-    });
-
     it('should throw NotFoundException when user does not exist', async () => {
       mockPrismaService.user.findUnique.mockResolvedValue(null);
 
@@ -627,6 +647,198 @@ describe('RegistrationsService', () => {
           campingOptions: [],
         }),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    const userId = 'user-id-camp';
+    const baseUser = {
+      id: userId,
+      email: 'test@example.playaplan.app',
+      firstName: 'Test',
+      lastName: 'User',
+      playaName: null as string | null,
+      role: UserRole.PARTICIPANT,
+      allowRegistration: true,
+      allowEarlyRegistration: false,
+      allowNoJob: false,
+      allowDeferredDuesPayment: false,
+    };
+
+    const baseDto = {
+      campingOptions: [],
+      jobs: ['job-1'],
+      acceptedTerms: true,
+    } as unknown as Parameters<RegistrationsService['createCampRegistration']>[1];
+
+    const buildCreatedRegistration = (overrides: Partial<{
+      status: RegistrationStatus;
+      paymentDeferred: boolean;
+      id: string;
+    }> = {}) => ({
+      id: overrides.id ?? 'reg-1',
+      status: overrides.status ?? RegistrationStatus.PENDING,
+      paymentDeferred: overrides.paymentDeferred ?? false,
+      year: new Date().getFullYear(),
+      userId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      jobs: [],
+      payments: [],
+      user: baseUser,
+    });
+
+    beforeEach(() => {
+      mockPolicyService.assertCanCreateCampRegistration.mockResolvedValue(undefined);
+      mockPrismaService.user.findUnique.mockResolvedValue(baseUser);
+      mockPrismaService.registration.findFirst.mockResolvedValue(null);
+      mockPrismaService.job.findUnique.mockImplementation(({ where }: { where: { id: string } }) => ({
+        id: where.id,
+        maxRegistrations: 10,
+        staffOnly: false,
+        registrations: [],
+      }));
+    });
+
+    it('does not call the policy gate from inside the broad try/catch, so policy 4xx rejections do not trigger the error email', async () => {
+      const policyError = new ForbiddenException('Registration is not currently open.');
+      mockPolicyService.assertCanCreateCampRegistration.mockRejectedValue(policyError);
+      // Wire registration.create to throw a distinct error so we can prove
+      // we never reached the broad try/catch (which would log + email).
+      mockPrismaService.registration.create.mockRejectedValue(new Error('should not be reached'));
+
+      await expect(
+        service.createCampRegistration(userId, baseDto),
+      ).rejects.toBe(policyError);
+
+      // The notifications mock is per-suite; assert sendRegistrationErrorEmail
+      // was NOT called by checking that the user.findUnique to fetch the
+      // error-email recipient ran only the initial "load user" pass.
+      // (The current implementation no longer makes a second findUnique
+      // for the error email, so a single call is the expected baseline.)
+      expect(mockPrismaService.user.findUnique).toHaveBeenCalledTimes(1);
+    });
+
+    it('always creates a Registration even when jobs is empty (relies on policy gate to enforce allowNoJob)', async () => {
+      const dtoNoJobs = { ...baseDto, jobs: [] };
+      const created = buildCreatedRegistration({ status: RegistrationStatus.PENDING });
+      mockPrismaService.registration.create.mockResolvedValue(created);
+
+      const result = await service.createCampRegistration(userId, dtoNoJobs);
+
+      expect(mockPrismaService.registration.create).toHaveBeenCalledTimes(1);
+      expect(result.jobRegistration).toEqual(created);
+    });
+
+    it('creates deferred registration as CONFIRMED + paymentDeferred=true when no chosen job is over capacity', async () => {
+      const dtoDeferred = { ...baseDto, deferPayment: true };
+      const created = buildCreatedRegistration({
+        status: RegistrationStatus.CONFIRMED,
+        paymentDeferred: true,
+      });
+      mockPrismaService.registration.create.mockResolvedValue(created);
+
+      const result = await service.createCampRegistration(userId, dtoDeferred);
+
+      expect(mockPrismaService.registration.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: RegistrationStatus.CONFIRMED,
+            paymentDeferred: true,
+          }),
+        }),
+      );
+      expect(result.jobRegistration?.status).toBe(RegistrationStatus.CONFIRMED);
+      expect(result.jobRegistration?.paymentDeferred).toBe(true);
+    });
+
+    it('creates deferred + waitlisted as WAITLISTED + paymentDeferred=true (capacity beats deferral)', async () => {
+      const dtoDeferred = { ...baseDto, deferPayment: true };
+      // One full job triggers WAITLISTED.
+      mockPrismaService.job.findUnique.mockResolvedValue({
+        id: 'job-1',
+        maxRegistrations: 0,
+        staffOnly: false,
+        registrations: [],
+      });
+      const created = buildCreatedRegistration({
+        status: RegistrationStatus.WAITLISTED,
+        paymentDeferred: true,
+      });
+      mockPrismaService.registration.create.mockResolvedValue(created);
+
+      const result = await service.createCampRegistration(userId, dtoDeferred);
+
+      expect(mockPrismaService.registration.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: RegistrationStatus.WAITLISTED,
+            paymentDeferred: true,
+          }),
+        }),
+      );
+      expect(result.jobRegistration?.status).toBe(RegistrationStatus.WAITLISTED);
+    });
+
+    it('throws if terms are not accepted (before any DB write)', async () => {
+      const dtoNoTerms = { ...baseDto, acceptedTerms: false };
+
+      await expect(
+        service.createCampRegistration(userId, dtoNoTerms),
+      ).rejects.toThrow(/Terms and conditions/);
+
+      expect(mockPrismaService.registration.create).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException if the user already has an active registration for the year', async () => {
+      mockPrismaService.registration.findFirst.mockResolvedValue(buildCreatedRegistration());
+
+      await expect(
+        service.createCampRegistration(userId, baseDto),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('propagates failure and rolls back atomically when a downstream camping-option write fails inside the transaction', async () => {
+      // Stub user + jobs OK; the registration insert succeeds; but the
+      // camping-option insert fails. The transaction wrapping the writes
+      // guarantees the Registration is rolled back too — without this
+      // wrap, CampingOptionRegistration rows have no FK to Registration
+      // so deleting the registration manually would leave orphaned
+      // camping-option rows and block retries.
+      const created = buildCreatedRegistration({ status: RegistrationStatus.PENDING });
+      mockPrismaService.registration.create.mockResolvedValueOnce(created);
+      mockPrismaService.campingOption.findUnique.mockResolvedValueOnce({
+        id: 'opt-1',
+        name: 'Standard',
+        fields: [],
+      });
+      mockPrismaService.campingOptionRegistration.findFirst.mockResolvedValueOnce(null);
+      mockPrismaService.campingOptionRegistration.create.mockRejectedValueOnce(new Error('boom'));
+
+      const dtoWithOption = {
+        ...baseDto,
+        campingOptions: ['opt-1'],
+      };
+
+      await expect(
+        service.createCampRegistration(userId, dtoWithOption),
+      ).rejects.toThrow(/boom/);
+
+      // The transaction should have been invoked (so rollback semantics
+      // apply); no manual cleanup delete is needed.
+      expect(mockPrismaService.$transaction).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException with the user-friendly message when user.allowRegistration is false', async () => {
+      mockPrismaService.user.findUnique.mockResolvedValue({
+        ...baseUser,
+        allowRegistration: false,
+      });
+
+      const call = service.createCampRegistration(userId, baseDto);
+
+      await expect(call).rejects.toBeInstanceOf(ForbiddenException);
+      await expect(call).rejects.toThrow(
+        'Registration is not available for your account. Please contact an administrator.',
+      );
     });
   });
 });

--- a/apps/api/src/registrations/registrations.service.spec.ts
+++ b/apps/api/src/registrations/registrations.service.spec.ts
@@ -832,6 +832,15 @@ describe('RegistrationsService', () => {
         ...baseUser,
         allowRegistration: false,
       });
+      // Simulate the policy service rejecting because allowRegistration=false.
+      // The policy service's own spec covers the exact message; this test
+      // verifies the integration surface — that the message reaches the
+      // caller unchanged.
+      mockPolicyService.assertCanCreateCampRegistration.mockRejectedValueOnce(
+        new ForbiddenException(
+          'Registration is not available for your account. Please contact an administrator.',
+        ),
+      );
 
       const call = service.createCampRegistration(userId, baseDto);
 

--- a/apps/api/src/registrations/registrations.service.ts
+++ b/apps/api/src/registrations/registrations.service.ts
@@ -648,6 +648,17 @@ export class RegistrationsService {
     );
 
     const deferPayment = createCampRegistrationDto.deferPayment ?? false;
+    // hasWaitlistedJob: under normal UI flow this is unreachable — the
+    // RegistrationPage disables full-job checkboxes
+    // (RegistrationPage.tsx:1017) so a participant cannot select an
+    // over-capacity job. Kept as defense-in-depth for two paths the
+    // UI does not guard: (a) a direct API call from a malicious or
+    // out-of-date client, and (b) a TOCTOU race where two participants
+    // load the form with a job at N-1 of N spots taken and both submit.
+    // The check costs one extra prisma read per job and keeps capacity
+    // enforced server-side, consistent with what
+    // `RegistrationsService.create()` (used by admin/staff and
+    // `POST /jobs/:id/register`) already does.
     const hasWaitlistedJob = jobsWithCounts.some(
       ({ job, currentRegistrationCount }) =>
         currentRegistrationCount >= job.maxRegistrations,
@@ -655,7 +666,11 @@ export class RegistrationsService {
 
     // Status semantics (Option A from issue #160 design):
     //   - WAITLISTED wins when any chosen job is over capacity, even for
-    //     deferred registrations (capacity > deferral preference).
+    //     deferred registrations (capacity > deferral preference). Payment
+    //     must not buy a slot the user can't have; see also the matching
+    //     guard in `payments.service.ts` `verifyStripeSession` and
+    //     `markRegistrationPaid` which refuse to promote WAITLISTED →
+    //     CONFIRMED on payment.
     //   - Otherwise: deferred registrations land CONFIRMED (no payment is
     //     expected up front); non-deferred land PENDING (awaiting payment).
     let status: RegistrationStatus;
@@ -773,9 +788,15 @@ export class RegistrationsService {
       // registration lands CONFIRMED (which today happens only when
       // paymentDeferred=true and no chosen job was waitlisted). For
       // non-deferred PENDING registrations the email is still sent by the
-      // payments webhook on completed payment. For deferred WAITLISTED
-      // registrations we skip auto-email — the standard waitlist flow
-      // handles user communication and "confirmation" copy would mislead.
+      // payments webhook on completed payment.
+      //
+      // For deferred WAITLISTED registrations we skip auto-email. This
+      // state is unreachable via the normal UI flow (RegistrationPage
+      // disables full-job checkboxes), but a direct API call or a TOCTOU
+      // race could produce it. If it does, "Registration Confirmation"
+      // copy would mislead a waitlisted participant into thinking they
+      // have a slot; the standard waitlist flow (admin-driven via
+      // RegistrationAdminService) is responsible for their communication.
       if (
         jobRegistration.paymentDeferred &&
         jobRegistration.status === RegistrationStatus.CONFIRMED

--- a/apps/api/src/registrations/registrations.service.ts
+++ b/apps/api/src/registrations/registrations.service.ts
@@ -4,6 +4,7 @@ import { NotificationsService } from '../notifications/services/notifications.se
 import { CreateRegistrationDto, AddJobToRegistrationDto, CreateCampRegistrationDto, UpdateRegistrationDto } from './dto';
 import { Registration, RegistrationStatus, UserRole } from '@prisma/client';
 import { DayOfWeek } from '../common/enums/day-of-week.enum';
+import { RegistrationPolicyService } from './services/registration-policy.service';
 
 interface JobRegistrationWithJobs extends Registration {
   jobs?: Array<{
@@ -23,6 +24,24 @@ interface JobRegistrationWithJobs extends Registration {
   }>;
 }
 
+/**
+ * Options passed to `create()` to control registration creation beyond what
+ * the public DTO exposes. Used by `createCampRegistration` to flag a
+ * registration as intentionally deferred (server-side enforcement of the
+ * camp + per-user deferred-payment policy lives in
+ * `RegistrationPolicyService`).
+ */
+interface CreateRegistrationOptions {
+  /**
+   * When true, the registration is marked `paymentDeferred = true`, and
+   * if no chosen job is over capacity the status is set to `CONFIRMED`
+   * instead of `PENDING`. A waitlisted-by-capacity outcome still wins
+   * (capacity > deferral); the row is stored `WAITLISTED + paymentDeferred=true`
+   * in that case.
+   */
+  paymentDeferred?: boolean;
+}
+
 @Injectable()
 export class RegistrationsService {
   private readonly logger = new Logger(RegistrationsService.name);
@@ -30,6 +49,7 @@ export class RegistrationsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly notificationsService: NotificationsService,
+    private readonly policyService: RegistrationPolicyService,
   ) {}
 
   /**
@@ -37,7 +57,10 @@ export class RegistrationsService {
    * @param createRegistrationDto - The data to create the registration
    * @returns The created registration
    */
-  async create(createRegistrationDto: CreateRegistrationDto): Promise<Registration> {
+  async create(
+    createRegistrationDto: CreateRegistrationDto,
+    options: CreateRegistrationOptions = {},
+  ): Promise<Registration> {
     // Check if user exists
     const user = await this.prisma.user.findUnique({
       where: { id: createRegistrationDto.userId },
@@ -89,17 +112,29 @@ export class RegistrationsService {
       })
     );
 
-    // Determine overall registration status
+    // Determine overall registration status.
+    //   - WAITLISTED wins when any chosen job is over capacity, even for
+    //     deferred registrations (capacity > deferral preference).
+    //   - Otherwise: deferred registrations land CONFIRMED (no payment is
+    //     expected up front); non-deferred land PENDING (awaiting payment).
     const hasWaitlistedJob = jobs.some(
       ({ job, currentRegistrationCount }) => currentRegistrationCount >= job.maxRegistrations
     );
-    
-    const status = hasWaitlistedJob ? RegistrationStatus.WAITLISTED : RegistrationStatus.PENDING;
+    const paymentDeferred = options.paymentDeferred === true;
+    let status: RegistrationStatus;
+    if (hasWaitlistedJob) {
+      status = RegistrationStatus.WAITLISTED;
+    } else if (paymentDeferred) {
+      status = RegistrationStatus.CONFIRMED;
+    } else {
+      status = RegistrationStatus.PENDING;
+    }
 
     // Create registration with jobs
     return this.prisma.registration.create({
       data: {
         status,
+        paymentDeferred,
         year: createRegistrationDto.year,
         user: { connect: { id: createRegistrationDto.userId } },
         jobs: {
@@ -513,150 +548,238 @@ export class RegistrationsService {
 
   /**
    * Create a comprehensive camp registration
+   *
+   * Runs the participant-side policy gates (`RegistrationPolicyService`)
+   * BEFORE entering the broad try/catch that emits a registration-error
+   * email, so policy 4xx rejections (`closed window`, `not eligible`,
+   * `must pick a job`, `not eligible to defer`) propagate cleanly and do
+   * NOT trigger an "unexpected error" email. The broad try/catch only wraps
+   * the create-database-rows section where any failure really is unexpected
+   * and worth notifying the user about.
+   *
+   * Always creates a `Registration` row when policy passes, even when the
+   * user has chosen no jobs (relies on `user.allowNoJob` for eligibility,
+   * checked by the policy service). This is a change from the previous
+   * behavior, which silently created no `Registration` at all for a
+   * camping-only signup — leaving nowhere to track payment or surface the
+   * signup on the dashboard.
+   *
    * @param userId - The ID of the user
    * @param createCampRegistrationDto - The camp registration data
    * @returns The created registrations and camping option registrations
    */
   async createCampRegistration(userId: string, createCampRegistrationDto: CreateCampRegistrationDto) {
-    try {
-      // Check if user exists
-      const user = await this.prisma.user.findUnique({
-        where: { id: userId },
+    // Load user once so the policy gate and downstream queries share it.
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${userId} not found`);
+    }
+
+    // Policy gates run OUTSIDE the broad try/catch — a 4xx from these is
+    // an expected rejection, not an "unexpected registration error".
+    await this.policyService.assertCanCreateCampRegistration(user, {
+      jobs: createCampRegistrationDto.jobs ?? [],
+      deferPayment: createCampRegistrationDto.deferPayment ?? false,
+    });
+
+    // Validate that terms have been accepted. Kept outside the broad
+    // try/catch for the same reason — terms-missing is a user-correctable
+    // input error, not an "unexpected" failure.
+    if (!createCampRegistrationDto.acceptedTerms) {
+      throw new BadRequestException('Terms and conditions must be accepted');
+    }
+
+    // Pre-flight: active-registration conflict and camping-option existence
+    // checks. These are expected 4xx rejections and stay outside the
+    // broad try/catch that emits the registration-error email.
+    const currentYear = new Date().getFullYear();
+    const existingActiveRegistration = await this.prisma.registration.findFirst({
+      where: {
+        userId,
+        year: currentYear,
+        status: { notIn: [RegistrationStatus.CANCELLED] },
+      },
+    });
+    if (existingActiveRegistration) {
+      throw new ConflictException(`User already has an active registration for ${currentYear}`);
+    }
+
+    const campingOptionIds = createCampRegistrationDto.campingOptions ?? [];
+    // Validate every camping option up front: must exist and the user must
+    // not already be registered for it. This catches a stale option id or
+    // a duplicate signup before any writes happen, avoiding the
+    // half-created-registration trap.
+    const validatedCampingOptions: Array<{
+      campingOptionId: string;
+      fields: Array<{ id: string }>;
+      name: string;
+    }> = [];
+    for (const campingOptionId of campingOptionIds) {
+      const campingOption = await this.prisma.campingOption.findUnique({
+        where: { id: campingOptionId },
+        include: { fields: true },
       });
-
-      if (!user) {
-        throw new NotFoundException(`User with ID ${userId} not found`);
+      if (!campingOption) {
+        throw new NotFoundException(`Camping option with ID ${campingOptionId} not found`);
       }
-
-      // Enforce the per-user allowRegistration flag. Admins can disable the
-      // ability for a specific user to register; respect that here so the
-      // toggle cannot be bypassed by calling the API directly.
-      if (user.allowRegistration === false) {
-        throw new ForbiddenException('Registration is not available for your account. Please contact an administrator.');
+      const existingCampingRegistration =
+        await this.prisma.campingOptionRegistration.findFirst({
+          where: { userId, campingOptionId },
+        });
+      if (existingCampingRegistration) {
+        throw new ConflictException(
+          `User already registered for camping option: ${campingOption.name}`,
+        );
       }
+      validatedCampingOptions.push({
+        campingOptionId,
+        fields: campingOption.fields,
+        name: campingOption.name,
+      });
+    }
 
-      // Validate that terms have been accepted
-      if (!createCampRegistrationDto.acceptedTerms) {
-        throw new BadRequestException('Terms and conditions must be accepted');
-      }
+    // Job validation reads. Done outside the transaction (reads can race
+    // with concurrent writers — that's a pre-existing limitation we
+    // accept) and used both to determine WAITLISTED status and to block
+    // participants from grabbing staff-only jobs.
+    const jobIds = createCampRegistrationDto.jobs ?? [];
+    await this.validateNoStaffOnlyJobsForParticipant(user.role, jobIds);
 
-      // Get current year for job registration
-      const currentYear = new Date().getFullYear();
-
-      let jobRegistration = null;
-      const campingOptionRegistrations: Array<{
-        id: string;
-        userId: string;
-        campingOptionId: string;
-        createdAt: Date;
-        updatedAt: Date;
-        campingOption: {
-          id: string;
-          name: string;
-          description: string | null;
-          enabled: boolean;
-          workShiftsRequired: number;
-          participantDues: number;
-          staffDues: number;
-          maxSignups: number;
-          createdAt: Date;
-          updatedAt: Date;
-          fields: Array<{
-            id: string;
-            displayName: string;
-            description: string | null;
-            dataType: string;
-            required: boolean;
-            maxLength: number | null;
-            minValue: number | null;
-            maxValue: number | null;
-            createdAt: Date;
-            updatedAt: Date;
-            campingOptionId: string;
-          }>;
-        };
-      }> = [];
-
-      // Create job registration if jobs are provided
-      if (createCampRegistrationDto.jobs && createCampRegistrationDto.jobs.length > 0) {
-        // Check if user already has an active registration for this year
-        const existingActiveRegistration = await this.prisma.registration.findFirst({
-          where: {
-            userId,
-            year: currentYear,
-            status: { notIn: [RegistrationStatus.CANCELLED] },
+    const jobsWithCounts = await Promise.all(
+      jobIds.map(async (jobId) => {
+        const job = await this.prisma.job.findUnique({
+          where: { id: jobId },
+          include: {
+            registrations: { include: { registration: true } },
           },
         });
-
-        if (existingActiveRegistration) {
-          throw new ConflictException(`User already has an active registration for ${currentYear}`);
+        if (!job) {
+          throw new NotFoundException(`Job with ID ${jobId} not found`);
         }
+        const currentRegistrationCount = job.registrations.filter(
+          (r) => r.registration.status !== RegistrationStatus.CANCELLED,
+        ).length;
+        return { job, currentRegistrationCount };
+      }),
+    );
 
-        // Create the job registration
-        jobRegistration = await this.create({
-          userId,
-          year: currentYear,
-          jobIds: createCampRegistrationDto.jobs,
-        });
-      }
+    const deferPayment = createCampRegistrationDto.deferPayment ?? false;
+    const hasWaitlistedJob = jobsWithCounts.some(
+      ({ job, currentRegistrationCount }) =>
+        currentRegistrationCount >= job.maxRegistrations,
+    );
 
-      // Create camping option registrations
-      if (createCampRegistrationDto.campingOptions && createCampRegistrationDto.campingOptions.length > 0) {
-        for (const campingOptionId of createCampRegistrationDto.campingOptions) {
-          // Check if camping option exists
-          const campingOption = await this.prisma.campingOption.findUnique({
-            where: { id: campingOptionId },
-            include: { fields: true },
-          });
+    // Status semantics (Option A from issue #160 design):
+    //   - WAITLISTED wins when any chosen job is over capacity, even for
+    //     deferred registrations (capacity > deferral preference).
+    //   - Otherwise: deferred registrations land CONFIRMED (no payment is
+    //     expected up front); non-deferred land PENDING (awaiting payment).
+    let status: RegistrationStatus;
+    if (hasWaitlistedJob) {
+      status = RegistrationStatus.WAITLISTED;
+    } else if (deferPayment) {
+      status = RegistrationStatus.CONFIRMED;
+    } else {
+      status = RegistrationStatus.PENDING;
+    }
 
-          if (!campingOption) {
-            throw new NotFoundException(`Camping option with ID ${campingOptionId} not found`);
-          }
-
-          // Check if user already has this camping option registered
-          const existingCampingRegistration = await this.prisma.campingOptionRegistration.findFirst({
-            where: {
-              userId,
-              campingOptionId,
-            },
-          });
-
-          if (existingCampingRegistration) {
-            throw new ConflictException(`User already registered for camping option: ${campingOption.name}`);
-          }
-
-          // Create the camping option registration
-          const campingRegistration = await this.prisma.campingOptionRegistration.create({
+    try {
+      // Atomic write of Registration + RegistrationJobs + CampingOptionRegistrations
+      // + CampingOptionFieldValues. Wrapping in $transaction guarantees that
+      // a downstream failure (e.g., the 3rd camping option fails to insert)
+      // rolls back ALL earlier writes — including the Registration and any
+      // CampingOptionRegistrations that already succeeded. Without this,
+      // CampingOptionRegistration has no FK to Registration so deleting the
+      // Registration in a manual catch leaves orphaned rows behind that
+      // block retries with "already registered for camping option X".
+      const { jobRegistration, campingOptionRegistrations } =
+        await this.prisma.$transaction(async (tx) => {
+          const jobRegistration = await tx.registration.create({
             data: {
-              userId,
-              campingOptionId,
-            },
-            include: {
-              campingOption: {
-                include: { fields: true },
+              status,
+              paymentDeferred: deferPayment,
+              year: currentYear,
+              user: { connect: { id: userId } },
+              jobs: {
+                create: jobIds.map((jobId) => ({
+                  job: { connect: { id: jobId } },
+                })),
               },
             },
+            include: {
+              user: true,
+              jobs: {
+                include: {
+                  job: { include: { category: true, shift: true } },
+                },
+              },
+              payments: true,
+            },
           });
 
-          // Create custom field values if provided
-          if (createCampRegistrationDto.customFields && campingOption.fields.length > 0) {
-            for (const field of campingOption.fields) {
-              const fieldValue = createCampRegistrationDto.customFields[field.id];
-              if (fieldValue !== undefined) {
-                await this.prisma.campingOptionFieldValue.create({
-                  data: {
-                    fieldId: field.id,
-                    registrationId: campingRegistration.id,
-                    value: String(fieldValue),
-                  },
-                });
+          const created: Array<{
+            id: string;
+            userId: string;
+            campingOptionId: string;
+            createdAt: Date;
+            updatedAt: Date;
+            campingOption: {
+              id: string;
+              name: string;
+              description: string | null;
+              enabled: boolean;
+              workShiftsRequired: number;
+              participantDues: number;
+              staffDues: number;
+              maxSignups: number;
+              createdAt: Date;
+              updatedAt: Date;
+              fields: Array<{
+                id: string;
+                displayName: string;
+                description: string | null;
+                dataType: string;
+                required: boolean;
+                maxLength: number | null;
+                minValue: number | null;
+                maxValue: number | null;
+                createdAt: Date;
+                updatedAt: Date;
+                campingOptionId: string;
+              }>;
+            };
+          }> = [];
+
+          for (const opt of validatedCampingOptions) {
+            const campingRegistration =
+              await tx.campingOptionRegistration.create({
+                data: { userId, campingOptionId: opt.campingOptionId },
+                include: { campingOption: { include: { fields: true } } },
+              });
+
+            if (createCampRegistrationDto.customFields && opt.fields.length > 0) {
+              for (const field of opt.fields) {
+                const fieldValue =
+                  createCampRegistrationDto.customFields[field.id];
+                if (fieldValue !== undefined) {
+                  await tx.campingOptionFieldValue.create({
+                    data: {
+                      fieldId: field.id,
+                      registrationId: campingRegistration.id,
+                      value: String(fieldValue),
+                    },
+                  });
+                }
               }
             }
+
+            created.push(campingRegistration);
           }
 
-          campingOptionRegistrations.push(campingRegistration);
-        }
-      }
+          return { jobRegistration, campingOptionRegistrations: created };
+        });
 
       const result = {
         jobRegistration,
@@ -664,8 +787,37 @@ export class RegistrationsService {
         message: 'Camp registration completed successfully',
       };
 
-      // Note: Registration confirmation email will be sent after payment completion
-      // This prevents race condition where email shows "pending" status before payment is processed
+      // Send registration confirmation email immediately when the
+      // registration lands CONFIRMED (which today happens only when
+      // paymentDeferred=true and no chosen job was waitlisted). For
+      // non-deferred PENDING registrations the email is still sent by the
+      // payments webhook on completed payment. For deferred WAITLISTED
+      // registrations we skip auto-email — the standard waitlist flow
+      // handles user communication and "confirmation" copy would mislead.
+      if (
+        jobRegistration.paymentDeferred &&
+        jobRegistration.status === RegistrationStatus.CONFIRMED
+      ) {
+        // Best-effort: log and swallow failures so a transient email
+        // outage never blocks the registration response.
+        this.sendRegistrationConfirmationEmail(
+          {
+            email: user.email,
+            firstName: user.firstName ?? undefined,
+            lastName: user.lastName ?? undefined,
+            playaName: user.playaName,
+          },
+          jobRegistration,
+          campingOptionRegistrations,
+          currentYear,
+          { paymentDeferred: true },
+        ).catch((emailErr) => {
+          const message = emailErr instanceof Error ? emailErr.message : String(emailErr);
+          this.logger.warn(
+            `Failed to send deferred-registration confirmation email to ${user.email}: ${message}`,
+          );
+        });
+      }
 
       return result;
     } catch (error: unknown) {
@@ -680,20 +832,19 @@ export class RegistrationsService {
 
       const err = error as Error;
       this.logger.error(`Registration creation failed for user ${userId}: ${err.message}`, err.stack);
-      
-      // Send registration error email (non-blocking)
-      const user = await this.prisma.user.findUnique({
-        where: { id: userId },
-        select: { email: true },
-      });
-      
-      if (user) {
-        this.sendRegistrationErrorEmail(user.email, err, userId)
-          .catch(emailError => {
-            this.logger.warn(`Failed to send registration error email to ${user.email}: ${emailError.message}`);
-          });
-      }
-      
+
+      // The transaction above rolls back all writes on failure, so there
+      // is no half-created Registration or CampingOptionRegistration to
+      // clean up here. The catch only logs and emails the user.
+
+      // Send registration error email (non-blocking). Only fires for
+      // unexpected failures inside the transaction — policy/terms/conflict
+      // 4xx rejections short-circuited above and never reach this catch.
+      this.sendRegistrationErrorEmail(user.email, err, userId)
+        .catch(emailError => {
+          this.logger.warn(`Failed to send registration error email to ${user.email}: ${emailError.message}`);
+        });
+
       // Re-throw the original error
       throw error;
     }
@@ -741,7 +892,8 @@ export class RegistrationsService {
         }>;
       };
     }>,
-    year: number
+    year: number,
+    options: { paymentDeferred?: boolean } = {},
   ): Promise<void> {
     try {
       // Calculate total cost from camping options
@@ -795,6 +947,7 @@ export class RegistrationsService {
         jobs,
         totalCost: totalCost > 0 ? totalCost * 100 : undefined, // Convert to cents
         currency: 'USD',
+        paymentDeferred: options.paymentDeferred === true,
       };
 
       // Build user name for email personalization

--- a/apps/api/src/registrations/registrations.service.ts
+++ b/apps/api/src/registrations/registrations.service.ts
@@ -24,24 +24,6 @@ interface JobRegistrationWithJobs extends Registration {
   }>;
 }
 
-/**
- * Options passed to `create()` to control registration creation beyond what
- * the public DTO exposes. Used by `createCampRegistration` to flag a
- * registration as intentionally deferred (server-side enforcement of the
- * camp + per-user deferred-payment policy lives in
- * `RegistrationPolicyService`).
- */
-interface CreateRegistrationOptions {
-  /**
-   * When true, the registration is marked `paymentDeferred = true`, and
-   * if no chosen job is over capacity the status is set to `CONFIRMED`
-   * instead of `PENDING`. A waitlisted-by-capacity outcome still wins
-   * (capacity > deferral); the row is stored `WAITLISTED + paymentDeferred=true`
-   * in that case.
-   */
-  paymentDeferred?: boolean;
-}
-
 @Injectable()
 export class RegistrationsService {
   private readonly logger = new Logger(RegistrationsService.name);
@@ -53,13 +35,21 @@ export class RegistrationsService {
   ) {}
 
   /**
-   * Create a new registration for a user for a specific year
+   * Create a new registration for a user for a specific year.
+   *
+   * Used by the admin/staff `POST /registrations` endpoint and the
+   * single-job participant `POST /jobs/:id/register` endpoint. Sets
+   * status to `WAITLISTED` when any chosen job is over capacity, else
+   * `PENDING`. The deferred-payment branch lives entirely in
+   * `createCampRegistration` and is intentionally not exposed here —
+   * deferral is a participant choice tied to the policy gate, not a
+   * standalone admin operation.
+   *
    * @param createRegistrationDto - The data to create the registration
    * @returns The created registration
    */
   async create(
     createRegistrationDto: CreateRegistrationDto,
-    options: CreateRegistrationOptions = {},
   ): Promise<Registration> {
     // Check if user exists
     const user = await this.prisma.user.findUnique({
@@ -112,29 +102,21 @@ export class RegistrationsService {
       })
     );
 
-    // Determine overall registration status.
-    //   - WAITLISTED wins when any chosen job is over capacity, even for
-    //     deferred registrations (capacity > deferral preference).
-    //   - Otherwise: deferred registrations land CONFIRMED (no payment is
-    //     expected up front); non-deferred land PENDING (awaiting payment).
+    // Determine overall registration status. WAITLISTED wins when any
+    // chosen job is over capacity; otherwise PENDING (awaiting payment).
+    // The deferred-payment CONFIRMED branch is exclusive to
+    // `createCampRegistration` and lives in its own transactional write
+    // path — `create()` does not surface it.
     const hasWaitlistedJob = jobs.some(
       ({ job, currentRegistrationCount }) => currentRegistrationCount >= job.maxRegistrations
     );
-    const paymentDeferred = options.paymentDeferred === true;
-    let status: RegistrationStatus;
-    if (hasWaitlistedJob) {
-      status = RegistrationStatus.WAITLISTED;
-    } else if (paymentDeferred) {
-      status = RegistrationStatus.CONFIRMED;
-    } else {
-      status = RegistrationStatus.PENDING;
-    }
+
+    const status = hasWaitlistedJob ? RegistrationStatus.WAITLISTED : RegistrationStatus.PENDING;
 
     // Create registration with jobs
     return this.prisma.registration.create({
       data: {
         status,
-        paymentDeferred,
         year: createRegistrationDto.year,
         user: { connect: { id: createRegistrationDto.userId } },
         jobs: {

--- a/apps/api/src/registrations/services/registration-admin.service.spec.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.spec.ts
@@ -32,6 +32,7 @@ describe('RegistrationAdminService', () => {
     userId: 'user-123',
     year: 2024,
     status: RegistrationStatus.CONFIRMED,
+    paymentDeferred: false,
     createdAt: new Date('2024-01-01'),
     updatedAt: new Date('2024-01-01'),
     user: {

--- a/apps/api/src/registrations/services/registration-policy.service.spec.ts
+++ b/apps/api/src/registrations/services/registration-policy.service.spec.ts
@@ -1,0 +1,335 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { RegistrationPolicyService } from './registration-policy.service';
+import { CoreConfigService } from '../../core-config/services/core-config.service';
+
+type PolicyUser = {
+  id: string;
+  allowRegistration: boolean;
+  allowEarlyRegistration: boolean;
+  allowNoJob: boolean;
+  allowDeferredDuesPayment: boolean;
+};
+
+const buildUser = (overrides: Partial<PolicyUser> = {}): PolicyUser => ({
+  id: 'user-1',
+  allowRegistration: true,
+  allowEarlyRegistration: false,
+  allowNoJob: false,
+  allowDeferredDuesPayment: false,
+  ...overrides,
+});
+
+const buildConfig = (overrides: {
+  registrationOpen?: boolean;
+  earlyRegistrationOpen?: boolean;
+  allowDeferredDuesPayment?: boolean;
+} = {}) => ({
+  registrationOpen: false,
+  earlyRegistrationOpen: false,
+  allowDeferredDuesPayment: false,
+  ...overrides,
+});
+
+describe('RegistrationPolicyService', () => {
+  let service: RegistrationPolicyService;
+  let coreConfig: { findCurrent: jest.Mock };
+
+  beforeEach(async () => {
+    coreConfig = { findCurrent: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegistrationPolicyService,
+        { provide: CoreConfigService, useValue: coreConfig },
+      ],
+    }).compile();
+
+    service = module.get(RegistrationPolicyService);
+  });
+
+  describe('assertCanCreateCampRegistration', () => {
+    describe('per-user allowRegistration flag', () => {
+      it('throws ForbiddenException when allowRegistration is false', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ registrationOpen: true }),
+        );
+        const inputUser = buildUser({ allowRegistration: false });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+          }),
+        ).rejects.toBeInstanceOf(ForbiddenException);
+      });
+
+      it('uses the account-not-enabled message when allowRegistration is false', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ registrationOpen: true }),
+        );
+        const inputUser = buildUser({ allowRegistration: false });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+          }),
+        ).rejects.toThrow(/not available for your account/i);
+      });
+    });
+
+    describe('registration window', () => {
+      it('allows when registrationOpen is true', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ registrationOpen: true }),
+        );
+        const inputUser = buildUser();
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+          }),
+        ).resolves.toBeUndefined();
+      });
+
+      it('rejects when both windows are closed', async () => {
+        coreConfig.findCurrent.mockResolvedValue(buildConfig());
+        const inputUser = buildUser();
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+          }),
+        ).rejects.toThrow(/not currently open/i);
+      });
+
+      it('rejects when only early window is open and user is not flagged', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ earlyRegistrationOpen: true }),
+        );
+        const inputUser = buildUser({ allowEarlyRegistration: false });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+          }),
+        ).rejects.toThrow(/not currently open/i);
+      });
+
+      it('uses the same not-open message for closed and early-only-ineligible to avoid leaking state', async () => {
+        coreConfig.findCurrent
+          .mockResolvedValueOnce(buildConfig())
+          .mockResolvedValueOnce(
+            buildConfig({ earlyRegistrationOpen: true }),
+          );
+        const inputUser = buildUser({ allowEarlyRegistration: false });
+
+        const closedErr = await service
+          .assertCanCreateCampRegistration(inputUser, { jobs: ['job-1'] })
+          .catch((e) => e);
+        const earlyOnlyErr = await service
+          .assertCanCreateCampRegistration(inputUser, { jobs: ['job-1'] })
+          .catch((e) => e);
+
+        expect(closedErr.message).toBe(earlyOnlyErr.message);
+      });
+
+      it('allows early-only window when user has allowEarlyRegistration', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ earlyRegistrationOpen: true }),
+        );
+        const inputUser = buildUser({ allowEarlyRegistration: true });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+          }),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe('must-have-jobs rule', () => {
+      it('rejects when user lacks allowNoJob and jobs is empty', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ registrationOpen: true }),
+        );
+        const inputUser = buildUser({ allowNoJob: false });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, { jobs: [] }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+      });
+
+      it('allows when user has allowNoJob and jobs is empty', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ registrationOpen: true }),
+        );
+        const inputUser = buildUser({ allowNoJob: true });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, { jobs: [] }),
+        ).resolves.toBeUndefined();
+      });
+
+      it('allows when user lacks allowNoJob but has at least one job', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ registrationOpen: true }),
+        );
+        const inputUser = buildUser({ allowNoJob: false });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+          }),
+        ).resolves.toBeUndefined();
+      });
+
+      it('treats undefined jobs as empty for the requirement check', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ registrationOpen: true }),
+        );
+        const inputUser = buildUser({ allowNoJob: false });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: undefined as unknown as string[],
+          }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+      });
+    });
+
+    describe('deferred-payment gate', () => {
+      it('is a no-op when deferPayment is false', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({
+            registrationOpen: true,
+            allowDeferredDuesPayment: false,
+          }),
+        );
+        const inputUser = buildUser({ allowDeferredDuesPayment: false });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+            deferPayment: false,
+          }),
+        ).resolves.toBeUndefined();
+      });
+
+      it('rejects when deferPayment is true but camp config disallows it', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({
+            registrationOpen: true,
+            allowDeferredDuesPayment: false,
+          }),
+        );
+        const inputUser = buildUser({ allowDeferredDuesPayment: true });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+            deferPayment: true,
+          }),
+        ).rejects.toThrow(/not enabled for this camp/i);
+      });
+
+      it('rejects when deferPayment is true but per-user flag is false', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({
+            registrationOpen: true,
+            allowDeferredDuesPayment: true,
+          }),
+        );
+        const inputUser = buildUser({ allowDeferredDuesPayment: false });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+            deferPayment: true,
+          }),
+        ).rejects.toThrow(/not eligible to defer/i);
+      });
+
+      it('allows when deferPayment is true and both flags are true', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({
+            registrationOpen: true,
+            allowDeferredDuesPayment: true,
+          }),
+        );
+        const inputUser = buildUser({ allowDeferredDuesPayment: true });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+            deferPayment: true,
+          }),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe('check ordering', () => {
+      it('checks allowRegistration before window state', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ registrationOpen: false }),
+        );
+        const inputUser = buildUser({ allowRegistration: false });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: ['job-1'],
+          }),
+        ).rejects.toThrow(/not available for your account/i);
+      });
+
+      it('checks window before must-have-jobs', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({ registrationOpen: false }),
+        );
+        const inputUser = buildUser({ allowNoJob: false });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, { jobs: [] }),
+        ).rejects.toThrow(/not currently open/i);
+      });
+
+      it('checks must-have-jobs before deferred-payment gate', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({
+            registrationOpen: true,
+            allowDeferredDuesPayment: false,
+          }),
+        );
+        const inputUser = buildUser({
+          allowNoJob: false,
+          allowDeferredDuesPayment: true,
+        });
+
+        await expect(
+          service.assertCanCreateCampRegistration(inputUser, {
+            jobs: [],
+            deferPayment: true,
+          }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+      });
+
+      it('loads coreConfig exactly once per call', async () => {
+        coreConfig.findCurrent.mockResolvedValue(
+          buildConfig({
+            registrationOpen: true,
+            allowDeferredDuesPayment: true,
+          }),
+        );
+        const inputUser = buildUser({
+          allowDeferredDuesPayment: true,
+        });
+
+        await service.assertCanCreateCampRegistration(inputUser, {
+          jobs: ['job-1'],
+          deferPayment: true,
+        });
+
+        expect(coreConfig.findCurrent).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/apps/api/src/registrations/services/registration-policy.service.ts
+++ b/apps/api/src/registrations/services/registration-policy.service.ts
@@ -1,0 +1,131 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { User } from '@prisma/client';
+import { CoreConfigService } from '../../core-config/services/core-config.service';
+import { CreateCampRegistrationDto } from '../dto/create-camp-registration.dto';
+
+/**
+ * Centralized policy enforcement for participant camp registrations.
+ *
+ * Used by the participant endpoint (`POST /registrations/camp`) only. The
+ * admin/staff endpoint `POST /registrations` (gated by `@Roles(ADMIN, STAFF)`)
+ * intentionally bypasses these checks so admins can create or modify
+ * registrations as an override path.
+ *
+ * The public API is a single `assertCanCreateCampRegistration(user, dto)`
+ * method that loads the current `coreConfig` once and runs every applicable
+ * check in a defined order. This makes it impossible for a caller to forget
+ * one of the gates.
+ */
+@Injectable()
+export class RegistrationPolicyService {
+  private readonly logger = new Logger(RegistrationPolicyService.name);
+
+  constructor(private readonly coreConfigService: CoreConfigService) {}
+
+  /**
+   * Run every camp-registration policy check against the calling user and
+   * the submitted DTO. Throws a NestJS HttpException on the first failure;
+   * returns silently on success.
+   *
+   * Order of checks (each takes precedence over the next):
+   *   1. `assertRegistrationOpen(user, config)` — eligibility + window.
+   *   2. `assertJobsRequirementMet(user, dto.jobs)` — must-have-jobs.
+   *   3. `assertDeferAllowed(user, config, dto.deferPayment)` — only when
+   *      the participant is opting to defer; verifies camp + user flags.
+   */
+  async assertCanCreateCampRegistration(
+    user: Pick<
+      User,
+      | 'id'
+      | 'allowRegistration'
+      | 'allowEarlyRegistration'
+      | 'allowNoJob'
+      | 'allowDeferredDuesPayment'
+    >,
+    dto: Pick<CreateCampRegistrationDto, 'jobs' | 'deferPayment'>,
+  ): Promise<void> {
+    const config = await this.coreConfigService.findCurrent();
+
+    this.assertRegistrationOpen(user, {
+      registrationOpen: config.registrationOpen,
+      earlyRegistrationOpen: config.earlyRegistrationOpen,
+    });
+    this.assertJobsRequirementMet(user, dto.jobs ?? []);
+    this.assertDeferAllowed(
+      user,
+      { allowDeferredDuesPayment: config.allowDeferredDuesPayment },
+      dto.deferPayment ?? false,
+    );
+  }
+
+  /**
+   * Window + per-user eligibility check.
+   *
+   * Rules (first match wins):
+   *   1. If `!user.allowRegistration` → 403 "account not enabled".
+   *   2. If `registrationOpen` is true → allow.
+   *   3. If `earlyRegistrationOpen` is true AND
+   *      `user.allowEarlyRegistration` is true → allow.
+   *   4. Otherwise → 403 "registration not currently open".
+   *
+   * Note: the same message is used for "fully closed" and "early-only and
+   * not eligible" so the early-window state is not leaked to ineligible
+   * participants. The client `registrationUtils.ts` already does the same.
+   */
+  private assertRegistrationOpen(
+    user: Pick<User, 'allowRegistration' | 'allowEarlyRegistration'>,
+    config: { registrationOpen: boolean; earlyRegistrationOpen: boolean },
+  ): void {
+    if (!user.allowRegistration) {
+      throw new ForbiddenException(
+        'Registration is not available for your account. Please contact an administrator.',
+      );
+    }
+    if (config.registrationOpen) return;
+    if (config.earlyRegistrationOpen && user.allowEarlyRegistration) return;
+    throw new ForbiddenException('Registration is not currently open.');
+  }
+
+  /**
+   * Must-have-jobs check. Throws BadRequestException if the user is not
+   * flagged `allowNoJob` and the DTO carries an empty `jobs` array.
+   */
+  private assertJobsRequirementMet(
+    user: Pick<User, 'allowNoJob'>,
+    jobIds: string[],
+  ): void {
+    if (user.allowNoJob) return;
+    if (jobIds.length > 0) return;
+    throw new BadRequestException(
+      'You must select at least one work shift to register.',
+    );
+  }
+
+  /**
+   * Deferred-payment eligibility check. No-op when the participant is not
+   * opting to defer. Otherwise both the camp-wide config flag and the
+   * per-user flag must be true.
+   */
+  private assertDeferAllowed(
+    user: Pick<User, 'allowDeferredDuesPayment'>,
+    config: { allowDeferredDuesPayment: boolean },
+    deferPayment: boolean,
+  ): void {
+    if (!deferPayment) return;
+    if (!config.allowDeferredDuesPayment) {
+      throw new ForbiddenException(
+        'Deferred payment is not enabled for this camp.',
+      );
+    }
+    if (!user.allowDeferredDuesPayment) {
+      throw new ForbiddenException(
+        'Your account is not eligible to defer payment.',
+      );
+    }
+  }
+}

--- a/apps/web/src/components/admin/registrations/RegistrationSearchTable.tsx
+++ b/apps/web/src/components/admin/registrations/RegistrationSearchTable.tsx
@@ -7,6 +7,12 @@ interface Registration {
   id: string;
   year: number;
   status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'WAITLISTED';
+  /**
+   * When true the registration was created as CONFIRMED with payment
+   * deferred. Surfaced in the admin table next to the status so admins
+   * can distinguish "paid CONFIRMED" from "deferred CONFIRMED".
+   */
+  paymentDeferred?: boolean;
   createdAt: string;
   user: {
     id: string;
@@ -103,19 +109,29 @@ export function RegistrationSearchTable({
         id: 'status',
         header: 'Status',
         accessor: (row) => (
-          <span
-            className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-              row.status === 'CONFIRMED'
-                ? 'bg-green-100 text-green-800'
-                : row.status === 'PENDING'
-                ? 'bg-yellow-100 text-yellow-800'
-                : row.status === 'WAITLISTED'
-                ? 'bg-blue-100 text-blue-800'
-                : 'bg-red-100 text-red-800'
-            }`}
-          >
-            {row.status}
-          </span>
+          <div className="flex items-center gap-1">
+            <span
+              className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                row.status === 'CONFIRMED'
+                  ? 'bg-green-100 text-green-800'
+                  : row.status === 'PENDING'
+                  ? 'bg-yellow-100 text-yellow-800'
+                  : row.status === 'WAITLISTED'
+                  ? 'bg-blue-100 text-blue-800'
+                  : 'bg-red-100 text-red-800'
+              }`}
+            >
+              {row.status}
+            </span>
+            {row.paymentDeferred && (
+              <span
+                className="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-amber-100 text-amber-800"
+                title="Participant opted to defer dues payment"
+              >
+                Deferred
+              </span>
+            )}
+          </div>
         ),
         sortable: true,
       },

--- a/apps/web/src/hooks/useRegistration.ts
+++ b/apps/web/src/hooks/useRegistration.ts
@@ -7,6 +7,13 @@ export interface RegistrationFormData {
   customFields: Record<string, unknown>;
   jobs: string[];  // Changed from shifts to jobs
   acceptedTerms: boolean;
+  /**
+   * When true, the participant is opting to defer dues payment. The server
+   * enforces eligibility (`coreConfig.allowDeferredDuesPayment` AND
+   * `user.allowDeferredDuesPayment`) and rejects with 403 otherwise; the
+   * client should only set this when the "Pay Dues Later" button is shown.
+   */
+  deferPayment?: boolean;
 }
 
 // Using JobSchema and ShiftSchema from api.ts instead of redefining them here

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -450,6 +450,12 @@ export interface Registration {
   userId: string;
   year: number;
   status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'WAITLISTED';
+  /**
+   * When true, the participant opted to defer dues payment. The registration
+   * is CONFIRMED (no payment required up front); the dashboard should still
+   * surface a "Pay Now" CTA and a "Payment Deferred" indicator.
+   */
+  paymentDeferred?: boolean;
   createdAt: string;
   updatedAt: string;
   user?: User;

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -114,16 +114,91 @@ const DashboardPage: React.FC = () => {
                 <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
                   <div className="flex items-center justify-between">
                     <h4 className="font-medium text-blue-900">Registration Status</h4>
-                    <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                      currentRegistration.status === 'CONFIRMED' ? 'bg-green-100 text-green-800' :
-                      currentRegistration.status === 'PENDING' ? 'bg-yellow-100 text-yellow-800' :
-                      currentRegistration.status === 'WAITLISTED' ? 'bg-orange-100 text-orange-800' :
-                      'bg-gray-100 text-gray-800'
-                    }`}>
-                      {currentRegistration.status}
-                    </span>
+                    <div className="flex items-center gap-2">
+                      <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                        currentRegistration.status === 'CONFIRMED' ? 'bg-green-100 text-green-800' :
+                        currentRegistration.status === 'PENDING' ? 'bg-yellow-100 text-yellow-800' :
+                        currentRegistration.status === 'WAITLISTED' ? 'bg-orange-100 text-orange-800' :
+                        'bg-gray-100 text-gray-800'
+                      }`}>
+                        {currentRegistration.status}
+                      </span>
+                      {currentRegistration.paymentDeferred && (
+                        <span className="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-amber-100 text-amber-800">
+                          Payment Deferred
+                        </span>
+                      )}
+                    </div>
                   </div>
                 </div>
+
+                {/* Deferred Payment CTA — surfaces a Pay Now button for
+                    CONFIRMED registrations created with paymentDeferred=true.
+                    Excludes WAITLISTED: payment must not buy a slot the
+                    user can't have (capacity > payment), and the payments
+                    webhook will refuse to promote WAITLISTED → CONFIRMED.
+                    Distinct loading / error states avoid the trap where
+                    the badge shows but the CTA is hidden because the
+                    camp-registration query is still in flight. */}
+                {currentRegistration.paymentDeferred &&
+                  currentRegistration.status === 'CONFIRMED' && (
+                  <>
+                    {campLoading && (
+                      <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg flex items-center">
+                        <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-amber-600 mr-3"></div>
+                        <span className="text-sm text-amber-800">Loading deferred dues…</span>
+                      </div>
+                    )}
+                    {!campLoading && campError && (
+                      <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg">
+                        <h5 className="font-medium text-amber-900">Deferred Dues</h5>
+                        <p className="text-sm text-amber-800">
+                          We couldn't load your deferred dues right now. Please refresh or contact the admins to complete payment.
+                        </p>
+                      </div>
+                    )}
+                    {!campLoading && !campError && (() => {
+                      const isStaffOrAdmin =
+                        user?.role === 'staff' || user?.role === 'admin';
+                      const deferredAmount =
+                        campRegistration?.campingOptions.reduce((sum, opt) => {
+                          const dues = isStaffOrAdmin
+                            ? opt.campingOption?.staffDues
+                            : opt.campingOption?.participantDues;
+                          return sum + (dues ?? 0);
+                        }, 0) ?? 0;
+
+                      if (deferredAmount <= 0) return null;
+
+                      return (
+                        <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg">
+                          <div className="flex items-center justify-between mb-3">
+                            <div>
+                              <h5 className="font-medium text-amber-900">Deferred Dues</h5>
+                              <p className="text-sm text-amber-800">
+                                You opted to defer payment. Complete your ${deferredAmount.toFixed(2)} dues whenever you're ready.
+                              </p>
+                            </div>
+                          </div>
+                          <PaymentButton
+                            amount={deferredAmount}
+                            registrationId={currentRegistration.id}
+                            description={`${config?.name || 'Camp'} Deferred Dues Payment ${config?.currentYear || new Date().getFullYear()}`}
+                            onPaymentStart={() => {
+                              console.log('Completing deferred payment for registration:', currentRegistration.id);
+                            }}
+                            onPaymentError={(error) => {
+                              console.error('Payment error:', error);
+                            }}
+                            className="w-full"
+                          >
+                            Pay Now - ${deferredAmount.toFixed(2)}
+                          </PaymentButton>
+                        </div>
+                      );
+                    })()}
+                  </>
+                )}
 
                 {/* Work Shifts Section */}
                 {currentRegistration.jobs.length > 0 && (

--- a/apps/web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/pages/__tests__/DashboardPage.test.tsx
@@ -456,6 +456,235 @@ describe('DashboardPage Registration Status', () => {
       expect(screen.queryByTestId('payment-button')).not.toBeInTheDocument();
     });
   });
+
+  /**
+   * Coverage for the deferred-payment dashboard UX introduced with #160:
+   * a CONFIRMED registration with paymentDeferred=true must surface both
+   * a "Payment Deferred" badge AND a "Pay Now" CTA driven by the camping
+   * option dues (no PENDING payment row exists for a deferred reg).
+   */
+  describe('Deferred payment registration', () => {
+    const baseDeferredRegistration = {
+      id: 'reg-deferred-1',
+      userId: 'user-1',
+      year: 2025,
+      status: 'CONFIRMED' as const,
+      paymentDeferred: true,
+      jobs: [],
+      payments: [],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+
+    const openConfig = {
+      name: 'Test Camp',
+      description: 'Test Description',
+      homePageBlurb: 'Test Blurb',
+      registrationOpen: true,
+      earlyRegistrationOpen: false,
+      currentYear: 2025,
+    };
+
+    beforeEach(() => {
+      mockUseConfig.mockReturnValue({
+        config: openConfig,
+        isLoading: false,
+        error: null,
+        refreshConfig: vi.fn(),
+        isConnecting: false,
+        isConnected: true,
+        connectionError: null,
+      });
+    });
+
+    it('renders a Payment Deferred badge for a deferred CONFIRMED registration', () => {
+      mockUseUserRegistrations.mockReturnValue({
+        registrations: [baseDeferredRegistration],
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      mockUseCampRegistration.mockReturnValue({
+        campRegistration: {
+          campingOptions: [],
+          customFieldValues: [],
+          jobRegistrations: [],
+          hasRegistration: true,
+        },
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      render(<DashboardPageWrapper />);
+
+      expect(screen.getByText('Payment Deferred')).toBeInTheDocument();
+    });
+
+    it('renders the Pay Now CTA with the dues amount computed from camping options', () => {
+      mockUseUserRegistrations.mockReturnValue({
+        registrations: [baseDeferredRegistration],
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      mockUseCampRegistration.mockReturnValue({
+        campRegistration: {
+          campingOptions: [
+            {
+              id: 'cor-1',
+              userId: 'user-1',
+              campingOptionId: 'opt-1',
+              createdAt: '2025-01-01T00:00:00.000Z',
+              updatedAt: '2025-01-01T00:00:00.000Z',
+              campingOption: {
+                id: 'opt-1',
+                name: 'Standard',
+                description: null,
+                enabled: true,
+                workShiftsRequired: 0,
+                participantDues: 200,
+                staffDues: 100,
+                maxSignups: 100,
+                createdAt: '2025-01-01T00:00:00.000Z',
+                updatedAt: '2025-01-01T00:00:00.000Z',
+                fields: [],
+              },
+            },
+          ],
+          customFieldValues: [],
+          jobRegistrations: [],
+          hasRegistration: true,
+        },
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      render(<DashboardPageWrapper />);
+
+      const payButton = screen.getByTestId('payment-button');
+      expect(payButton).toBeInTheDocument();
+      expect(payButton).toHaveAttribute('data-amount', '200');
+      expect(payButton).toHaveTextContent('Pay Now - $200.00');
+    });
+
+    it('omits the deferred CTA when camping options total $0', () => {
+      mockUseUserRegistrations.mockReturnValue({
+        registrations: [baseDeferredRegistration],
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      mockUseCampRegistration.mockReturnValue({
+        campRegistration: {
+          campingOptions: [],
+          customFieldValues: [],
+          jobRegistrations: [],
+          hasRegistration: true,
+        },
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      render(<DashboardPageWrapper />);
+
+      // Badge still renders (status indicator); CTA does not (nothing to pay).
+      expect(screen.getByText('Payment Deferred')).toBeInTheDocument();
+      expect(screen.queryByTestId('payment-button')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the Pay Now CTA for a WAITLISTED deferred registration (capacity wins)', () => {
+      mockUseUserRegistrations.mockReturnValue({
+        registrations: [{ ...baseDeferredRegistration, status: 'WAITLISTED' as const }],
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      mockUseCampRegistration.mockReturnValue({
+        campRegistration: {
+          campingOptions: [
+            {
+              id: 'cor-1',
+              userId: 'user-1',
+              campingOptionId: 'opt-1',
+              createdAt: '2025-01-01T00:00:00.000Z',
+              updatedAt: '2025-01-01T00:00:00.000Z',
+              campingOption: {
+                id: 'opt-1',
+                name: 'Standard',
+                description: null,
+                enabled: true,
+                workShiftsRequired: 0,
+                participantDues: 200,
+                staffDues: 100,
+                maxSignups: 100,
+                createdAt: '2025-01-01T00:00:00.000Z',
+                updatedAt: '2025-01-01T00:00:00.000Z',
+                fields: [],
+              },
+            },
+          ],
+          customFieldValues: [],
+          jobRegistrations: [],
+          hasRegistration: true,
+        },
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      render(<DashboardPageWrapper />);
+
+      // Badge shows (registration IS deferred), but the Pay Now CTA is
+      // hidden because a WAITLISTED registration must not buy a slot
+      // the user can't have. The payments webhook also refuses to
+      // promote WAITLISTED → CONFIRMED on payment.
+      expect(screen.getByText('Payment Deferred')).toBeInTheDocument();
+      expect(screen.queryByTestId('payment-button')).not.toBeInTheDocument();
+    });
+
+    it('renders a loading state for deferred dues while the camp registration query is in flight (no CTA, no error)', () => {
+      mockUseUserRegistrations.mockReturnValue({
+        registrations: [baseDeferredRegistration],
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      mockUseCampRegistration.mockReturnValue({
+        campRegistration: null,
+        loading: true,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      render(<DashboardPageWrapper />);
+
+      expect(screen.getByText(/Loading deferred dues/i)).toBeInTheDocument();
+      expect(screen.queryByTestId('payment-button')).not.toBeInTheDocument();
+    });
+
+    it('renders an error message for deferred dues when the camp registration query fails (no silent CTA hide)', () => {
+      mockUseUserRegistrations.mockReturnValue({
+        registrations: [baseDeferredRegistration],
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      mockUseCampRegistration.mockReturnValue({
+        campRegistration: null,
+        loading: false,
+        error: 'Failed to fetch camp registration',
+        refetch: vi.fn(),
+      });
+
+      render(<DashboardPageWrapper />);
+
+      expect(screen.getByText(/couldn't load your deferred dues/i)).toBeInTheDocument();
+      expect(screen.queryByTestId('payment-button')).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe('DashboardPage - Registration after cancellation', () => {

--- a/apps/web/src/pages/registration/RegistrationPage.tsx
+++ b/apps/web/src/pages/registration/RegistrationPage.tsx
@@ -1292,7 +1292,19 @@ export default function RegistrationPage() {
                 try {
                   // Create registration if it doesn't exist yet
                   if (!registrationId) {
-                    const result = await submitRegistration(formData);
+                    // When totalCost > 0, this branch corresponds to the
+                    // "Pay Dues Later" CTA — flag the submission so the
+                    // server creates the registration as CONFIRMED with
+                    // paymentDeferred=true and skips the payment step.
+                    // For totalCost === 0 ("free") there's nothing to
+                    // defer, so we omit the flag and the registration
+                    // lands PENDING per the current free-registration
+                    // semantics.
+                    const submission =
+                      totalCost > 0
+                        ? { ...formData, deferPayment: true }
+                        : formData;
+                    const result = await submitRegistration(submission);
                     if (result?.jobRegistration?.id) {
                       setRegistrationId(result.jobRegistration.id);
                     }

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -107,6 +107,12 @@ export interface Registration {
   userId: string;
   year: number;
   status: RegistrationStatus;
+  /**
+   * When true, the participant opted to defer dues payment. The registration
+   * is CONFIRMED (no payment required up front); the dashboard should still
+   * surface a "Pay Now" CTA and a "Payment Deferred" indicator.
+   */
+  paymentDeferred?: boolean;
   createdAt: string;
   updatedAt: string;
   user?: User;

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -33,6 +33,16 @@ interface FreshFixtures {
    * allowDeferredDuesPayment is enabled by seed.e2e.ts.
    */
   freshDeferredParticipant: FreshUser;
+  /**
+   * Same as freshParticipant but with allowNoJob=true so the server accepts
+   * a registration with an empty jobs array.
+   */
+  freshNoJobParticipant: FreshUser;
+  /**
+   * Same as freshParticipant but with allowRegistration=false. The server
+   * should reject every camp-registration attempt by this user.
+   */
+  freshDisabledParticipant: FreshUser;
 }
 
 interface CreateOpts {
@@ -46,6 +56,11 @@ interface CreateOpts {
     allowDeferredDuesPayment?: boolean;
     allowEarlyRegistration?: boolean;
     allowNoJob?: boolean;
+    /**
+     * Per-user opt-out from self-registration. Defaults to `true` (matches
+     * the schema default); set to `false` to test the rejection path.
+     */
+    allowRegistration?: boolean;
   };
 }
 
@@ -65,6 +80,7 @@ async function createAndLogin(page: import('@playwright/test').Page, opts: Creat
     isEmailVerified: true,
     phone: '555-0100',
     emergencyContact: 'E2E Auto, 555-0199, friend',
+    allowRegistration: opts.flags?.allowRegistration ?? true,
     allowDeferredDuesPayment: opts.flags?.allowDeferredDuesPayment ?? false,
     allowEarlyRegistration: opts.flags?.allowEarlyRegistration ?? false,
     allowNoJob: opts.flags?.allowNoJob ?? false,
@@ -78,6 +94,7 @@ async function createAndLogin(page: import('@playwright/test').Page, opts: Creat
     update: {
       role: opts.role,
       isEmailVerified: true,
+      allowRegistration: baseData.allowRegistration,
       allowDeferredDuesPayment: baseData.allowDeferredDuesPayment,
       allowEarlyRegistration: baseData.allowEarlyRegistration,
       allowNoJob: baseData.allowNoJob,
@@ -120,6 +137,26 @@ export const test = base.extend<FreshFixtures>({
       workerIndex: testInfo.workerIndex,
       retry: testInfo.retry,
       flags: { allowDeferredDuesPayment: true },
+    });
+    await use(user);
+  },
+  freshNoJobParticipant: async ({ page }, use, testInfo) => {
+    const user = await createAndLogin(page, {
+      role: 'PARTICIPANT',
+      scope: `${testInfo.file}:${testInfo.title}`,
+      workerIndex: testInfo.workerIndex,
+      retry: testInfo.retry,
+      flags: { allowNoJob: true },
+    });
+    await use(user);
+  },
+  freshDisabledParticipant: async ({ page }, use, testInfo) => {
+    const user = await createAndLogin(page, {
+      role: 'PARTICIPANT',
+      scope: `${testInfo.file}:${testInfo.title}`,
+      workerIndex: testInfo.workerIndex,
+      retry: testInfo.retry,
+      flags: { allowRegistration: false },
     });
     await use(user);
   },

--- a/tests/registration/register-deferred.spec.ts
+++ b/tests/registration/register-deferred.spec.ts
@@ -3,18 +3,19 @@
  *  - End-to-end deferred-dues path: a participant with allowDeferredDuesPayment
  *    set both at config and user level should see "Pay Dues Later" instead of
  *    Stripe Checkout, complete registration without paying, and land on the
- *    dashboard with a PENDING registration and no completed payment.
+ *    dashboard with a CONFIRMED registration carrying paymentDeferred=true
+ *    and no completed payment.
  *
- * Note on status: the registration is created by `createCampRegistration`
- * which calls `create()` with the user's chosen jobs. That sets the row to
- * PENDING (or WAITLISTED if a chosen job is full); the only path that today
- * transitions a registration to CONFIRMED is a successful payment in
- * `payments.service.ts`. Server-side promotion of deferred registrations is
- * tracked as a separate follow-up to issue #154.
+ * Server semantics (post-#160): when the client sends `deferPayment: true`
+ * to POST /registrations/camp and policy allows it (both coreConfig and
+ * per-user flag are true), the registration is created with status =
+ * CONFIRMED and paymentDeferred = true. A later successful payment via the
+ * dashboard's "Pay Now" CTA clears paymentDeferred.
  */
 import { test, expect } from '../helpers/fixtures';
 import { walkRegistrationToPayment } from '../helpers/registration';
 import { getPrisma } from '../helpers/db';
+import { payViaStripeCheckout } from '../helpers/stripe';
 
 test.describe(
   'Registration: deferred dues',
@@ -44,11 +45,58 @@ test.describe(
           orderBy: { createdAt: 'desc' },
         });
         expect(reg).not.toBeNull();
-        expect(reg!.status).toBe('PENDING');
+        expect(reg!.status).toBe('CONFIRMED');
+        expect(reg!.paymentDeferred).toBe(true);
         expect(reg!.year).toBe(new Date().getFullYear());
         expect(reg!.jobs.length).toBeGreaterThanOrEqual(2);
         const completed = reg!.payments.filter((p) => p.status === 'COMPLETED');
         expect(completed).toHaveLength(0);
+
+        // Dashboard surfaces the deferred-payment indicator so the user
+        // knows to circle back later.
+        await expect(page.getByText(/payment deferred/i)).toBeVisible();
+      },
+    );
+
+    test(
+      'deferred participant can later complete payment, clearing paymentDeferred',
+      async ({ page, freshDeferredParticipant }) => {
+        test.setTimeout(120_000);
+
+        // First, walk through registration choosing the deferred path.
+        await walkRegistrationToPayment(page);
+        await page.getByRole('button', { name: /pay dues later/i }).click();
+        await expect(page).toHaveURL(/#\/dashboard/, { timeout: 15_000 });
+
+        // Sanity: registration landed CONFIRMED + paymentDeferred=true.
+        const prisma = getPrisma();
+        const regBefore = await prisma.registration.findFirst({
+          where: { userId: freshDeferredParticipant.id },
+          orderBy: { createdAt: 'desc' },
+        });
+        expect(regBefore?.status).toBe('CONFIRMED');
+        expect(regBefore?.paymentDeferred).toBe(true);
+
+        // Dashboard should expose a Pay Now CTA for the deferred dues.
+        const payNow = page.getByRole('button', { name: /pay now/i });
+        await expect(payNow).toBeVisible({ timeout: 15_000 });
+        await payNow.click();
+
+        // Stripe Checkout — drop in a test card and submit.
+        await payViaStripeCheckout(page, { card: 'visa' });
+
+        // Back in-app, the registration row should have paymentDeferred=false.
+        await expect(page).toHaveURL(/#\/dashboard|#\/payment/, { timeout: 30_000 });
+
+        const regAfter = await prisma.registration.findFirst({
+          where: { userId: freshDeferredParticipant.id },
+          include: { payments: true },
+          orderBy: { createdAt: 'desc' },
+        });
+        expect(regAfter?.status).toBe('CONFIRMED');
+        expect(regAfter?.paymentDeferred).toBe(false);
+        const completed = regAfter!.payments.filter((p) => p.status === 'COMPLETED');
+        expect(completed.length).toBeGreaterThanOrEqual(1);
       },
     );
   },

--- a/tests/registration/register-deferred.spec.ts
+++ b/tests/registration/register-deferred.spec.ts
@@ -82,11 +82,22 @@ test.describe(
         await expect(payNow).toBeVisible({ timeout: 15_000 });
         await payNow.click();
 
-        // Stripe Checkout — drop in a test card and submit.
-        await payViaStripeCheckout(page, { card: 'visa' });
+        // Stripe Checkout — drop in a test card and submit. `success` is
+        // the standard Stripe test-mode happy-path card from STRIPE_TEST_CARDS
+        // in tests/helpers/stripe.ts.
+        await payViaStripeCheckout(page, { card: 'success' });
 
-        // Back in-app, the registration row should have paymentDeferred=false.
-        await expect(page).toHaveURL(/#\/dashboard|#\/payment/, { timeout: 30_000 });
+        // After redirect back to /#/payment-success, the page calls
+        // `handleStripeSuccess` which hits POST /payments/verify-stripe-session.
+        // That endpoint is what flips `paymentDeferred` to false on the
+        // registration. Wait for the in-page spinner to disappear before
+        // reading the DB so we don't race the verification request.
+        await expect(page).toHaveURL(/#\/payment(-success)?|#\/dashboard/, {
+          timeout: 30_000,
+        });
+        await expect(page.getByText(/processing your payment/i)).toHaveCount(0, {
+          timeout: 30_000,
+        });
 
         const regAfter = await prisma.registration.findFirst({
           where: { userId: freshDeferredParticipant.id },

--- a/tests/registration/register-policy.spec.ts
+++ b/tests/registration/register-policy.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Server-side policy enforcement for POST /registrations/camp.
+ *
+ * Covers issues #158 / #159 / #160 for the cases that can be exercised
+ * without mutating the shared `coreConfig` row (which would race other
+ * parallel specs). The window-based checks
+ * (`registrationOpen`/`earlyRegistrationOpen` × `allowEarlyRegistration`)
+ * are fully covered by the policy-service unit tests in
+ * `apps/api/src/registrations/services/registration-policy.service.spec.ts`.
+ *
+ * Success cases for the deferred path live in `register-deferred.spec.ts`.
+ */
+import { test, expect } from '../helpers/fixtures';
+import { createAuthedApiClient } from '../helpers/api';
+import { getPrisma } from '../helpers/db';
+
+test.describe(
+  'Registration: server-side policy',
+  { tag: ['@registration', '@policy'] },
+  () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    /**
+     * Helper: find a real campingOption id (created by seed.ts) and a real
+     * job id (so the registration would otherwise succeed and the only
+     * thing left to reject is the policy gate).
+     */
+    async function findSeededIds(): Promise<{ campingOptionId: string; jobId: string }> {
+      const prisma = getPrisma();
+      const option = await prisma.campingOption.findFirst({ where: { enabled: true } });
+      const job = await prisma.job.findFirst();
+      if (!option || !job) {
+        throw new Error('Seed data missing: need at least one camping option and one job');
+      }
+      return { campingOptionId: option.id, jobId: job.id };
+    }
+
+    test(
+      'rejects POST /registrations/camp when user.allowRegistration=false',
+      async ({ freshDisabledParticipant }) => {
+        const { campingOptionId, jobId } = await findSeededIds();
+        const api = await createAuthedApiClient(freshDisabledParticipant.email);
+        try {
+          const res = await api.context.post('/registrations/camp', {
+            data: {
+              campingOptions: [campingOptionId],
+              jobs: [jobId],
+              acceptedTerms: true,
+            },
+          });
+          expect(res.status()).toBe(403);
+          const body = await res.json();
+          expect(JSON.stringify(body)).toMatch(/not available for your account/i);
+        } finally {
+          await api.dispose();
+        }
+      },
+    );
+
+    test(
+      'rejects POST /registrations/camp when user.allowNoJob=false and jobs is empty',
+      async ({ freshParticipant }) => {
+        const { campingOptionId } = await findSeededIds();
+        const api = await createAuthedApiClient(freshParticipant.email);
+        try {
+          const res = await api.context.post('/registrations/camp', {
+            data: {
+              campingOptions: [campingOptionId],
+              jobs: [],
+              acceptedTerms: true,
+            },
+          });
+          expect(res.status()).toBe(400);
+          const body = await res.json();
+          expect(JSON.stringify(body)).toMatch(/at least one work shift/i);
+        } finally {
+          await api.dispose();
+        }
+      },
+    );
+
+    test(
+      'allows POST /registrations/camp with empty jobs when user.allowNoJob=true',
+      async ({ freshNoJobParticipant }) => {
+        const { campingOptionId } = await findSeededIds();
+        const api = await createAuthedApiClient(freshNoJobParticipant.email);
+        try {
+          const res = await api.context.post('/registrations/camp', {
+            data: {
+              campingOptions: [campingOptionId],
+              jobs: [],
+              acceptedTerms: true,
+            },
+          });
+          expect(res.status()).toBeGreaterThanOrEqual(200);
+          expect(res.status()).toBeLessThan(300);
+
+          // The new behavior is "always create a Registration row, even with
+          // no jobs" — verify the row exists and renders with jobs: [].
+          const prisma = getPrisma();
+          const reg = await prisma.registration.findFirst({
+            where: { userId: freshNoJobParticipant.id },
+            include: { jobs: true },
+            orderBy: { createdAt: 'desc' },
+          });
+          expect(reg).not.toBeNull();
+          expect(reg!.jobs).toEqual([]);
+        } finally {
+          await api.dispose();
+        }
+      },
+    );
+
+    test(
+      'rejects POST /registrations/camp with deferPayment=true when user is not eligible to defer',
+      async ({ freshParticipant }) => {
+        const { campingOptionId, jobId } = await findSeededIds();
+        const api = await createAuthedApiClient(freshParticipant.email);
+        try {
+          const res = await api.context.post('/registrations/camp', {
+            data: {
+              campingOptions: [campingOptionId],
+              jobs: [jobId],
+              acceptedTerms: true,
+              deferPayment: true,
+            },
+          });
+          expect(res.status()).toBe(403);
+          const body = await res.json();
+          expect(JSON.stringify(body)).toMatch(/not eligible to defer/i);
+        } finally {
+          await api.dispose();
+        }
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Server-side enforcement of registration policy on `POST /registrations/camp` and a full server-side concept of a "deferred-payment" registration. Closes [#158](https://github.com/ChrisRomp/playa-plan/issues/158), [#159](https://github.com/ChrisRomp/playa-plan/issues/159), and [#160](https://github.com/ChrisRomp/playa-plan/issues/160).

### What it does

#### Policy (#158, #159)

- New `RegistrationPolicyService` with a single public `assertCanCreateCampRegistration(user, dto)` that loads `coreConfig` once and runs three checks in order: `allowRegistration`, registration window (`registrationOpen` OR `earlyRegistrationOpen` AND `allowEarlyRegistration`), and must-have-jobs (`allowNoJob`). Same 403 message for "closed" and "early-only and ineligible" avoids leaking the early-window state.
- Wired into `RegistrationsService.createCampRegistration` **before** the broad try/catch so policy 4xx rejections don't trigger the registration-error email.
- Pre-flight validation (active-registration conflict, camping option existence + duplicate check) moved out of the broad try/catch for the same reason.
- `createCampRegistration` now **always** creates a `Registration` row, even when `jobs` is empty (relies on the policy service to enforce `allowNoJob`). Previously a no-jobs signup silently created no Registration at all — broken on its own and a prerequisite for deferred semantics for `allowNoJob=true` users.

#### Deferred payment (#160)

- New `paymentDeferred Boolean @default(false)` column on `Registration` (migration `20260518023418_add_payment_deferred_to_registration`).
- DTO: optional `deferPayment?: boolean` on `CreateCampRegistrationDto`.
- Policy: rejects 403 when `deferPayment=true` but coreConfig or per-user flag is false.
- Status semantics: deferred + no waitlisted job → `CONFIRMED + paymentDeferred=true`. Deferred + any over-capacity job → still `WAITLISTED + paymentDeferred=true` (capacity beats deferral).
- Confirmation email sent immediately on deferred CONFIRMED (template renders a "Payment Deferred — please complete dues payment later" line). Skipped on WAITLISTED+deferred (use the standard waitlist flow).
- Payment-completion path: widened guard in `verifyStripeSession` so retries on a deferred → paid transition reliably clear the flag. New private `markRegistrationPaid` helper, also called from `recordManualPayment`. **WAITLISTED registrations are NOT promoted to CONFIRMED on payment** — payment must not buy a slot the user can't have. Post-payment confirmation email is suppressed for deferred → paid transitions (user already got an email at registration time).

#### Atomicity

- The full `createCampRegistration` write set — `Registration` + `RegistrationJob`s + `CampingOptionRegistration`s + `CampingOptionFieldValue`s — is now wrapped in a single `prisma.$transaction`. Without this wrap, `CampingOptionRegistration` has no FK to `Registration` so a downstream failure would leave orphaned camping-option rows that block retries with "already registered for camping option X".

#### Frontend

- "Pay Dues Later" sends `deferPayment: true`; `Registration` types gain `paymentDeferred`.
- `DashboardPage`:
  - "Payment Deferred" badge next to status for any deferred registration.
  - New "Pay Now" CTA — but ONLY when `status === CONFIRMED` (WAITLISTED deferred users see the badge with no CTA). Amount computed from camping option dues (staff/admin uses `staffDues`, else `participantDues`).
  - Distinct loading and error states for the deferred section so a slow/failed camp-registration query doesn't silently hide the CTA leaving the badge alone.
- `RegistrationSearchTable` (admin): distinguishes paid CONFIRMED from deferred CONFIRMED with a separate "Deferred" badge.

### Key changes

- `apps/api/prisma/schema.prisma` + migration: `paymentDeferred Boolean @default(false)` on `Registration`.
- `apps/api/src/registrations/services/registration-policy.service.ts` (new) + spec.
- `apps/api/src/registrations/registrations.service.ts`: policy wiring, `$transaction` wrap, always-create-Registration, deferred-CONFIRMED email path, pre-flight validation outside try/catch.
- `apps/api/src/registrations/dto/create-camp-registration.dto.ts`: `deferPayment` field; relaxed `@IsNotEmpty` on `jobs`.
- `apps/api/src/registrations/registrations.module.ts`: register policy service; import `CoreConfigModule`.
- `apps/api/src/payments/services/payments.service.ts`: `markRegistrationPaid` helper; widened deferred-clear guard; **respects WAITLISTED**; suppresses duplicate email on deferred-paid; manual-payment side-effect.
- `apps/api/src/notifications/services/notifications.service.ts`: `paymentDeferred` flag in registration-confirmation payload + conditional template line.
- `apps/web/src/pages/registration/RegistrationPage.tsx`, `useRegistration.ts`, `lib/api.ts`, `types/index.ts`: client-side `deferPayment` plumbing.
- `apps/web/src/pages/DashboardPage.tsx`: deferred badge + Pay Now CTA + loading/error/WAITLISTED branches.
- `apps/web/src/components/admin/registrations/RegistrationSearchTable.tsx`: deferred indicator.
- `tests/registration/register-deferred.spec.ts`: flipped to assert `CONFIRMED + paymentDeferred=true`; new second test that walks the deferred path then pays via Stripe checkout and asserts the flag clears.
- `tests/registration/register-policy.spec.ts` (new): per-user rejection paths (`allowRegistration=false`, `allowNoJob=false`+empty jobs, deferred-ineligible). Window-based cases stay in unit tests to avoid racing parallel specs on shared `coreConfig`.
- `tests/helpers/fixtures.ts`: new fixtures `freshNoJobParticipant`, `freshDisabledParticipant`.

### Security

- Server-side enforcement closes the trust-the-client gap on registration window, per-user eligibility flags, and deferred-payment eligibility — previously every gate was client UX only.
- `internalNotes` was already scrubbed from the AuthContext user (from #154) but **note**: this PR does NOT address [#7](https://github.com/ChrisRomp/playa-plan/issues/7) (user can self-PATCH the protected flags via `PUT /users/:id` to escalate). That's a separate vulnerability that would defeat this policy enforcement; it should land in a follow-up PR.

### Non-goals (intentional)

- Admin/staff `POST /registrations` and `POST /jobs/:id/register` not gated (override paths).
- "POST /registrations/camp without a payment intent leaves PENDING forever" on the non-deferred path is not addressed here.
- Free registrations (`totalCost=0`) still land PENDING.
- Reports/exports do not yet filter on `paymentDeferred` — only dashboard + admin search table get visible treatment.
- Two-`User`-type reconciliation still deferred.

### Verification

- `npm run lint` ✅
- `npm run build:api` ✅
- `npm run build:web` ✅
- `npm run test:api` ✅ **892 passed** (baseline 857 → +35 new: 19 policy + 9 service + 7 payments).
- `npm run test:web` ✅ **617 passed** (baseline 611 → +6 new dashboard).
- Two-reviewer pre-push pass (Opus + GPT-5.5) — both converged on three findings: camping option rollback gap, WAITLISTED+deferred self-confirming via payment, dashboard loading/error states. All three addressed in the final commit.

Fixes [#158](https://github.com/ChrisRomp/playa-plan/issues/158)
Fixes [#159](https://github.com/ChrisRomp/playa-plan/issues/159)
Fixes [#160](https://github.com/ChrisRomp/playa-plan/issues/160)
