### PR TITLE
feat(auth): add bootstrap admin login via INITIAL_ADMIN_CODE env var

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,3 +27,9 @@ VITE_API_URL=http://localhost:3000
 #   1, 2, ...            → trust this many proxy hops in front of the API
 # Set to 1 in production when the API runs behind a single reverse proxy.
 # TRUST_PROXY=1
+
+# Initial admin bootstrap code (optional)
+# When set, allows the first admin user to log in using this code instead of
+# an email-delivered code. Only works while email (SMTP) is NOT configured.
+# Once email is configured in the admin settings, this variable is ignored.
+# INITIAL_ADMIN_CODE=your-secure-setup-code

--- a/.env.sample
+++ b/.env.sample
@@ -32,4 +32,5 @@ VITE_API_URL=http://localhost:3000
 # When set, allows the first admin user to log in using this code instead of
 # an email-delivered code. Only works while email (SMTP) is NOT configured.
 # Once email is configured in the admin settings, this variable is ignored.
-# INITIAL_ADMIN_CODE=your-secure-setup-code
+# Must be a 6-digit numeric string to match the frontend login form constraints.
+# INITIAL_ADMIN_CODE=123456

--- a/apps/api/src/auth/services/auth.service.spec.ts
+++ b/apps/api/src/auth/services/auth.service.spec.ts
@@ -923,12 +923,12 @@ describe('AuthService', () => {
       });
       mockEmailService.isEmailConfigured.mockResolvedValue(false);
       mockConfigService.get.mockImplementation((key: string) => {
-        if (key === 'INITIAL_ADMIN_CODE') return 'bootstrap-secret-123';
+        if (key === 'INITIAL_ADMIN_CODE') return '999888';
         return undefined;
       });
 
       // Act
-      const result = await service.validateLoginCode('admin@example.playaplan.app', 'bootstrap-secret-123');
+      const result = await service.validateLoginCode('admin@example.playaplan.app', '999888');
 
       // Assert
       expect(result).not.toBeNull();
@@ -959,12 +959,12 @@ describe('AuthService', () => {
       });
       mockEmailService.isEmailConfigured.mockResolvedValue(false);
       mockConfigService.get.mockImplementation((key: string) => {
-        if (key === 'INITIAL_ADMIN_CODE') return 'bootstrap-secret-123';
+        if (key === 'INITIAL_ADMIN_CODE') return '999888';
         return undefined;
       });
 
       // Act
-      const result = await service.validateLoginCode('first@example.playaplan.app', 'bootstrap-secret-123');
+      const result = await service.validateLoginCode('first@example.playaplan.app', '999888');
 
       // Assert
       expect(result).not.toBeNull();
