### PR TITLE
feat: add registrationId FK to CampingOptionRegistration for year scoping

### DIFF
--- a/apps/api/prisma/migrations/20260519230656_add_registration_id_to_camping_option_registrations/migration.sql
+++ b/apps/api/prisma/migrations/20260519230656_add_registration_id_to_camping_option_registrations/migration.sql
@@ -1,20 +1,20 @@
 -- AlterTable
-ALTER TABLE "camping_option_registrations" ADD COLUMN "registration_id" TEXT;
+ALTER TABLE "camping_option_registrations" ADD COLUMN "registrationId" TEXT;
 
 -- Backfill: link each camping_option_registration to the user's existing
 -- non-cancelled registration (at most one per user in current data).
 UPDATE "camping_option_registrations"
-SET "registration_id" = (
+SET "registrationId" = (
   SELECT "id"
   FROM "registrations"
-  WHERE "registrations"."user_id" = "camping_option_registrations"."user_id"
+  WHERE "registrations"."userId" = "camping_option_registrations"."userId"
     AND "registrations"."status" != 'CANCELLED'
-  ORDER BY "registrations"."created_at" DESC
+  ORDER BY "registrations"."createdAt" DESC
   LIMIT 1
 );
 
 -- CreateIndex
-CREATE INDEX "camping_option_registrations_registration_id_idx" ON "camping_option_registrations"("registration_id");
+CREATE INDEX "camping_option_registrations_registrationId_idx" ON "camping_option_registrations"("registrationId");
 
 -- AddForeignKey
-ALTER TABLE "camping_option_registrations" ADD CONSTRAINT "camping_option_registrations_registration_id_fkey" FOREIGN KEY ("registration_id") REFERENCES "registrations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "camping_option_registrations" ADD CONSTRAINT "camping_option_registrations_registrationId_fkey" FOREIGN KEY ("registrationId") REFERENCES "registrations"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260519230656_add_registration_id_to_camping_option_registrations/migration.sql
+++ b/apps/api/prisma/migrations/20260519230656_add_registration_id_to_camping_option_registrations/migration.sql
@@ -1,0 +1,20 @@
+-- AlterTable
+ALTER TABLE "camping_option_registrations" ADD COLUMN "registration_id" TEXT;
+
+-- Backfill: link each camping_option_registration to the user's existing
+-- non-cancelled registration (at most one per user in current data).
+UPDATE "camping_option_registrations"
+SET "registration_id" = (
+  SELECT "id"
+  FROM "registrations"
+  WHERE "registrations"."user_id" = "camping_option_registrations"."user_id"
+    AND "registrations"."status" != 'CANCELLED'
+  ORDER BY "registrations"."created_at" DESC
+  LIMIT 1
+);
+
+-- CreateIndex
+CREATE INDEX "camping_option_registrations_registration_id_idx" ON "camping_option_registrations"("registration_id");
+
+-- AddForeignKey
+ALTER TABLE "camping_option_registrations" ADD CONSTRAINT "camping_option_registrations_registration_id_fkey" FOREIGN KEY ("registration_id") REFERENCES "registrations"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260520000000_add_unique_camping_option_per_registration/migration.sql
+++ b/apps/api/prisma/migrations/20260520000000_add_unique_camping_option_per_registration/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "camping_option_registrations_registration_id_camping_option_key" ON "camping_option_registrations"("registration_id", "camping_option_id");

--- a/apps/api/prisma/migrations/20260520000000_add_unique_camping_option_per_registration/migration.sql
+++ b/apps/api/prisma/migrations/20260520000000_add_unique_camping_option_per_registration/migration.sql
@@ -1,15 +1,61 @@
--- Deduplicate: if any rows have the same registrationId + campingOptionId,
--- keep only the earliest one (by createdAt).
+-- Deduplicate camping_option_registrations: when multiple rows share the same
+-- (registrationId, campingOptionId), keep the row with associated field values
+-- (or the most recently updated row). Migrate field values from duplicate rows
+-- to the kept row first, so ON DELETE CASCADE does not discard user data.
+
+-- Step 1: Migrate field values from duplicate rows to the keeper.
+-- The "keeper" for each group is the row with the most field values,
+-- breaking ties by latest updatedAt.
+WITH ranked AS (
+  SELECT cor."id",
+         cor."registrationId",
+         cor."campingOptionId",
+         ROW_NUMBER() OVER (
+           PARTITION BY cor."registrationId", cor."campingOptionId"
+           ORDER BY
+             (SELECT COUNT(*) FROM "camping_option_field_values" v
+              WHERE v."registrationId" = cor."id") DESC,
+             cor."updatedAt" DESC
+         ) AS rn
+  FROM "camping_option_registrations" cor
+  WHERE cor."registrationId" IS NOT NULL
+),
+keepers AS (
+  SELECT "id" AS keeper_id, "registrationId", "campingOptionId"
+  FROM ranked WHERE rn = 1
+),
+losers AS (
+  SELECT r."id" AS loser_id, k.keeper_id
+  FROM ranked r
+  JOIN keepers k ON r."registrationId" = k."registrationId"
+                AND r."campingOptionId" = k."campingOptionId"
+  WHERE r.rn > 1
+)
+UPDATE "camping_option_field_values" fv
+SET "registrationId" = l.keeper_id
+FROM losers l
+WHERE fv."registrationId" = l.loser_id
+AND NOT EXISTS (
+  SELECT 1 FROM "camping_option_field_values" existing
+  WHERE existing."registrationId" = l.keeper_id
+  AND existing."fieldId" = fv."fieldId"
+);
+
+-- Step 2: Delete duplicate rows (any field values still on these rows are
+-- for fields the keeper already has, so cascade-deleting them is safe).
 DELETE FROM "camping_option_registrations"
 WHERE "id" IN (
   SELECT "id" FROM (
-    SELECT "id",
+    SELECT cor."id",
            ROW_NUMBER() OVER (
-             PARTITION BY "registrationId", "campingOptionId"
-             ORDER BY "createdAt" ASC
+             PARTITION BY cor."registrationId", cor."campingOptionId"
+             ORDER BY
+               (SELECT COUNT(*) FROM "camping_option_field_values" v
+                WHERE v."registrationId" = cor."id") DESC,
+               cor."updatedAt" DESC
            ) AS rn
-    FROM "camping_option_registrations"
-    WHERE "registrationId" IS NOT NULL
+    FROM "camping_option_registrations" cor
+    WHERE cor."registrationId" IS NOT NULL
   ) sub
   WHERE sub.rn > 1
 );

--- a/apps/api/prisma/migrations/20260520000000_add_unique_camping_option_per_registration/migration.sql
+++ b/apps/api/prisma/migrations/20260520000000_add_unique_camping_option_per_registration/migration.sql
@@ -1,2 +1,18 @@
+-- Deduplicate: if any rows have the same registrationId + campingOptionId,
+-- keep only the earliest one (by createdAt).
+DELETE FROM "camping_option_registrations"
+WHERE "id" IN (
+  SELECT "id" FROM (
+    SELECT "id",
+           ROW_NUMBER() OVER (
+             PARTITION BY "registrationId", "campingOptionId"
+             ORDER BY "createdAt" ASC
+           ) AS rn
+    FROM "camping_option_registrations"
+    WHERE "registrationId" IS NOT NULL
+  ) sub
+  WHERE sub.rn > 1
+);
+
 -- CreateIndex
-CREATE UNIQUE INDEX "camping_option_registrations_registration_id_camping_option_key" ON "camping_option_registrations"("registration_id", "camping_option_id");
+CREATE UNIQUE INDEX "camping_option_registrations_registrationId_campingOptionId_key" ON "camping_option_registrations"("registrationId", "campingOptionId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -131,6 +131,7 @@ model CampingOptionRegistration {
 
   @@index([userId])
   @@index([registrationId])
+  @@unique([registrationId, campingOptionId])
   @@map("camping_option_registrations")
 }
 

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -123,11 +123,14 @@ model CampingOptionRegistration {
   updatedAt       DateTime                  @updatedAt
   userId          String
   campingOptionId String
+  registrationId  String?
   fieldValues     CampingOptionFieldValue[]
   campingOption   CampingOption             @relation(fields: [campingOptionId], references: [id])
   user            User                      @relation(fields: [userId], references: [id])
+  registration    Registration?             @relation(fields: [registrationId], references: [id])
 
   @@index([userId])
+  @@index([registrationId])
   @@map("camping_option_registrations")
 }
 
@@ -191,16 +194,17 @@ model Shift {
 }
 
 model Registration {
-  id              String             @id @default(uuid())
-  status          RegistrationStatus @default(PENDING)
-  paymentDeferred Boolean            @default(false)
-  year            Int
-  createdAt       DateTime           @default(now())
-  updatedAt       DateTime           @updatedAt
-  userId          String
-  user            User               @relation(fields: [userId], references: [id])
-  jobs            RegistrationJob[]
-  payments        Payment[]
+  id                        String                      @id @default(uuid())
+  status                    RegistrationStatus          @default(PENDING)
+  paymentDeferred           Boolean                     @default(false)
+  year                      Int
+  createdAt                 DateTime                    @default(now())
+  updatedAt                 DateTime                    @updatedAt
+  userId                    String
+  user                      User                        @relation(fields: [userId], references: [id])
+  jobs                      RegistrationJob[]
+  payments                  Payment[]
+  campingOptionRegistrations CampingOptionRegistration[]
 
   @@map("registrations")
 }

--- a/apps/api/src/camping-options/camping-options.module.ts
+++ b/apps/api/src/camping-options/camping-options.module.ts
@@ -4,12 +4,13 @@ import { CampingOptionFieldsController } from './controllers/camping-option-fiel
 import { CampingOptionsService } from './services/camping-options.service';
 import { CampingOptionFieldsService } from './services/camping-option-fields.service';
 import { PrismaModule } from '../common/prisma/prisma.module';
+import { CoreConfigModule } from '../core-config/core-config.module';
 
 /**
  * Module for managing camping options and their custom fields
  */
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, CoreConfigModule],
   controllers: [CampingOptionsController, CampingOptionFieldsController],
   providers: [CampingOptionsService, CampingOptionFieldsService],
   exports: [CampingOptionsService, CampingOptionFieldsService],