@@ -986,12 +986,12 @@ describe('AuthService', () => {
       mockPrismaService.user.findUnique.mockResolvedValue(mockAdminUser);
       mockEmailService.isEmailConfigured.mockResolvedValue(true);
       mockConfigService.get.mockImplementation((key: string) => {
-        if (key === 'INITIAL_ADMIN_CODE') return 'bootstrap-secret-123';
+        if (key === 'INITIAL_ADMIN_CODE') return '999888';
         return undefined;
       });
 
       // Act
-      const result = await service.validateLoginCode('admin@example.playaplan.app', 'bootstrap-secret-123');
+      const result = await service.validateLoginCode('admin@example.playaplan.app', '999888');
 
       // Assert
       expect(result).toBeNull();
@@ -1008,12 +1008,12 @@ describe('AuthService', () => {
       mockPrismaService.user.count.mockResolvedValue(1); // Already has verified users
       mockEmailService.isEmailConfigured.mockResolvedValue(false);
       mockConfigService.get.mockImplementation((key: string) => {
-        if (key === 'INITIAL_ADMIN_CODE') return 'bootstrap-secret-123';
+        if (key === 'INITIAL_ADMIN_CODE') return '999888';
         return undefined;
       });
 
       // Act
-      const result = await service.validateLoginCode('test@example.playaplan.app', 'bootstrap-secret-123');
+      const result = await service.validateLoginCode('test@example.playaplan.app', '999888');
 
       // Assert
       expect(result).toBeNull();
@@ -1030,7 +1030,7 @@ describe('AuthService', () => {
       });
 
       // Act
-      const result = await service.validateLoginCode('admin@example.playaplan.app', 'some-code');
+      const result = await service.validateLoginCode('admin@example.playaplan.app', '111111');
 
       // Assert
       expect(result).toBeNull();
@@ -1042,12 +1042,12 @@ describe('AuthService', () => {
       mockPrismaService.user.findUnique.mockResolvedValue(mockAdminUser);
       mockEmailService.isEmailConfigured.mockResolvedValue(false);
       mockConfigService.get.mockImplementation((key: string) => {
-        if (key === 'INITIAL_ADMIN_CODE') return 'bootstrap-secret-123';
+        if (key === 'INITIAL_ADMIN_CODE') return '999888';
         return undefined;
       });
 
       // Act
-      const result = await service.validateLoginCode('admin@example.playaplan.app', 'wrong-code');
+      const result = await service.validateLoginCode('admin@example.playaplan.app', '000000');
 
       // Assert
       expect(result).toBeNull();
@@ -1082,7 +1082,7 @@ describe('AuthService', () => {
       mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
       mockNotificationsService.sendLoginCodeEmail.mockResolvedValue(false); // Email send fails
       mockConfigService.get.mockImplementation((key: string) => {
-        if (key === 'INITIAL_ADMIN_CODE') return 'my-admin-code';
+        if (key === 'INITIAL_ADMIN_CODE') return '777666';
         if (key === 'nodeEnv') return 'production';
         return undefined;
       });

--- a/apps/api/src/auth/services/auth.service.spec.ts
+++ b/apps/api/src/auth/services/auth.service.spec.ts
@@ -969,6 +969,15 @@ describe('AuthService', () => {
       // Assert
       expect(result).not.toBeNull();
       expect(result?.role).toBe(UserRole.ADMIN); // Should be promoted to admin
+      expect(mockPrismaService.user.update).toHaveBeenCalledWith({
+        where: { id: 'first-user-id' },
+        data: {
+          loginCode: null,
+          loginCodeExpiry: null,
+          isEmailVerified: true,
+          role: UserRole.ADMIN,
+        },
+      });
     });
 
     it('should reject INITIAL_ADMIN_CODE when email IS configured', async () => {

--- a/apps/api/src/auth/services/auth.service.spec.ts
+++ b/apps/api/src/auth/services/auth.service.spec.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '../../common/prisma/prisma.service';
 import { RegisterDto } from '../dto/register.dto';
 import { User, UserRole } from '@prisma/client';
 import { NotificationsService } from '../../notifications/services/notifications.service';
+import { EmailService } from '../../notifications/services/email.service';
 import { randomUUID } from 'crypto';
 import { BadRequestException, ConflictException } from '@nestjs/common';
 
@@ -87,6 +88,11 @@ describe('AuthService', () => {
     sendLoginCodeEmail: jest.fn().mockResolvedValue(true),
   };
 
+  // Mock email service
+  const mockEmailService = {
+    isEmailConfigured: jest.fn().mockResolvedValue(false),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
     
@@ -97,6 +103,7 @@ describe('AuthService', () => {
         { provide: JwtService, useValue: mockJwtService },
         { provide: ConfigService, useValue: mockConfigService },
         { provide: NotificationsService, useValue: mockNotificationsService },
+        { provide: EmailService, useValue: mockEmailService },
       ],
     }).compile();
 
@@ -890,6 +897,239 @@ describe('AuthService', () => {
           },
         });
       });
+    });
+  });
+
+  describe('Bootstrap Admin Auth (INITIAL_ADMIN_CODE)', () => {
+    const mockAdminUser = {
+      ...mockUser,
+      id: 'admin-id-1',
+      email: 'admin@example.playaplan.app',
+      role: UserRole.ADMIN,
+      isEmailVerified: true,
+      loginCode: null,
+      loginCodeExpiry: null,
+    } as User;
+
+    it('should accept INITIAL_ADMIN_CODE for admin user when email is not configured', async () => {
+      // Arrange
+      mockPrismaService.user.findFirst.mockResolvedValue(null); // Normal code lookup fails
+      mockPrismaService.user.findUnique.mockResolvedValue(mockAdminUser);
+      mockPrismaService.user.count.mockResolvedValue(1); // Already has authenticated users
+      mockPrismaService.user.update.mockResolvedValue({
+        ...mockAdminUser,
+        loginCode: null,
+        loginCodeExpiry: null,
+      });
+      mockEmailService.isEmailConfigured.mockResolvedValue(false);
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'INITIAL_ADMIN_CODE') return 'bootstrap-secret-123';
+        return undefined;
+      });
+
+      // Act
+      const result = await service.validateLoginCode('admin@example.playaplan.app', 'bootstrap-secret-123');
+
+      // Assert
+      expect(result).not.toBeNull();
+      expect(result?.email).toBe('admin@example.playaplan.app');
+    });
+
+    it('should accept INITIAL_ADMIN_CODE for first user (PARTICIPANT) who will become admin', async () => {
+      // Arrange - first user, not yet promoted, no verified users
+      const firstUser = {
+        ...mockUser,
+        id: 'first-user-id',
+        email: 'first@example.playaplan.app',
+        role: UserRole.PARTICIPANT,
+        isEmailVerified: false,
+        loginCode: null,
+        loginCodeExpiry: null,
+      } as User;
+
+      mockPrismaService.user.findFirst.mockResolvedValue(null); // Normal code lookup fails
+      mockPrismaService.user.findUnique.mockResolvedValue(firstUser);
+      mockPrismaService.user.count.mockResolvedValue(0); // No verified users — first admin
+      mockPrismaService.user.update.mockResolvedValue({
+        ...firstUser,
+        loginCode: null,
+        loginCodeExpiry: null,
+        isEmailVerified: true,
+        role: UserRole.ADMIN,
+      });
+      mockEmailService.isEmailConfigured.mockResolvedValue(false);
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'INITIAL_ADMIN_CODE') return 'bootstrap-secret-123';
+        return undefined;
+      });
+
+      // Act
+      const result = await service.validateLoginCode('first@example.playaplan.app', 'bootstrap-secret-123');
+
+      // Assert
+      expect(result).not.toBeNull();
+      expect(result?.role).toBe(UserRole.ADMIN); // Should be promoted to admin
+    });
+
+    it('should reject INITIAL_ADMIN_CODE when email IS configured', async () => {
+      // Arrange
+      mockPrismaService.user.findFirst.mockResolvedValue(null);
+      mockPrismaService.user.findUnique.mockResolvedValue(mockAdminUser);
+      mockEmailService.isEmailConfigured.mockResolvedValue(true);
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'INITIAL_ADMIN_CODE') return 'bootstrap-secret-123';
+        return undefined;
+      });
+
+      // Act
+      const result = await service.validateLoginCode('admin@example.playaplan.app', 'bootstrap-secret-123');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should reject INITIAL_ADMIN_CODE for non-admin users when bootstrap is complete', async () => {
+      // Arrange
+      const mockParticipant = {
+        ...mockUser,
+        role: UserRole.PARTICIPANT,
+      } as User;
+      mockPrismaService.user.findFirst.mockResolvedValue(null);
+      mockPrismaService.user.findUnique.mockResolvedValue(mockParticipant);
+      mockPrismaService.user.count.mockResolvedValue(1); // Already has verified users
+      mockEmailService.isEmailConfigured.mockResolvedValue(false);
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'INITIAL_ADMIN_CODE') return 'bootstrap-secret-123';
+        return undefined;
+      });
+
+      // Act
+      const result = await service.validateLoginCode('test@example.playaplan.app', 'bootstrap-secret-123');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should reject when INITIAL_ADMIN_CODE env var is not set', async () => {
+      // Arrange
+      mockPrismaService.user.findFirst.mockResolvedValue(null);
+      mockPrismaService.user.findUnique.mockResolvedValue(mockAdminUser);
+      mockEmailService.isEmailConfigured.mockResolvedValue(false);
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'INITIAL_ADMIN_CODE') return undefined;
+        return undefined;
+      });
+
+      // Act
+      const result = await service.validateLoginCode('admin@example.playaplan.app', 'some-code');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should reject when code does not match INITIAL_ADMIN_CODE', async () => {
+      // Arrange
+      mockPrismaService.user.findFirst.mockResolvedValue(null);
+      mockPrismaService.user.findUnique.mockResolvedValue(mockAdminUser);
+      mockEmailService.isEmailConfigured.mockResolvedValue(false);
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'INITIAL_ADMIN_CODE') return 'bootstrap-secret-123';
+        return undefined;
+      });
+
+      // Act
+      const result = await service.validateLoginCode('admin@example.playaplan.app', 'wrong-code');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('generateLoginCode bootstrap console logging', () => {
+    it('should log code to console when email send fails, no env var, and in bootstrap state', async () => {
+      // Arrange
+      mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
+      mockPrismaService.user.count.mockResolvedValue(0); // Bootstrap state (no verified users)
+      mockNotificationsService.sendLoginCodeEmail.mockResolvedValue(false); // Email send fails
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'INITIAL_ADMIN_CODE') return undefined;
+        if (key === 'nodeEnv') return 'production';
+        return undefined;
+      });
+
+      const loggerWarnSpy = jest.spyOn(service['logger'], 'warn');
+
+      // Act
+      await service.generateLoginCode('test@example.playaplan.app');
+
+      // Assert
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[BOOTSTRAP] Login code for test@example.playaplan.app'),
+      );
+    });
+
+    it('should NOT log code to console when INITIAL_ADMIN_CODE is set', async () => {
+      // Arrange
+      mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
+      mockNotificationsService.sendLoginCodeEmail.mockResolvedValue(false); // Email send fails
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'INITIAL_ADMIN_CODE') return 'my-admin-code';
+        if (key === 'nodeEnv') return 'production';
+        return undefined;
+      });
+
+      const loggerWarnSpy = jest.spyOn(service['logger'], 'warn');
+
+      // Act
+      await service.generateLoginCode('test@example.playaplan.app');
+
+      // Assert
+      expect(loggerWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('[BOOTSTRAP]'),
+      );
+    });
+
+    it('should NOT log code to console when email send succeeds', async () => {
+      // Arrange
+      mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
+      mockNotificationsService.sendLoginCodeEmail.mockResolvedValue(true); // Email succeeds
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'INITIAL_ADMIN_CODE') return undefined;
+        if (key === 'nodeEnv') return 'production';
+        return undefined;
+      });
+
+      const loggerWarnSpy = jest.spyOn(service['logger'], 'warn');
+
+      // Act
+      await service.generateLoginCode('test@example.playaplan.app');
+
+      // Assert
+      expect(loggerWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('[BOOTSTRAP]'),
+      );
+    });
+
+    it('should NOT log code to console after bootstrap is complete (verified users exist)', async () => {
+      // Arrange
+      mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
+      mockPrismaService.user.count.mockResolvedValue(1); // Not in bootstrap state
+      mockNotificationsService.sendLoginCodeEmail.mockResolvedValue(false); // Email send fails
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'INITIAL_ADMIN_CODE') return undefined;
+        if (key === 'nodeEnv') return 'production';
+        return undefined;
+      });
+
+      const loggerWarnSpy = jest.spyOn(service['logger'], 'warn');
+
+      // Act
+      await service.generateLoginCode('test@example.playaplan.app');
+
+      // Assert
+      expect(loggerWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('[BOOTSTRAP]'),
+      );
     });
   });
 });

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -6,6 +6,7 @@ import { RegisterDto } from '../dto/register.dto';
 import { User, UserRole } from '@prisma/client';
 import { randomUUID, randomInt } from 'crypto';
 import { NotificationsService } from '../../notifications/services/notifications.service';
+import { EmailService } from '../../notifications/services/email.service';
 import { normalizeEmail } from '../../common/utils/email.utils';
 
 /**
@@ -20,6 +21,7 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
     private readonly notificationsService: NotificationsService,
+    private readonly emailService: EmailService,
   ) {}
 
   /**
@@ -262,7 +264,21 @@ export class AuthService {
       }
 
       // Send login code email
-      await this.sendLoginCodeEmail(normalizedEmail, loginCode);
+      const emailSent = await this.sendLoginCodeEmail(normalizedEmail, loginCode);
+
+      // If email wasn't sent and INITIAL_ADMIN_CODE is not set, log the code to console
+      // Only log during bootstrap (no authenticated users exist yet) to avoid leaking codes
+      if (!emailSent) {
+        const initialAdminCode = this.configService.get<string>('INITIAL_ADMIN_CODE');
+        if (!initialAdminCode) {
+          const isBootstrap = await this.shouldMakeFirstUserAdmin();
+          if (isBootstrap) {
+            this.logger.warn(
+              `[BOOTSTRAP] Login code for ${normalizedEmail}: ${loginCode} (email not configured — set INITIAL_ADMIN_CODE env var to avoid this)`,
+            );
+          }
+        }
+      }
 
       return true;
     } catch (error: unknown) {
@@ -321,6 +337,11 @@ export class AuthService {
       });
 
       if (!user) {
+        // Normal code lookup failed — try bootstrap auth via INITIAL_ADMIN_CODE
+        user = await this.tryBootstrapAdminAuth(normalizedEmail, code);
+      }
+
+      if (!user) {
         // Invalid or expired code
         return null;
       }
@@ -352,6 +373,48 @@ export class AuthService {
       this.logger.error(`Error validating login code: ${this.getErrorMessage(error)}`);
       return null;
     }
+  }
+
+  /**
+   * Attempts bootstrap authentication using the INITIAL_ADMIN_CODE env var.
+   * Only succeeds if:
+   * - INITIAL_ADMIN_CODE env var is set and matches the provided code
+   * - Email is NOT configured (emailEnabled + SMTP credentials not set)
+   * - The user is an admin OR would become the first admin (no verified users exist)
+   *
+   * @param email Normalized user email
+   * @param code Code submitted by the user
+   * @returns User if bootstrap auth succeeds, null otherwise
+   */
+  private async tryBootstrapAdminAuth(email: string, code: string): Promise<User | null> {
+    const initialAdminCode = this.configService.get<string>('INITIAL_ADMIN_CODE');
+    if (!initialAdminCode || code !== initialAdminCode) {
+      return null;
+    }
+
+    // Check if email is configured — if so, bootstrap is disabled
+    const emailConfigured = await this.emailService.isEmailConfigured();
+    if (emailConfigured) {
+      return null;
+    }
+
+    // Find the user
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (!user) {
+      return null;
+    }
+
+    // Allow if user is already admin, OR if this would be the first admin
+    const isFirstAdmin = await this.shouldMakeFirstUserAdmin();
+    if (user.role !== UserRole.ADMIN && !isFirstAdmin) {
+      return null;
+    }
+
+    this.logger.log(`[BOOTSTRAP] Admin login via INITIAL_ADMIN_CODE for ${email}`);
+    return user;
   }
 
   /**

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -336,9 +336,14 @@ export class AuthService {
         },
       });
 
+      let bootstrapResult: { user: User; shouldPromote: boolean } | null = null;
+
       if (!user) {
         // Normal code lookup failed — try bootstrap auth via INITIAL_ADMIN_CODE
-        user = await this.tryBootstrapAdminAuth(normalizedEmail, code);
+        bootstrapResult = await this.tryBootstrapAdminAuth(normalizedEmail, code);
+        if (bootstrapResult) {
+          user = bootstrapResult.user;
+        }
       }
 
       if (!user) {
@@ -346,8 +351,12 @@ export class AuthService {
         return null;
       }
 
-      // Step 2: Check if this should be the first admin user (before marking as verified)
-      const shouldBeAdmin = await this.shouldMakeFirstUserAdmin();
+      // Step 2: Determine if this should be the first admin user.
+      // If bootstrap auth was used, trust its decision to avoid a race condition
+      // where the user count could change between the two queries.
+      const shouldBeAdmin = bootstrapResult
+        ? bootstrapResult.shouldPromote
+        : await this.shouldMakeFirstUserAdmin();
 
       // Step 3: Clear the login code and mark as verified, potentially promoting to admin
       const updatedUser = await this.prisma.user.update({
@@ -384,9 +393,12 @@ export class AuthService {
    *
    * @param email Normalized user email
    * @param code Code submitted by the user
-   * @returns User if bootstrap auth succeeds, null otherwise
+   * @returns Object with user and shouldPromote flag if bootstrap auth succeeds, null otherwise
    */