--- a/apps/api/src/camping-options/controllers/camping-options.controller.spec.ts
+++ b/apps/api/src/camping-options/controllers/camping-options.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CampingOptionsController } from './camping-options.controller';
 import { CampingOptionsService } from '../services/camping-options.service';
+import { CoreConfigService } from '../../core-config/services/core-config.service';
 import { 
   CreateCampingOptionDto, 
   UpdateCampingOptionDto, 
@@ -86,6 +87,10 @@ describe('CampingOptionsController', () => {
       findOne: jest.fn(),
     };
 
+    const mockCoreConfigService = {
+      findCurrent: jest.fn().mockResolvedValue({ registrationYear: 2026 }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CampingOptionsController],
       providers: [
@@ -96,6 +101,10 @@ describe('CampingOptionsController', () => {
         {
           provide: CampingOptionFieldsService,
           useValue: mockCampingOptionFieldsService,
+        },
+        {
+          provide: CoreConfigService,
+          useValue: mockCoreConfigService,
         },
       ],
     }).compile();
@@ -123,10 +132,11 @@ describe('CampingOptionsController', () => {
   });
 
   describe('findAll', () => {
-    it('should return all camping options', async () => {
+    it('should return all camping options with year-scoped registration count', async () => {
       const result = await controller.findAll();
       
       expect(service.findAll).toHaveBeenCalledWith(false);
+      expect(service.getRegistrationCount).toHaveBeenCalledWith('test-id', 2026);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(expect.objectContaining(mockResponseDto));
     });
@@ -141,10 +151,11 @@ describe('CampingOptionsController', () => {
   });
 
   describe('findOne', () => {
-    it('should return a single camping option', async () => {
+    it('should return a single camping option with year-scoped registration count', async () => {
       const result = await controller.findOne('test-id');
       
       expect(service.findOne).toHaveBeenCalledWith('test-id');
+      expect(service.getRegistrationCount).toHaveBeenCalledWith('test-id', 2026);
       expect(result).toEqual(expect.objectContaining(mockResponseDto));
     });
 
@@ -156,10 +167,11 @@ describe('CampingOptionsController', () => {
   });
 
   describe('update', () => {
-    it('should update a camping option', async () => {
+    it('should update a camping option with year-scoped registration count', async () => {
       const result = await controller.update('test-id', mockUpdateCampingOptionDto);
       
       expect(service.update).toHaveBeenCalledWith('test-id', mockUpdateCampingOptionDto);
+      expect(service.getRegistrationCount).toHaveBeenCalledWith('test-id', 2026);
       expect(result).toEqual(expect.objectContaining(mockResponseDto));
     });
   });

--- a/apps/api/src/camping-options/controllers/camping-options.controller.spec.ts
+++ b/apps/api/src/camping-options/controllers/camping-options.controller.spec.ts
@@ -76,6 +76,7 @@ describe('CampingOptionsController', () => {
     update: jest.fn().mockResolvedValue(mockCampingOption),
     remove: jest.fn().mockResolvedValue(mockCampingOption),
     getRegistrationCount: jest.fn().mockResolvedValue(0),
+    getRegistrationCountBatch: jest.fn().mockResolvedValue(new Map([['test-id', 0]])),
   };
 
   beforeEach(async () => {
@@ -136,7 +137,7 @@ describe('CampingOptionsController', () => {
       const result = await controller.findAll();
       
       expect(service.findAll).toHaveBeenCalledWith(false);
-      expect(service.getRegistrationCount).toHaveBeenCalledWith('test-id', 2026);
+      expect(service.getRegistrationCountBatch).toHaveBeenCalledWith(['test-id'], 2026);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(expect.objectContaining(mockResponseDto));
     });

--- a/apps/api/src/camping-options/controllers/camping-options.controller.ts
+++ b/apps/api/src/camping-options/controllers/camping-options.controller.ts
@@ -92,11 +92,14 @@ export class CampingOptionsController {
 
     const config = await this.coreConfigService.findCurrent();
     const currentYear = config.registrationYear;
+
+    const optionIds = campingOptions.map(o => o.id);
+    const counts = await this.campingOptionsService.getRegistrationCountBatch(optionIds, currentYear);
     
     const responseDtos: CampingOptionResponseDto[] = [];
     
     for (const option of campingOptions) {
-      const registrationCount = await this.campingOptionsService.getRegistrationCount(option.id, currentYear);
+      const registrationCount = counts.get(option.id) ?? 0;
       const responseDto = new CampingOptionResponseDto();
       
       Object.assign(responseDto, option);

--- a/apps/api/src/camping-options/controllers/camping-options.controller.ts
+++ b/apps/api/src/camping-options/controllers/camping-options.controller.ts
@@ -18,6 +18,7 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { CampingOptionsService } from '../services/camping-options.service';
 import { CampingOptionFieldsService } from '../services/camping-option-fields.service';
+import { CoreConfigService } from '../../core-config/services/core-config.service';
 import { 
   CreateCampingOptionDto, 
   UpdateCampingOptionDto,
@@ -39,7 +40,8 @@ import { UserRole } from '@prisma/client';
 export class CampingOptionsController {
   constructor(
     private readonly campingOptionsService: CampingOptionsService,
-    private readonly campingOptionFieldsService: CampingOptionFieldsService
+    private readonly campingOptionFieldsService: CampingOptionFieldsService,
+    private readonly coreConfigService: CoreConfigService,
   ) {}
 
   /**
@@ -87,11 +89,14 @@ export class CampingOptionsController {
     const campingOptions = await this.campingOptionsService.findAll(
       includeDisabled === true || includeDisabled === 'true'
     );
+
+    const config = await this.coreConfigService.findCurrent();
+    const currentYear = config.registrationYear;
     
     const responseDtos: CampingOptionResponseDto[] = [];
     
     for (const option of campingOptions) {
-      const registrationCount = await this.campingOptionsService.getRegistrationCount(option.id);
+      const registrationCount = await this.campingOptionsService.getRegistrationCount(option.id, currentYear);
       const responseDto = new CampingOptionResponseDto();
       
       Object.assign(responseDto, option);
@@ -121,7 +126,8 @@ export class CampingOptionsController {
   async findOne(@Param('id') id: string): Promise<CampingOptionResponseDto> {
     try {
       const campingOption = await this.campingOptionsService.findOne(id);
-      const registrationCount = await this.campingOptionsService.getRegistrationCount(id);
+      const config = await this.coreConfigService.findCurrent();
+      const registrationCount = await this.campingOptionsService.getRegistrationCount(id, config.registrationYear);
       const responseDto = new CampingOptionResponseDto();
       
       Object.assign(responseDto, campingOption);
@@ -160,7 +166,8 @@ export class CampingOptionsController {
     @Body() updateCampingOptionDto: UpdateCampingOptionDto
   ): Promise<CampingOptionResponseDto> {
     const campingOption = await this.campingOptionsService.update(id, updateCampingOptionDto);
-    const registrationCount = await this.campingOptionsService.getRegistrationCount(id);
+    const config = await this.coreConfigService.findCurrent();
+    const registrationCount = await this.campingOptionsService.getRegistrationCount(id, config.registrationYear);
     const responseDto = new CampingOptionResponseDto();
     
     Object.assign(responseDto, campingOption);

--- a/apps/api/src/camping-options/services/camping-options.service.spec.ts
+++ b/apps/api/src/camping-options/services/camping-options.service.spec.ts
@@ -72,6 +72,7 @@ describe('CampingOptionsService', () => {
     },
     campingOptionRegistration: {
       count: jest.fn(),
+      groupBy: jest.fn(),
     },
     campingOptionField: {
       count: jest.fn(),
@@ -262,6 +263,53 @@ describe('CampingOptionsService', () => {
       });
 
       expect(result).toBe(7);
+    });
+  });
+
+  describe('getRegistrationCountBatch', () => {
+    it('should return counts grouped by campingOptionId with year filter', async () => {
+      mockPrismaService.campingOptionRegistration.groupBy.mockResolvedValueOnce([
+        { campingOptionId: 'opt-1', _count: { campingOptionId: 3 } },
+        { campingOptionId: 'opt-2', _count: { campingOptionId: 5 } },
+      ]);
+
+      const result = await service.getRegistrationCountBatch(['opt-1', 'opt-2', 'opt-3'], 2026);
+
+      expect(prisma.campingOptionRegistration.groupBy).toHaveBeenCalledWith({
+        by: ['campingOptionId'],
+        where: {
+          campingOptionId: { in: ['opt-1', 'opt-2', 'opt-3'] },
+          registration: { year: 2026 },
+        },
+        _count: { campingOptionId: true },
+      });
+
+      expect(result.get('opt-1')).toBe(3);
+      expect(result.get('opt-2')).toBe(5);
+      expect(result.get('opt-3')).toBeUndefined();
+    });
+
+    it('should return empty map for empty ids array', async () => {
+      const result = await service.getRegistrationCountBatch([], 2026);
+
+      expect(result.size).toBe(0);
+      expect(prisma.campingOptionRegistration.groupBy).not.toHaveBeenCalled();
+    });
+
+    it('should not filter by year when year is undefined', async () => {
+      mockPrismaService.campingOptionRegistration.groupBy.mockResolvedValueOnce([
+        { campingOptionId: 'opt-1', _count: { campingOptionId: 10 } },
+      ]);
+
+      await service.getRegistrationCountBatch(['opt-1']);
+
+      expect(prisma.campingOptionRegistration.groupBy).toHaveBeenCalledWith({
+        by: ['campingOptionId'],
+        where: {
+          campingOptionId: { in: ['opt-1'] },
+        },
+        _count: { campingOptionId: true },
+      });
     });
   });
 

--- a/apps/api/src/camping-options/services/camping-options.service.spec.ts
+++ b/apps/api/src/camping-options/services/camping-options.service.spec.ts
@@ -220,7 +220,7 @@ describe('CampingOptionsService', () => {
   });
 
   describe('getRegistrationCount', () => {
-    it('should return the count of registrations for a camping option', async () => {
+    it('should return the count of registrations for a camping option (all-time when no year)', async () => {
       mockPrismaService.campingOptionRegistration.count.mockResolvedValueOnce(5);
       
       const result = await service.getRegistrationCount('test-id');
@@ -238,6 +238,30 @@ describe('CampingOptionsService', () => {
       const result = await service.getRegistrationCount('test-id');
       
       expect(result).toBe(0);
+    });
+
+    it('should filter by year when year parameter is provided', async () => {
+      mockPrismaService.campingOptionRegistration.count.mockResolvedValueOnce(3);
+
+      const result = await service.getRegistrationCount('test-id', 2026);
+
+      expect(prisma.campingOptionRegistration.count).toHaveBeenCalledWith({
+        where: { campingOptionId: 'test-id', registration: { year: 2026 } },
+      });
+
+      expect(result).toBe(3);
+    });
+
+    it('should not filter by year when year parameter is undefined', async () => {
+      mockPrismaService.campingOptionRegistration.count.mockResolvedValueOnce(7);
+
+      const result = await service.getRegistrationCount('test-id', undefined);
+
+      expect(prisma.campingOptionRegistration.count).toHaveBeenCalledWith({
+        where: { campingOptionId: 'test-id' },
+      });
+
+      expect(result).toBe(7);
     });
   });
 

--- a/apps/api/src/camping-options/services/camping-options.service.ts
+++ b/apps/api/src/camping-options/services/camping-options.service.ts
@@ -164,6 +164,37 @@ export class CampingOptionsService {
   }
 
   /**
+   * Get registration counts for multiple camping options in a single query
+   * @param ids - The IDs of the camping options
+   * @param year - Optional year to scope counts to (via registration relation)
+   * @returns Map of camping option ID to registration count
+   */
+  async getRegistrationCountBatch(ids: string[], year?: number): Promise<Map<string, number>> {
+    if (ids.length === 0) {
+      return new Map();
+    }
+
+    const where: Prisma.CampingOptionRegistrationWhereInput = {
+      campingOptionId: { in: ids },
+    };
+    if (year !== undefined) {
+      where.registration = { year };
+    }
+
+    const grouped = await this.prisma.campingOptionRegistration.groupBy({
+      by: ['campingOptionId'],
+      where,
+      _count: { campingOptionId: true },
+    });
+
+    const result = new Map<string, number>();
+    for (const row of grouped) {
+      result.set(row.campingOptionId, row._count.campingOptionId);
+    }
+    return result;
+  }
+
+  /**
    * Update a camping option
    * @param id - The ID of the camping option to update
    * @param updateCampingOptionDto - The data to update

--- a/apps/api/src/camping-options/services/camping-options.service.ts
+++ b/apps/api/src/camping-options/services/camping-options.service.ts
@@ -149,12 +149,16 @@ export class CampingOptionsService {
   /**
    * Get the current registration count for a camping option
    * @param id - The ID of the camping option
+   * @param year - Optional year to scope the count to (via registration relation)
    * @returns The number of registrations
    */
-  async getRegistrationCount(id: string): Promise<number> {
-    const count = await this.prisma.campingOptionRegistration.count({
-      where: { campingOptionId: id },
-    });
+  async getRegistrationCount(id: string, year?: number): Promise<number> {
+    const where: Prisma.CampingOptionRegistrationWhereInput = { campingOptionId: id };
+    if (year !== undefined) {
+      where.registration = { year };
+    }
+
+    const count = await this.prisma.campingOptionRegistration.count({ where });
 
     return count;
   }

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -739,9 +739,9 @@ export class PaymentsService {
         return;
       }
 
-      // Get camping option registrations for this user
+      // Get camping option registrations for this registration
       const campingOptionRegistrations = await this.prisma.campingOptionRegistration.findMany({
-        where: { userId: registration.userId },
+        where: { userId: registration.userId, registrationId },
         include: {
           campingOption: {
             include: { fields: true },

--- a/apps/api/src/registrations/controllers/admin-registrations.controller.spec.ts
+++ b/apps/api/src/registrations/controllers/admin-registrations.controller.spec.ts
@@ -94,6 +94,7 @@ describe('AdminRegistrationsController', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       userId: 'user-123',
+      registrationId: 'reg-123',
       campingOptionId: 'camping-option-1',
       campingOption: {
         id: 'camping-option-1',

--- a/apps/api/src/registrations/registrations.service.spec.ts
+++ b/apps/api/src/registrations/registrations.service.spec.ts
@@ -3,12 +3,14 @@ import { RegistrationsService } from './registrations.service';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { NotificationsService } from '../notifications/services/notifications.service';
 import { RegistrationPolicyService } from './services/registration-policy.service';
+import { CoreConfigService } from '../core-config/services/core-config.service';
 import { NotFoundException, ConflictException, ForbiddenException } from '@nestjs/common';
 import { RegistrationStatus, UserRole } from '@prisma/client';
 import { CreateRegistrationDto } from './dto';
 
 describe('RegistrationsService', () => {
   let service: RegistrationsService;
+  let mockCoreConfigService: { findCurrent: jest.Mock };
   // PrismaService is mocked and not directly used in tests
 
   type MockPrismaService = {
@@ -93,6 +95,15 @@ describe('RegistrationsService', () => {
         {
           provide: RegistrationPolicyService,
           useValue: mockPolicyService,
+        },
+        {
+          provide: CoreConfigService,
+          useFactory: () => {
+            mockCoreConfigService = {
+              findCurrent: jest.fn().mockResolvedValue({ registrationYear: new Date().getFullYear() }),
+            };
+            return mockCoreConfigService;
+          },
         },
       ],
     }).compile();
@@ -848,6 +859,85 @@ describe('RegistrationsService', () => {
       await expect(call).rejects.toThrow(
         'Registration is not available for your account. Please contact an administrator.',
       );
+    });
+  });
+
+  describe('getMyCampRegistration', () => {
+    const userId = 'user-123';
+
+    beforeEach(() => {
+      mockPrismaService.user.findUnique.mockResolvedValue({ id: userId });
+    });
+
+    it('should return only current-year camping option registrations', async () => {
+      mockCoreConfigService.findCurrent.mockResolvedValue({ registrationYear: 2026 });
+      mockPrismaService.campingOptionRegistration.findMany.mockResolvedValue([
+        { id: 'cor-1', campingOption: { fields: [] }, fieldValues: [] },
+      ]);
+      mockPrismaService.registration.findMany.mockResolvedValue([]);
+
+      const result = await service.getMyCampRegistration(userId);
+
+      expect(mockPrismaService.campingOptionRegistration.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId, registration: { year: 2026 } },
+        })
+      );
+      expect(result.campingOptions).toHaveLength(1);
+    });
+
+    it('should return hasRegistration false when user only has prior-year registrations', async () => {
+      mockCoreConfigService.findCurrent.mockResolvedValue({ registrationYear: 2026 });
+      // No camping options for current year
+      mockPrismaService.campingOptionRegistration.findMany.mockResolvedValue([]);
+      // No registrations for current year
+      mockPrismaService.registration.findMany.mockResolvedValue([]);
+
+      const result = await service.getMyCampRegistration(userId);
+
+      expect(result.hasRegistration).toBe(false);
+    });
+
+    it('should return hasRegistration true when user has current-year camping options', async () => {
+      mockCoreConfigService.findCurrent.mockResolvedValue({ registrationYear: 2026 });
+      mockPrismaService.campingOptionRegistration.findMany.mockResolvedValue([
+        { id: 'cor-1', campingOption: { fields: [] }, fieldValues: [] },
+      ]);
+      mockPrismaService.registration.findMany.mockResolvedValue([]);
+
+      const result = await service.getMyCampRegistration(userId);
+
+      expect(result.hasRegistration).toBe(true);
+    });
+
+    it('should return hasRegistration true when user has active current-year registration', async () => {
+      mockCoreConfigService.findCurrent.mockResolvedValue({ registrationYear: 2026 });
+      mockPrismaService.campingOptionRegistration.findMany.mockResolvedValue([]);
+      mockPrismaService.registration.findMany.mockResolvedValue([
+        { id: 'reg-1', status: RegistrationStatus.CONFIRMED, jobs: [], payments: [] },
+      ]);
+
+      const result = await service.getMyCampRegistration(userId);
+
+      expect(result.hasRegistration).toBe(true);
+    });
+
+    it('should return hasRegistration false when only current-year registration is cancelled', async () => {
+      mockCoreConfigService.findCurrent.mockResolvedValue({ registrationYear: 2026 });
+      mockPrismaService.campingOptionRegistration.findMany.mockResolvedValue([]);
+      mockPrismaService.registration.findMany.mockResolvedValue([
+        { id: 'reg-1', status: RegistrationStatus.CANCELLED, jobs: [], payments: [] },
+      ]);
+
+      const result = await service.getMyCampRegistration(userId);
+
+      expect(result.hasRegistration).toBe(false);
+    });
+
+    it('should throw NotFoundException if user does not exist', async () => {
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.getMyCampRegistration('nonexistent')).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/apps/api/src/registrations/registrations.service.ts
+++ b/apps/api/src/registrations/registrations.service.ts
@@ -5,6 +5,7 @@ import { CreateRegistrationDto, AddJobToRegistrationDto, CreateCampRegistrationD
 import { Registration, RegistrationStatus, UserRole } from '@prisma/client';
 import { DayOfWeek } from '../common/enums/day-of-week.enum';
 import { RegistrationPolicyService } from './services/registration-policy.service';
+import { CoreConfigService } from '../core-config/services/core-config.service';
 
 interface JobRegistrationWithJobs extends Registration {
   jobs?: Array<{
@@ -32,6 +33,7 @@ export class RegistrationsService {
     private readonly prisma: PrismaService,
     private readonly notificationsService: NotificationsService,
     private readonly policyService: RegistrationPolicyService,
+    private readonly coreConfigService: CoreConfigService,
   ) {}
 
   /**
@@ -608,7 +610,7 @@ export class RegistrationsService {
       }
       const existingCampingRegistration =
         await this.prisma.campingOptionRegistration.findFirst({
-          where: { userId, campingOptionId },
+          where: { userId, campingOptionId, registration: { year: currentYear } },
         });
       if (existingCampingRegistration) {
         throw new ConflictException(
@@ -752,7 +754,7 @@ export class RegistrationsService {
           for (const opt of validatedCampingOptions) {
             const campingRegistration =
               await tx.campingOptionRegistration.create({
-                data: { userId, campingOptionId: opt.campingOptionId },
+                data: { userId, campingOptionId: opt.campingOptionId, registrationId: jobRegistration.id },
                 include: { campingOption: { include: { fields: true } } },
               });
 
@@ -995,9 +997,9 @@ export class RegistrationsService {
     }
   ): Promise<void> {
     try {
-      // Get camping option registrations for this user
+      // Get camping option registrations for this registration
       const campingOptionRegistrations = await this.prisma.campingOptionRegistration.findMany({
-        where: { userId: registration.userId },
+        where: { userId: registration.userId, registrationId: registration.id },
         include: {
           campingOption: {
             include: { fields: true },
@@ -1084,7 +1086,7 @@ export class RegistrationsService {
   /**
    * Get user's camp registration
    * @param userId - The ID of the user
-   * @returns The user's camping option registrations and custom field values
+   * @returns The user's camping option registrations and custom field values for the current year
    */
   async getMyCampRegistration(userId: string) {
     // Check if user exists
@@ -1096,9 +1098,16 @@ export class RegistrationsService {
       throw new NotFoundException(`User with ID ${userId} not found`);
     }
 
-    // Get camping option registrations for the user
+    // Get current registration year from config
+    const config = await this.coreConfigService.findCurrent();
+    const currentYear = config.registrationYear;
+
+    // Get camping option registrations for the user, scoped to the current year
     const campingOptionRegistrations = await this.prisma.campingOptionRegistration.findMany({
-      where: { userId },
+      where: {
+        userId,
+        registration: { year: currentYear },
+      },
       include: {
         campingOption: {
           include: {
@@ -1113,9 +1122,9 @@ export class RegistrationsService {
       },
     });
 
-    // Get user's job registrations (all years)
+    // Get user's registrations for the current year
     const jobRegistrations = await this.prisma.registration.findMany({
-      where: { userId },
+      where: { userId, year: currentYear },
       include: {
         jobs: {
           include: {
@@ -1142,7 +1151,7 @@ export class RegistrationsService {
       }))
     );
 
-    // Check if user has any active registrations (non-cancelled)
+    // Check if user has any active registrations for the current year
     const activeJobRegistrations = jobRegistrations.filter(
       reg => reg.status !== RegistrationStatus.CANCELLED
     );

--- a/apps/api/src/registrations/registrations.service.ts
+++ b/apps/api/src/registrations/registrations.service.ts
@@ -578,7 +578,8 @@ export class RegistrationsService {
     // Pre-flight: active-registration conflict and camping-option existence
     // checks. These are expected 4xx rejections and stay outside the
     // broad try/catch that emits the registration-error email.
-    const currentYear = new Date().getFullYear();
+    const config = await this.coreConfigService.findCurrent();
+    const currentYear = config.registrationYear;
     const existingActiveRegistration = await this.prisma.registration.findFirst({
       where: {
         userId,
@@ -590,7 +591,7 @@ export class RegistrationsService {
       throw new ConflictException(`User already has an active registration for ${currentYear}`);
     }
 
-    const campingOptionIds = createCampRegistrationDto.campingOptions ?? [];
+    const campingOptionIds = [...new Set(createCampRegistrationDto.campingOptions ?? [])];
     // Validate every camping option up front: must exist and the user must
     // not already be registered for it. This catches a stale option id or
     // a duplicate signup before any writes happen, avoiding the

--- a/apps/api/src/registrations/services/registration-admin.service.spec.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.spec.ts
@@ -85,6 +85,7 @@ describe('RegistrationAdminService', () => {
       campingOptionRegistration: {
         findMany: jest.fn(),
         create: jest.fn(),
+        count: jest.fn(),
       },
       campingOption: {
         findUnique: jest.fn(),
@@ -264,6 +265,7 @@ describe('RegistrationAdminService', () => {
       (prismaService.campingOption.findUnique as jest.Mock).mockResolvedValue(mockCampingOptions[0]);
       (prismaService.campingOption.findMany as jest.Mock).mockResolvedValue(mockCampingOptions);
       (prismaService.campingOptionRegistration.findMany as jest.Mock).mockResolvedValue([]);
+      (prismaService.campingOptionRegistration.count as jest.Mock).mockResolvedValue(0);
 
       const result = await service.editRegistration('reg-123', editData, 'admin-123');
 

--- a/apps/api/src/registrations/services/registration-admin.service.spec.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.spec.ts
@@ -872,7 +872,7 @@ describe('RegistrationAdminService', () => {
 
       expect(result).toEqual(mockCampingOptionRegistrations);
       expect(prismaService.campingOptionRegistration.findMany).toHaveBeenCalledWith({
-        where: { userId: 'user-123' },
+        where: { userId: 'user-123', registrationId: 'reg-123' },
         include: {
           campingOption: {
             select: {
@@ -1095,7 +1095,7 @@ describe('RegistrationAdminService', () => {
       );
     });
 
-    it('should filter by year through user registrations', async () => {
+    it('should filter by year through registration relation', async () => {
       (prismaService.campingOptionRegistration.findMany as jest.Mock).mockResolvedValue([mockCampingOptionRegistration]);
 
       await service.getCampingOptionRegistrationsWithFields({ year: 2024 });
@@ -1103,12 +1103,8 @@ describe('RegistrationAdminService', () => {
       expect(prismaService.campingOptionRegistration.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            user: {
-              registrations: {
-                some: {
-                  year: 2024,
-                },
-              },
+            registration: {
+              year: 2024,
             },
           }),
         })
@@ -1127,6 +1123,7 @@ describe('RegistrationAdminService', () => {
     const mockCampingOptionRegistration = {
       id: 'cor-123',
       userId: 'user-123',
+      registrationId: 'reg-123',
       campingOptionId: 'co-123',
       createdAt: new Date('2024-01-01'),
       updatedAt: new Date('2024-01-01'),
@@ -1153,7 +1150,7 @@ describe('RegistrationAdminService', () => {
       
       expect(prismaService.campingOptionRegistration.findMany).toHaveBeenCalledWith({
         where: {
-          userId: { in: ['user-123'] },
+          registrationId: { in: ['reg-123'] },
           campingOption: {
             enabled: true,
           },

--- a/apps/api/src/registrations/services/registration-admin.service.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.ts
@@ -159,14 +159,14 @@ export class RegistrationAdminService {
     // If camping options are requested, fetch them separately and merge
     let registrationsWithCampingOptions = registrations;
     if (query.includeCampingOptions) {
-      // Get unique user IDs from registrations
-      const userIds = [...new Set(registrations.map(r => r.userId))];
+      // Get registration IDs to scope camping option lookups
+      const registrationIds = registrations.map(r => r.id);
       
-      if (userIds.length > 0) {
-        // Fetch camping option registrations for these users
+      if (registrationIds.length > 0) {
+        // Fetch camping option registrations linked to these registrations
         const campingOptionRegistrations = await this.prisma.campingOptionRegistration.findMany({
           where: {
-            userId: { in: userIds },
+            registrationId: { in: registrationIds },
             campingOption: {
               enabled: true, // Only include active camping options
             },
@@ -196,19 +196,22 @@ export class RegistrationAdminService {
           },
         });
 
-        // Group camping options by user ID for efficient lookup
-        const campingOptionsByUserId = campingOptionRegistrations.reduce((acc, cor) => {
-          if (!acc[cor.userId]) {
-            acc[cor.userId] = [];
+        // Group camping options by registration ID for efficient lookup
+        const campingOptionsByRegistrationId = campingOptionRegistrations.reduce((acc, cor) => {
+          const regId = cor.registrationId;
+          if (regId) {
+            if (!acc[regId]) {
+              acc[regId] = [];
+            }
+            acc[regId].push(cor);
           }
-          acc[cor.userId].push(cor);
           return acc;
         }, {} as Record<string, typeof campingOptionRegistrations>);
 
         // Add camping options to registrations
         registrationsWithCampingOptions = registrations.map(registration => ({
           ...registration,
-          campingOptions: campingOptionsByUserId[registration.userId] || [],
+          campingOptions: campingOptionsByRegistrationId[registration.id] || [],
         }));
       }
     }
@@ -348,9 +351,9 @@ export class RegistrationAdminService {
 
         // Handle camping option changes
         if (editData.campingOptionIds) {
-          // Get current camping options for this user
+          // Get current camping options linked to this registration
           const currentCampingOptions = await prisma.campingOptionRegistration.findMany({
-            where: { userId: currentRegistration.userId },
+            where: { userId: currentRegistration.userId, registrationId: currentRegistration.id },
             include: { campingOption: true },
           });
 
@@ -397,6 +400,7 @@ export class RegistrationAdminService {
               data: {
                 userId: currentRegistration.userId,
                 campingOptionId,
+                registrationId: currentRegistration.id,
               },
             });
 
@@ -468,9 +472,9 @@ export class RegistrationAdminService {
           });
 
           if (adminUser) {
-            // Get camping options for the user
+            // Get camping options for this registration
             const campingOptions = await this.prisma.campingOptionRegistration.findMany({
-              where: { userId: result.user.id },
+              where: { userId: result.user.id, registrationId: result.id },
               include: { campingOption: true },
             });
 
@@ -801,9 +805,9 @@ export class RegistrationAdminService {
       throw new NotFoundException(`Registration ${registrationId} not found`);
     }
 
-    // Get user's camping option registrations
+    // Get user's camping option registrations for this registration
     const campingOptionRegistrations = await this.prisma.campingOptionRegistration.findMany({
-      where: { userId: registration.userId },
+      where: { userId: registration.userId, registrationId },
       include: {
         campingOption: {
           select: {
@@ -864,15 +868,10 @@ export class RegistrationAdminService {
         };
       }
 
-      // For year filtering, we need to join through user registrations
-      // Since camping option registrations don't have a year field directly
+      // Filter by year via the direct registration FK
       if (filters?.year) {
-        where.user = {
-          registrations: {
-            some: {
-              year: filters.year,
-            },
-          },
+        where.registration = {
+          year: filters.year,
         };
       }
 

--- a/apps/api/src/registrations/services/registration-admin.service.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.ts
@@ -380,19 +380,23 @@ export class RegistrationAdminService {
             id => !currentCampingOptionIds.includes(id)
           );
           for (const campingOptionId of campingOptionsToAdd) {
-            // Validate camping option exists and has capacity
+            // Validate camping option exists and has capacity (year-scoped)
             const campingOption = await prisma.campingOption.findUnique({
               where: { id: campingOptionId },
-              include: {
-                registrations: true,
-              },
             });
 
             if (!campingOption) {
               throw new BadRequestException(`Camping option ${campingOptionId} not found`);
             }
 
-            if (campingOption.registrations.length >= campingOption.maxSignups) {
+            const yearScopedCount = await prisma.campingOptionRegistration.count({
+              where: {
+                campingOptionId,
+                registration: { year: currentRegistration.year },
+              },
+            });
+
+            if (yearScopedCount >= campingOption.maxSignups) {
               throw new ConflictException(`Camping option ${campingOption.name} is at capacity`);
             }
 

--- a/apps/api/src/registrations/services/registration-admin.service.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.ts
@@ -371,6 +371,7 @@ export class RegistrationAdminService {
               adminUserId,
               `Camping options modified: ${editData.notes || 'No notes provided'}`,
               transactionId,
+              currentRegistration.id,
             );
           }
 

--- a/apps/api/src/registrations/services/registration-cleanup.service.spec.ts
+++ b/apps/api/src/registrations/services/registration-cleanup.service.spec.ts
@@ -20,29 +20,29 @@ describe('RegistrationCleanupService', () => {
       firstName: 'John',
       lastName: 'Doe',
       role: UserRole.PARTICIPANT,
-      campingOptionRegistrations: [
-        {
-          id: 'camping-reg-1',
-          userId: 'user-123',
-          campingOptionId: 'camping-option-1',
-          campingOption: {
-            id: 'camping-option-1',
-            name: 'RV Spot',
-            description: 'RV parking spot',
-          },
-        },
-        {
-          id: 'camping-reg-2',
-          userId: 'user-123',
-          campingOptionId: 'camping-option-2',
-          campingOption: {
-            id: 'camping-option-2',
-            name: 'Tent Area',
-            description: 'Tent camping area',
-          },
-        },
-      ],
     },
+    campingOptionRegistrations: [
+      {
+        id: 'camping-reg-1',
+        userId: 'user-123',
+        campingOptionId: 'camping-option-1',
+        campingOption: {
+          id: 'camping-option-1',
+          name: 'RV Spot',
+          description: 'RV parking spot',
+        },
+      },
+      {
+        id: 'camping-reg-2',
+        userId: 'user-123',
+        campingOptionId: 'camping-option-2',
+        campingOption: {
+          id: 'camping-option-2',
+          name: 'Tent Area',
+          description: 'Tent camping area',
+        },
+      },
+    ],
     jobs: [
       {
         id: 'reg-job-1',
@@ -181,10 +181,7 @@ describe('RegistrationCleanupService', () => {
       const registrationWithNoRelated = {
         ...mockRegistration,
         jobs: [],
-        user: {
-          ...mockRegistration.user,
-          campingOptionRegistrations: [],
-        },
+        campingOptionRegistrations: [],
       };
 
       prismaService.$transaction.mockImplementation(async (callback) => {

--- a/apps/api/src/registrations/services/registration-cleanup.service.spec.ts
+++ b/apps/api/src/registrations/services/registration-cleanup.service.spec.ts
@@ -484,5 +484,47 @@ describe('RegistrationCleanupService', () => {
         service.cleanupCampingOptions('user-123', ['camping-option-1'], 'admin-123', 'Test error')
       ).rejects.toThrow('Database error');
     });
+
+    it('should scope cleanup by registrationId when provided', async () => {
+      const mockCampingOptionRegs = [
+        {
+          id: 'camping-reg-1',
+          userId: 'user-123',
+          campingOptionId: 'camping-option-1',
+          registrationId: 'reg-123',
+          campingOption: { id: 'camping-option-1', name: 'RV Spot' },
+        },
+      ];
+
+      prismaService.$transaction.mockImplementation(async (callback) => {
+        return await callback(prismaService);
+      });
+
+      (prismaService.campingOptionRegistration.findMany as jest.Mock).mockResolvedValue(mockCampingOptionRegs);
+      (prismaService.campingOptionRegistration.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+      adminAuditService.createMultipleAuditRecords.mockResolvedValue([
+        { ...mockAuditRecord, id: 'audit-1' },
+      ]);
+
+      const result = await service.cleanupCampingOptions(
+        'user-123',
+        ['camping-option-1'],
+        'admin-123',
+        'Scoped cleanup',
+        undefined,
+        'reg-123'
+      );
+
+      expect(prismaService.campingOptionRegistration.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: 'user-123',
+          campingOptionId: { in: ['camping-option-1'] },
+          registrationId: 'reg-123',
+        },
+        include: { campingOption: true },
+      });
+
+      expect(result).toBe(1);
+    });
   });
-}); 
+});

--- a/apps/api/src/registrations/services/registration-cleanup.service.ts
+++ b/apps/api/src/registrations/services/registration-cleanup.service.ts
@@ -50,17 +50,10 @@ export class RegistrationCleanupService {
                 job: true,
               },
             },
-            user: {
+            user: true,
+            campingOptionRegistrations: {
               include: {
-                campingOptionRegistrations: {
-                  where: {
-                    // Find camping options for this registration year
-                    // We'll match by user and then filter by registration context
-                  },
-                  include: {
-                    campingOption: true,
-                  },
-                },
+                campingOption: true,
               },
             },
           },
@@ -102,16 +95,8 @@ export class RegistrationCleanupService {
           this.logger.log(`Removed ${workShiftsRemoved} work shifts for registration ${registrationId}`);
         }
 
-        // Clean up camping option registrations
-        // Filter camping options that are related to this registration's year
-        const relevantCampingOptions = registration.user.campingOptionRegistrations.filter(
-          () => {
-            // We need to determine if this camping option registration is related to this registration
-            // For now, we'll use a heuristic based on creation time proximity or other logic
-            // This might need refinement based on your specific business logic
-            return true; // For now, clean up all camping options for the user
-          }
-        );
+        // Clean up camping option registrations linked to this registration
+        const relevantCampingOptions = registration.campingOptionRegistrations;
 
         if (relevantCampingOptions.length > 0) {
           for (const campingOptionReg of relevantCampingOptions) {
@@ -238,18 +223,24 @@ export class RegistrationCleanupService {
     adminUserId: string,
     reason: string,
     transactionId?: string,
+    registrationId?: string,
   ): Promise<number> {
     const txId = transactionId || randomUUID();
 
     try {
       return await this.prisma.$transaction(async (prisma) => {
-        const campingOptionRegs = await prisma.campingOptionRegistration.findMany({
-          where: {
-            userId,
-            campingOptionId: {
-              in: campingOptionIds,
-            },
+        const where: { userId: string; campingOptionId: { in: string[] }; registrationId?: string } = {
+          userId,
+          campingOptionId: {
+            in: campingOptionIds,
           },
+        };
+        if (registrationId) {
+          where.registrationId = registrationId;
+        }
+
+        const campingOptionRegs = await prisma.campingOptionRegistration.findMany({
+          where,
           include: {
             campingOption: true,
           },

--- a/apps/api/src/registrations/services/registration-cleanup.service.ts
+++ b/apps/api/src/registrations/services/registration-cleanup.service.ts
@@ -50,7 +50,6 @@ export class RegistrationCleanupService {
                 job: true,
               },
             },
-            user: true,
             campingOptionRegistrations: {
               include: {
                 campingOption: true,

--- a/apps/web/src/hooks/__tests__/useCampRegistration.test.tsx
+++ b/apps/web/src/hooks/__tests__/useCampRegistration.test.tsx
@@ -13,6 +13,13 @@ vi.mock('../../lib/api', () => {
   };
 });
 
+// Mock the auth module
+vi.mock('../../store/authUtils', () => ({
+  useAuth: vi.fn(),
+}));
+
+import { useAuth } from '../../store/authUtils';
+
 describe('useCampRegistration', () => {
   const mockCampRegistration = {
     campingOptions: [
@@ -102,6 +109,9 @@ describe('useCampRegistration', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    
+    // Mock authenticated user by default
+    (useAuth as Mock).mockReturnValue({ isAuthenticated: true });
     
     // Mock successful API response by default
     (apiModule.registrations.getMyCampRegistration as Mock).mockResolvedValue(mockCampRegistration);
@@ -208,5 +218,17 @@ describe('useCampRegistration', () => {
     
     expect(result.current.error).toBe('Failed to fetch camp registration');
     expect(result.current.loading).toBe(false);
+  });
+
+  it('should not fetch when user is not authenticated', async () => {
+    (useAuth as Mock).mockReturnValue({ isAuthenticated: false });
+
+    const { result } = renderHook(() => useCampRegistration());
+
+    // Should not be loading and should not call the API
+    expect(result.current.loading).toBe(false);
+    expect(result.current.campRegistration).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(apiModule.registrations.getMyCampRegistration).not.toHaveBeenCalled();
   });
 }) 

--- a/apps/web/src/hooks/__tests__/useUserRegistrations.test.tsx
+++ b/apps/web/src/hooks/__tests__/useUserRegistrations.test.tsx
@@ -13,6 +13,13 @@ vi.mock('../../lib/api', () => {
   };
 });
 
+// Mock the auth module
+vi.mock('../../store/authUtils', () => ({
+  useAuth: vi.fn(),
+}));
+
+import { useAuth } from '../../store/authUtils';
+
 describe('useUserRegistrations', () => {
   const mockRegistrations = [
     {
@@ -69,6 +76,9 @@ describe('useUserRegistrations', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    
+    // Mock authenticated user by default
+    (useAuth as Mock).mockReturnValue({ isAuthenticated: true });
     
     // Mock successful API response by default
     (apiModule.registrations.getMyRegistrations as Mock).mockResolvedValue(mockRegistrations);

--- a/apps/web/src/hooks/__tests__/useUserRegistrations.test.tsx
+++ b/apps/web/src/hooks/__tests__/useUserRegistrations.test.tsx
@@ -143,6 +143,18 @@ describe('useUserRegistrations', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('should not fetch when user is not authenticated', async () => {
+    (useAuth as Mock).mockReturnValue({ isAuthenticated: false });
+
+    const { result } = renderHook(() => useUserRegistrations());
+
+    // Should not be loading and should not call the API
+    expect(result.current.loading).toBe(false);
+    expect(result.current.registrations).toEqual([]);
+    expect(result.current.error).toBeNull();
+    expect(apiModule.registrations.getMyRegistrations).not.toHaveBeenCalled();
+  });
+
   it('should update loading state correctly during refetch', async () => {
     const { result } = renderHook(() => useUserRegistrations());
     

--- a/apps/web/src/hooks/useCampRegistration.ts
+++ b/apps/web/src/hooks/useCampRegistration.ts
@@ -71,8 +71,13 @@ export function useCampRegistration(): UseCampRegistrationResult {
   }, [isAuthenticated]);
 
   useEffect(() => {
+    if (!isAuthenticated) {
+      setCampRegistration(null);
+      setError(null);
+      return;
+    }
     fetchCampRegistration();
-  }, [fetchCampRegistration]);
+  }, [isAuthenticated, fetchCampRegistration]);
 
   return {
     campRegistration,

--- a/apps/web/src/hooks/useCampRegistration.ts
+++ b/apps/web/src/hooks/useCampRegistration.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { registrations, CampingOptionRegistration, CampingOptionField } from '../lib/api';
+import { useAuth } from '../store/authUtils';
 
 interface CampRegistrationData {
   campingOptions: CampingOptionRegistration[];
@@ -47,11 +48,15 @@ interface UseCampRegistrationResult {
  * @returns An object containing camp registration data, loading state, error state, and refetch function
  */
 export function useCampRegistration(): UseCampRegistrationResult {
+  const { isAuthenticated } = useAuth();
   const [campRegistration, setCampRegistration] = useState<CampRegistrationData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchCampRegistration = useCallback(async () => {
+    if (!isAuthenticated) {
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -63,7 +68,7 @@ export function useCampRegistration(): UseCampRegistrationResult {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [isAuthenticated]);
 
   useEffect(() => {
     fetchCampRegistration();

--- a/apps/web/src/hooks/useUserRegistrations.ts
+++ b/apps/web/src/hooks/useUserRegistrations.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { registrations, Registration } from '../lib/api';
+import { useAuth } from '../store/authUtils';
 
 interface UseUserRegistrationsResult {
   registrations: Registration[];
@@ -13,11 +14,15 @@ interface UseUserRegistrationsResult {
  * @returns An object containing registrations data, loading state, error state, and refetch function
  */
 export function useUserRegistrations(): UseUserRegistrationsResult {
+  const { isAuthenticated } = useAuth();
   const [userRegistrations, setUserRegistrations] = useState<Registration[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchRegistrations = useCallback(async () => {
+    if (!isAuthenticated) {
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -29,7 +34,7 @@ export function useUserRegistrations(): UseUserRegistrationsResult {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [isAuthenticated]);
 
   useEffect(() => {
     fetchRegistrations();

--- a/apps/web/src/hooks/useUserRegistrations.ts
+++ b/apps/web/src/hooks/useUserRegistrations.ts
@@ -37,8 +37,13 @@ export function useUserRegistrations(): UseUserRegistrationsResult {
   }, [isAuthenticated]);
 
   useEffect(() => {
+    if (!isAuthenticated) {
+      setUserRegistrations([]);
+      setError(null);
+      return;
+    }
     fetchRegistrations();
-  }, [fetchRegistrations]);
+  }, [isAuthenticated, fetchRegistrations]);
 
   return {
     registrations: userRegistrations,


### PR DESCRIPTION
## Motivation

When a new registration year is created (e.g., admin bumps `registrationYear` to 2026), users with prior-year camping registrations were completely blocked from registering. The `getMyCampRegistration` endpoint returned `hasRegistration: true` based on prior-year data, causing `RegistrationPage` to redirect users back to the dashboard. The dashboard also showed stale camping options from previous years, adding to the confusion.

The root cause: `CampingOptionRegistration` had no foreign key to `Registration` (which carries the `year` field), so all queries returned data regardless of year.

## Approach

Add a nullable `registrationId` FK from `CampingOptionRegistration` to `Registration`, making camping registrations proper child records. Year scoping then happens naturally through the parent's `year` field.

Key design decisions:

- **FK is nullable** to accommodate historical orphan data that predates the Registration model
- **Backfill migration** links each user's existing camping options to their non-cancelled Registration (confirmed max 1 per user historically)
- **Unique constraint** `@@unique([registrationId, campingOptionId])` prevents duplicate rows per registration (PostgreSQL treats NULLs as distinct, so legacy rows are unaffected)
- **`getRegistrationCount` takes optional `year` param** -- with year returns current-year capacity (for UI); without returns all-time count (for delete guard)
- **`createCampRegistration` uses `CoreConfig.registrationYear`** instead of `new Date().getFullYear()` for consistency when registration year differs from calendar year

## Changes

- **Schema**: Added `registrationId` FK, index, unique constraint, and reverse relation
- **Migrations**: Backfill SQL + unique index migration
- **`getMyCampRegistration`**: Filters by current `registrationYear` from config
- **`createCampRegistration`**: Passes `registrationId`, deduplicates input, uses config year
- **Admin queries**: Scope by `registrationId` for reports, edits, notifications
- **Payments**: Confirmation email scopes camping options by `registrationId`
- **Cleanup service**: `cleanupRegistration` uses `registration.campingOptionRegistrations` relation directly; `cleanupCampingOptions` accepts optional `registrationId`
- **`getRegistrationCount`**: Optional `year` parameter; controller passes current year
- **Tests**: 8 new tests, all existing tests updated for new field/dependencies (982 total passing)

## Things to note

- The frontend requires no code changes -- it already consumes what the API returns
- `CampingOptionsService.getRegistrationCount` without a year param still counts all-time (used by delete guard -- intentionally conservative)
- Registration counts currently include cancelled registrations in capacity; this is a minor edge case for follow-up since cancelled registrations should have their camping options cleaned up
- Before deploying, validate backfill assumptions with: `SELECT user_id, COUNT(*) FROM registrations WHERE status != 'CANCELLED' GROUP BY user_id HAVING COUNT(*) > 1`