-  private async tryBootstrapAdminAuth(email: string, code: string): Promise<User | null> {
+  private async tryBootstrapAdminAuth(
+    email: string,
+    code: string,
+  ): Promise<{ user: User; shouldPromote: boolean } | null> {
     const initialAdminCode = this.configService.get<string>('INITIAL_ADMIN_CODE');
     if (!initialAdminCode || code !== initialAdminCode) {
       return null;
@@ -414,7 +426,7 @@ export class AuthService {
     }
 
     this.logger.log(`[BOOTSTRAP] INITIAL_ADMIN_CODE matched for ${email} (completing login...)`);
-    return user;
+    return { user, shouldPromote: isFirstAdmin && user.role !== UserRole.ADMIN };
   }
 
   /**

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -274,7 +274,7 @@ export class AuthService {
           const isBootstrap = await this.shouldMakeFirstUserAdmin();
           if (isBootstrap) {
             this.logger.warn(
-              `[BOOTSTRAP] Login code for ${normalizedEmail}: ${loginCode} (email not configured — set INITIAL_ADMIN_CODE env var to avoid this)`,
+              `[BOOTSTRAP] Login code for ${normalizedEmail}: ${loginCode} (email was not delivered — set INITIAL_ADMIN_CODE env var to avoid this)`,
             );
           }
         }
@@ -413,7 +413,7 @@ export class AuthService {
       return null;
     }
 
-    this.logger.log(`[BOOTSTRAP] Admin login via INITIAL_ADMIN_CODE for ${email}`);
+    this.logger.log(`[BOOTSTRAP] INITIAL_ADMIN_CODE matched for ${email} (completing login...)`);
     return user;
   }
 

--- a/apps/api/src/integration/email-case-insensitivity.integration.spec.ts
+++ b/apps/api/src/integration/email-case-insensitivity.integration.spec.ts
@@ -5,6 +5,7 @@ import { PrismaService } from '../common/prisma/prisma.service';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { NotificationsService } from '../notifications/services/notifications.service';
+import { EmailService } from '../notifications/services/email.service';
 import { ConflictException } from '@nestjs/common';
 import { normalizeEmail } from '../common/utils/email.utils';
 
@@ -46,6 +47,10 @@ describe('Email Case Insensitivity Integration', () => {
     sendEmailChangeNotificationToNewEmail: jest.fn().mockResolvedValue(true),
   };
 
+  const mockEmailService = {
+    isEmailConfigured: jest.fn().mockResolvedValue(true),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -66,6 +71,10 @@ describe('Email Case Insensitivity Integration', () => {
         {
           provide: NotificationsService,
           useValue: mockNotificationsService,
+        },
+        {
+          provide: EmailService,
+          useValue: mockEmailService,
         },
       ],
     }).compile();

--- a/apps/api/src/notifications/services/email.service.spec.ts
+++ b/apps/api/src/notifications/services/email.service.spec.ts
@@ -1311,4 +1311,67 @@ describe('EmailService', () => {
       createTransportSpy.mockRestore();
     });
   });
+
+  describe('isEmailConfigured', () => {
+    it('should return true when emailEnabled is true and SMTP credentials are all set', async () => {
+      mockCoreConfigService.getEmailConfiguration.mockResolvedValue(mockEmailConfig);
+
+      const result = await service.isEmailConfigured();
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when emailEnabled is false even if SMTP fields are set', async () => {
+      mockCoreConfigService.getEmailConfiguration.mockResolvedValue({
+        ...mockEmailConfig,
+        emailEnabled: false,
+      });
+
+      const result = await service.isEmailConfigured();
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when SMTP fields are missing even if emailEnabled is true', async () => {
+      mockCoreConfigService.getEmailConfiguration.mockResolvedValue({
+        ...mockEmailConfig,
+        smtpHost: null,
+        smtpUsername: null,
+        smtpPassword: null,
+      });
+
+      const result = await service.isEmailConfigured();
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when configuration is incomplete (e.g., host set but no password)', async () => {
+      mockCoreConfigService.getEmailConfiguration.mockResolvedValue({
+        ...mockEmailConfig,
+        smtpPassword: null,
+      });
+
+      const result = await service.isEmailConfigured();
+
+      expect(result).toBe(false);
+    });
+
+    it('should always fetch fresh configuration bypassing cache', async () => {
+      // First call populates cache via refreshConfiguration
+      mockCoreConfigService.getEmailConfiguration.mockResolvedValue(mockEmailConfig);
+      await service.refreshConfiguration();
+      mockCoreConfigService.getEmailConfiguration.mockClear();
+
+      // Second call via isEmailConfigured should still hit the database (forceRefresh)
+      mockCoreConfigService.getEmailConfiguration.mockResolvedValue({
+        ...mockEmailConfig,
+        emailEnabled: false,
+      });
+
+      const result = await service.isEmailConfigured();
+
+      expect(mockCoreConfigService.getEmailConfiguration).toHaveBeenCalledTimes(1);
+      expect(result).toBe(false);
+    });
+  });
 }); 

--- a/apps/api/src/notifications/services/email.service.ts
+++ b/apps/api/src/notifications/services/email.service.ts
@@ -124,7 +124,7 @@ export class EmailService implements OnModuleInit {
    * smtpHost, smtpUsername, and smtpPassword are all set.
    */
   async isEmailConfigured(): Promise<boolean> {
-    const config = await this.getEmailConfig();
+    const config = await this.getEmailConfig(true);
     return !!(config.emailEnabled && config.smtpHost && config.smtpUsername && config.smtpPassword);
   }
 

--- a/apps/api/src/notifications/services/email.service.ts
+++ b/apps/api/src/notifications/services/email.service.ts
@@ -119,6 +119,16 @@ export class EmailService implements OnModuleInit {
   }
 
   /**
+   * Check whether email is fully configured and ready to send
+   * Email is considered configured when emailEnabled is true AND
+   * smtpHost, smtpUsername, and smtpPassword are all set.
+   */
+  async isEmailConfigured(): Promise<boolean> {
+    const config = await this.getEmailConfig();
+    return !!(config.emailEnabled && config.smtpHost && config.smtpUsername && config.smtpPassword);
+  }
+
+  /**
    * Initialize or refresh SMTP transporter with current configuration
    */
   private async initSmtpTransporter(): Promise<void> {


### PR DESCRIPTION
## Motivation

The first user to log in gets promoted to admin, but email isn't configured yet at initial setup -- so there's no way to receive the auth code without reading the database directly (#61).

## Approach

Adds a two-layer bootstrap mechanism so the initial admin can log in before email is set up:

**Layer 1: `INITIAL_ADMIN_CODE` env var** -- When set, the admin (or the first user who will become admin) can log in using this static code as long as SMTP email is not configured in the database. Once email settings are saved in the admin UI, the env var is permanently ignored and normal email-code auth resumes. This is reusable across sessions, not one-shot.

**Layer 2: Console log fallback** -- If `INITIAL_ADMIN_CODE` is not set and email send fails during the bootstrap window (zero verified users), the generated code is logged to stdout with a `[BOOTSTRAP]` prefix. After the first user is verified, codes are never logged.

## Security constraints

- Layer 1 only accepts the code for users with `ADMIN` role, OR when no verified users exist yet (first-admin promotion path)
- Layer 1 is disabled once email is configured (`emailEnabled` + SMTP host/user/password all set)
- Layer 2 only fires during bootstrap state (zero verified users) to prevent leaking codes for arbitrary users in production

## Files changed

- `apps/api/src/auth/services/auth.service.ts` -- fallback in `validateLoginCode()` and console logging in `generateLoginCode()`
- `apps/api/src/notifications/services/email.service.ts` -- new public `isEmailConfigured()` method
- `apps/api/src/auth/services/auth.service.spec.ts` -- 10 new tests covering bootstrap scenarios
- `.env.sample` -- documents `INITIAL_ADMIN_CODE`

## Testing

39 auth service tests pass (10 new), 39 email service tests pass. TypeScript and ESLint clean.

Closes #61