### PR TITLE
fix: scope job capacity checks to registration year

### DIFF
--- a/apps/api/prisma/seeds/seed.e2e.ts
+++ b/apps/api/prisma/seeds/seed.e2e.ts
@@ -110,7 +110,9 @@ async function main(): Promise<void> {
  * prior-year entry.
  */
 async function seedPriorYearRegistration(): Promise<void> {
-  const currentConfig = await prisma.coreConfig.findFirst();
+  const currentConfig = await prisma.coreConfig.findFirst({
+    orderBy: { createdAt: 'desc' },
+  });
   if (!currentConfig) {
     console.log('⚠️  No coreConfig found, skipping prior-year registration seed');
     return;

--- a/apps/api/prisma/seeds/seed.e2e.ts
+++ b/apps/api/prisma/seeds/seed.e2e.ts
@@ -94,7 +94,70 @@ async function main(): Promise<void> {
     console.log('✅ Enabled allowDeferredDuesPayment on coreConfig');
   }
 
+  // Seed prior-year registration data for testing year-scoped capacity.
+  // This creates a CONFIRMED registration from the previous year for the admin
+  // persona on a low-capacity job (maxRegistrations=1). Tests verify that
+  // current-year registrations are not incorrectly waitlisted due to prior-year data.
+  await seedPriorYearRegistration();
+
   console.log('E2E personas seed complete.');
+}
+
+/**
+ * Create a prior-year CONFIRMED registration for the admin persona on a
+ * 1-capacity job. This exercises the year-scoping logic: current-year
+ * registrants for the same job should NOT be waitlisted because of this
+ * prior-year entry.
+ */
+async function seedPriorYearRegistration(): Promise<void> {
+  const currentConfig = await prisma.coreConfig.findFirst();
+  if (!currentConfig) {
+    console.log('⚠️  No coreConfig found, skipping prior-year registration seed');
+    return;
+  }
+
+  const priorYear = currentConfig.registrationYear - 1;
+  const adminUser = await prisma.user.findUnique({
+    where: { email: 'e2e-admin@test.playaplan.local' },
+  });
+  if (!adminUser) {
+    console.log('⚠️  Admin persona not found, skipping prior-year registration seed');
+    return;
+  }
+
+  // Find a 1-capacity, non-staff-only job to attach the prior-year registration to.
+  const targetJob = await prisma.job.findFirst({
+    where: {
+      maxRegistrations: 1,
+      category: { staffOnly: false },
+    },
+  });
+  if (!targetJob) {
+    console.log('⚠️  No 1-capacity non-staff job found, skipping prior-year registration seed');
+    return;
+  }
+
+  // Idempotent: skip if the admin already has a registration for priorYear.
+  const existing = await prisma.registration.findFirst({
+    where: { userId: adminUser.id, year: priorYear },
+  });
+  if (existing) {
+    console.log(`✅ Prior-year registration already exists (year=${priorYear}), skipping`);
+    return;
+  }
+
+  await prisma.registration.create({
+    data: {
+      status: 'CONFIRMED',
+      year: priorYear,
+      user: { connect: { id: adminUser.id } },
+      jobs: {
+        create: [{ job: { connect: { id: targetJob.id } } }],
+      },
+    },
+  });
+
+  console.log(`✅ Created prior-year (${priorYear}) CONFIRMED registration for admin on job "${targetJob.name}"`);
 }
 
 main()

--- a/apps/api/src/jobs/jobs.controller.spec.ts
+++ b/apps/api/src/jobs/jobs.controller.spec.ts
@@ -4,6 +4,7 @@ import { JobsService } from './jobs.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { RegistrationsService } from '../registrations/registrations.service';
+import { CoreConfigService } from '../core-config/services/core-config.service';
 import { UserRole } from '@prisma/client';
 
 describe('JobsController', () => {
@@ -25,6 +26,10 @@ describe('JobsController', () => {
     update: jest.fn(),
   };
 
+  const mockCoreConfigService = {
+    findCurrent: jest.fn().mockResolvedValue({ registrationYear: new Date().getFullYear() }),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [JobsController],
@@ -36,6 +41,10 @@ describe('JobsController', () => {
         {
           provide: RegistrationsService,
           useValue: mockRegistrationsService,
+        },
+        {
+          provide: CoreConfigService,
+          useValue: mockCoreConfigService,
         },
       ],
     })

--- a/apps/api/src/jobs/jobs.controller.spec.ts
+++ b/apps/api/src/jobs/jobs.controller.spec.ts
@@ -288,6 +288,32 @@ describe('JobsController', () => {
     });
   });
 
+  describe('register', () => {
+    it('should register the current user for a job using year from config', async () => {
+      const jobId = 'test-job-id';
+      const userId = 'test-user-id';
+      const mockReq = { user: { id: userId, role: UserRole.PARTICIPANT } } as unknown as Parameters<typeof controller.register>[1];
+      const expectedRegistration = {
+        id: 'reg-id',
+        userId,
+        year: new Date().getFullYear(),
+        status: 'PENDING',
+      };
+
+      mockRegistrationsService.create.mockResolvedValue(expectedRegistration);
+
+      const result = await controller.register(jobId, mockReq);
+
+      expect(mockCoreConfigService.findCurrent).toHaveBeenCalled();
+      expect(mockRegistrationsService.create).toHaveBeenCalledWith({
+        userId,
+        year: new Date().getFullYear(),
+        jobIds: [jobId],
+      });
+      expect(result).toEqual(expectedRegistration);
+    });
+  });
+
   describe('remove', () => {
     it('should remove a job', async () => {
       const jobId = 'test-id';

--- a/apps/api/src/jobs/jobs.controller.ts
+++ b/apps/api/src/jobs/jobs.controller.ts
@@ -8,6 +8,7 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { UserRole } from '@prisma/client';
 import { ApiTags, ApiBearerAuth, ApiCreatedResponse, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { RegistrationsService } from '../registrations/registrations.service';
+import { CoreConfigService } from '../core-config/services/core-config.service';
 import { Request } from 'express';
 
 interface RequestWithUser extends Request {
@@ -27,6 +28,7 @@ export class JobsController {
   constructor(
     private readonly jobsService: JobsService,
     private readonly registrationsService: RegistrationsService,
+    private readonly coreConfigService: CoreConfigService,
   ) {}
 
   @Post()
@@ -72,11 +74,11 @@ export class JobsController {
   @ApiCreatedResponse({ description: 'User has been successfully registered for the job.' })
   async register(@Param('id') jobId: string, @Req() req: RequestWithUser) {
     const userId = req.user.id;
-    const currentYear = new Date().getFullYear(); // You might want to get this from config instead
+    const config = await this.coreConfigService.findCurrent();
     
     return this.registrationsService.create({
       userId,
-      year: currentYear,
+      year: config.registrationYear,
       jobIds: [jobId],
     });
   }

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -4,9 +4,10 @@ import { JobsService } from './jobs.service';
 import { PrismaModule } from '../common/prisma/prisma.module';
 import { CategoriesModule } from './categories/categories.module';
 import { RegistrationsModule } from '../registrations/registrations.module';
+import { CoreConfigModule } from '../core-config/core-config.module';
 
 @Module({
-  imports: [PrismaModule, CategoriesModule, RegistrationsModule],
+  imports: [PrismaModule, CategoriesModule, RegistrationsModule, CoreConfigModule],
   controllers: [JobsController],
   providers: [JobsService],
   exports: [JobsService],

--- a/apps/api/src/jobs/jobs.service.spec.ts
+++ b/apps/api/src/jobs/jobs.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { JobsService } from './jobs.service';
 import { PrismaService } from '../common/prisma/prisma.service';
+import { CoreConfigService } from '../core-config/services/core-config.service';
 import { NotFoundException } from '@nestjs/common';
 import { UserRole } from '@prisma/client';
 import { CreateJobDto } from './dto/create-job.dto';
@@ -21,6 +22,10 @@ describe('JobsService', () => {
     },
   };
 
+  const mockCoreConfigService = {
+    findCurrent: jest.fn().mockResolvedValue({ registrationYear: new Date().getFullYear() }),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -28,6 +33,10 @@ describe('JobsService', () => {
         {
           provide: PrismaService,
           useValue: mockPrismaService,
+        },
+        {
+          provide: CoreConfigService,
+          useValue: mockCoreConfigService,
         },
       ],
     }).compile();
@@ -644,6 +653,65 @@ describe('JobsService', () => {
 
       expect(result).toEqual(expectedJob);
       expect(result.currentRegistrations).toBe(2);
+    });
+
+    it('should use registrationYear from config, not calendar year', async () => {
+      // Simulate config year being different from Date().getFullYear()
+      const configYear = 2025;
+      mockCoreConfigService.findCurrent.mockResolvedValue({ registrationYear: configYear });
+
+      const mockJob = {
+        id: 'test-id',
+        name: 'Test Job',
+        location: 'Test Location',
+        categoryId: 'test-category-id',
+        shiftId: 'test-shift-id',
+        maxRegistrations: 5,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        category: {
+          id: 'test-category-id',
+          name: 'Test Category',
+          description: 'Test Category Description',
+          staffOnly: false,
+          alwaysRequired: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        shift: {
+          id: 'test-shift-id',
+          name: 'Test Shift',
+          description: 'Test Shift Description',
+          startTime: '09:00',
+          endTime: '17:00',
+          dayOfWeek: 'MONDAY',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        registrations: [
+          {
+            id: 'reg-job-1',
+            registrationId: 'reg-1',
+            jobId: 'test-id',
+            createdAt: new Date(),
+            registration: { id: 'reg-1', status: 'CONFIRMED', year: 2025, createdAt: new Date(), updatedAt: new Date(), userId: 'user-1' },
+          },
+          {
+            id: 'reg-job-2',
+            registrationId: 'reg-2',
+            jobId: 'test-id',
+            createdAt: new Date(),
+            registration: { id: 'reg-2', status: 'CONFIRMED', year: 2026, createdAt: new Date(), updatedAt: new Date(), userId: 'user-2' },
+          },
+        ],
+      };
+
+      mockPrismaService.job.findUnique.mockResolvedValue(mockJob);
+
+      const result = await service.findOne('test-id');
+
+      // Only the 2025 registration should count (configYear=2025)
+      expect(result.currentRegistrations).toBe(1);
     });
   });
 }); 

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../common/prisma/prisma.service';
+import { CoreConfigService } from '../core-config/services/core-config.service';
 import { CreateJobDto } from './dto/create-job.dto';
 import { UpdateJobDto } from './dto/update-job.dto';
 import { Job, Prisma, UserRole } from '@prisma/client';
@@ -41,9 +42,13 @@ type JobWithRelations = Job & {
 
 @Injectable()
 export class JobsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private coreConfigService: CoreConfigService,
+  ) {}
 
   async create(createJobDto: CreateJobDto) {
+    const config = await this.coreConfigService.findCurrent();
     const job = await this.prisma.job.create({
       data: {
         name: createJobDto.name,
@@ -68,7 +73,7 @@ export class JobsService {
     });
 
     // Add derived properties from category and calculate current registrations
-    return this.addDerivedPropertiesWithRegistrations(job);
+    return this.addDerivedPropertiesWithRegistrations(job, config.registrationYear);
   }
 
   /**
@@ -77,6 +82,7 @@ export class JobsService {
    * @param userRole - Optional role to filter results
    */
   async findAll(userRole?: UserRole) {
+    const config = await this.coreConfigService.findCurrent();
     const jobs = await this.prisma.job.findMany({
       where: {
         ...(userRole === UserRole.PARTICIPANT && { category: { staffOnly: false } }),
@@ -92,10 +98,11 @@ export class JobsService {
       },
     });
 
-    return jobs.map(job => this.addDerivedPropertiesWithRegistrations(job));
+    return jobs.map(job => this.addDerivedPropertiesWithRegistrations(job, config.registrationYear));
   }
 
   async findOne(id: string) {
+    const config = await this.coreConfigService.findCurrent();
     const job = await this.prisma.job.findUnique({
       where: { id },
       include: {
@@ -114,11 +121,12 @@ export class JobsService {
     }
 
     // Add derived properties from category and calculate current registrations
-    return this.addDerivedPropertiesWithRegistrations(job);
+    return this.addDerivedPropertiesWithRegistrations(job, config.registrationYear);
   }
 
   async update(id: string, updateJobDto: UpdateJobDto) {
     try {
+      const config = await this.coreConfigService.findCurrent();
       // Create update data object with proper typing
       const updateData: Prisma.JobUpdateInput = {};
       
@@ -149,7 +157,7 @@ export class JobsService {
       });
 
       // Add derived properties from category and calculate current registrations
-      return this.addDerivedPropertiesWithRegistrations(job);
+      return this.addDerivedPropertiesWithRegistrations(job, config.registrationYear);
     } catch {
       throw new NotFoundException(`Job with ID ${id} not found`);
     }
@@ -157,6 +165,7 @@ export class JobsService {
 
   async remove(id: string) {
     try {
+      const config = await this.coreConfigService.findCurrent();
       const job = await this.prisma.job.delete({
         where: { id },
         include: {
@@ -171,7 +180,7 @@ export class JobsService {
       });
 
       // Add derived properties from category and calculate current registrations
-      return this.addDerivedPropertiesWithRegistrations(job);
+      return this.addDerivedPropertiesWithRegistrations(job, config.registrationYear);
     } catch {
       throw new NotFoundException(`Job with ID ${id} not found`);
     }
@@ -180,14 +189,11 @@ export class JobsService {
   /**
    * Add derived properties from category and calculate current registrations for a job
    */
-  private addDerivedPropertiesWithRegistrations(job: JobWithRelations) {
-    // Get current year
-    const currentYear = new Date().getFullYear();
-    
-    // Count all non-cancelled registrations for the current year
+  private addDerivedPropertiesWithRegistrations(job: JobWithRelations, registrationYear: number) {
+    // Count all non-cancelled registrations for the configured registration year
     // This includes PENDING, CONFIRMED, and WAITLISTED registrations
     const currentRegistrations = job.registrations?.filter(
-      reg => reg.registration.status !== 'CANCELLED' && reg.registration.year === currentYear
+      reg => reg.registration.status !== 'CANCELLED' && reg.registration.year === registrationYear
     ).length || 0;
 
     // Exclude registrations from the returned object

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -125,8 +125,8 @@ export class JobsService {
   }
 
   async update(id: string, updateJobDto: UpdateJobDto) {
+    const config = await this.coreConfigService.findCurrent();
     try {
-      const config = await this.coreConfigService.findCurrent();
       // Create update data object with proper typing
       const updateData: Prisma.JobUpdateInput = {};
       
@@ -164,8 +164,8 @@ export class JobsService {
   }
 
   async remove(id: string) {
+    const config = await this.coreConfigService.findCurrent();
     try {
-      const config = await this.coreConfigService.findCurrent();
       const job = await this.prisma.job.delete({
         where: { id },
         include: {

--- a/apps/api/src/registrations/registrations.service.spec.ts
+++ b/apps/api/src/registrations/registrations.service.spec.ts
@@ -227,7 +227,7 @@ describe('RegistrationsService', () => {
       const fullJob = {
         id: 'job-id-1',
         maxRegistrations: 1,
-        registrations: [{ registration: { status: RegistrationStatus.CONFIRMED } }],
+        registrations: [{ registration: { status: RegistrationStatus.CONFIRMED, year: 2024 } }],
       };
       
       mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
@@ -243,6 +243,39 @@ describe('RegistrationsService', () => {
       const result = await service.create(createDto);
       
       expect(result.status).toBe(RegistrationStatus.WAITLISTED);
+      expect(mockPrismaService.registration.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: RegistrationStatus.WAITLISTED,
+          }),
+        }),
+      );
+    });
+
+    it('should not count prior-year registrations toward capacity', async () => {
+      const jobWithPriorYearReg = {
+        id: 'job-id-1',
+        maxRegistrations: 1,
+        registrations: [{ registration: { status: RegistrationStatus.CONFIRMED, year: 2023 } }],
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
+      mockPrismaService.registration.findFirst.mockResolvedValue(null);
+      mockPrismaService.job.findUnique
+        .mockResolvedValueOnce(jobWithPriorYearReg)
+        .mockResolvedValueOnce(mockJobs[1]);
+      mockPrismaService.registration.create.mockResolvedValue(mockRegistration);
+
+      const result = await service.create(createDto);
+
+      expect(result.status).toBe(RegistrationStatus.PENDING);
+      expect(mockPrismaService.registration.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: RegistrationStatus.PENDING,
+          }),
+        }),
+      );
     });
 
     it('should throw ForbiddenException when participant registers for staffOnly job', async () => {
@@ -859,6 +892,55 @@ describe('RegistrationsService', () => {
       await expect(call).rejects.toThrow(
         'Registration is not available for your account. Please contact an administrator.',
       );
+    });
+
+    it('should not count prior-year registrations toward capacity in createCampRegistration', async () => {
+      // Job has maxRegistrations=1 with one CONFIRMED registration from a prior year.
+      // Current registration year is 2026, but the existing registration is for 2025.
+      mockCoreConfigService.findCurrent.mockResolvedValue({ registrationYear: 2026 });
+      mockPrismaService.job.findUnique.mockResolvedValue({
+        id: 'job-1',
+        maxRegistrations: 1,
+        staffOnly: false,
+        registrations: [{ registration: { status: RegistrationStatus.CONFIRMED, year: 2025 } }],
+      });
+      const created = buildCreatedRegistration({ status: RegistrationStatus.PENDING });
+      mockPrismaService.registration.create.mockResolvedValue(created);
+
+      const result = await service.createCampRegistration(userId, baseDto);
+
+      expect(mockPrismaService.registration.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: RegistrationStatus.PENDING,
+          }),
+        }),
+      );
+      expect(result.jobRegistration?.status).toBe(RegistrationStatus.PENDING);
+    });
+
+    it('should count same-year registrations toward capacity in createCampRegistration', async () => {
+      // Job has maxRegistrations=1 with one CONFIRMED registration for the current year.
+      mockCoreConfigService.findCurrent.mockResolvedValue({ registrationYear: 2026 });
+      mockPrismaService.job.findUnique.mockResolvedValue({
+        id: 'job-1',
+        maxRegistrations: 1,
+        staffOnly: false,
+        registrations: [{ registration: { status: RegistrationStatus.CONFIRMED, year: 2026 } }],
+      });
+      const created = buildCreatedRegistration({ status: RegistrationStatus.WAITLISTED });
+      mockPrismaService.registration.create.mockResolvedValue(created);
+
+      const result = await service.createCampRegistration(userId, baseDto);
+
+      expect(mockPrismaService.registration.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: RegistrationStatus.WAITLISTED,
+          }),
+        }),
+      );
+      expect(result.jobRegistration?.status).toBe(RegistrationStatus.WAITLISTED);
     });
   });
 

--- a/apps/api/src/registrations/registrations.service.ts
+++ b/apps/api/src/registrations/registrations.service.ts
@@ -98,6 +98,7 @@ export class RegistrationsService {
 
         const currentRegistrationCount = job.registrations.filter(
           r => r.registration.status !== RegistrationStatus.CANCELLED
+            && r.registration.year === createRegistrationDto.year
         ).length;
 
         return { job, currentRegistrationCount };
@@ -212,6 +213,7 @@ export class RegistrationsService {
     // Check if this affects the registration status
     const currentRegistrationCount = job.registrations.filter(
       r => r.registration.status !== RegistrationStatus.CANCELLED
+        && r.registration.year === registration.year
     ).length;
 
     const shouldBeWaitlisted = currentRegistrationCount >= job.maxRegistrations;
@@ -644,7 +646,8 @@ export class RegistrationsService {
           throw new NotFoundException(`Job with ID ${jobId} not found`);
         }
         const currentRegistrationCount = job.registrations.filter(
-          (r) => r.registration.status !== RegistrationStatus.CANCELLED,
+          (r) => r.registration.status !== RegistrationStatus.CANCELLED
+            && r.registration.year === currentYear,
         ).length;
         return { job, currentRegistrationCount };
       }),

--- a/tests/registration/register-prior-year-data.spec.ts
+++ b/tests/registration/register-prior-year-data.spec.ts
@@ -22,7 +22,9 @@ test.describe(
       const prisma = getPrisma();
 
       // Find the job that has the prior-year registration from seed.e2e.ts
-      const config = await prisma.coreConfig.findFirst();
+      const config = await prisma.coreConfig.findFirst({
+        orderBy: { createdAt: 'desc' },
+      });
       expect(config).not.toBeNull();
       const currentYear = config!.registrationYear;
       const priorYear = currentYear - 1;
@@ -44,7 +46,7 @@ test.describe(
       });
       expect(jobWithPriorYearReg).not.toBeNull();
 
-      // Authenticate as a fresh participant and call the jobs endpoint
+      // Authenticate as a staff user and call the jobs endpoint
       const api: ApiClient = await createAuthedApiClient(
         'e2e-staff@test.playaplan.local',
       );
@@ -84,7 +86,9 @@ test.describe(
       freshParticipant,
     }) => {
       const prisma = getPrisma();
-      const config = await prisma.coreConfig.findFirst();
+      const config = await prisma.coreConfig.findFirst({
+        orderBy: { createdAt: 'desc' },
+      });
       expect(config).not.toBeNull();
       const currentYear = config!.registrationYear;
       const priorYear = currentYear - 1;

--- a/tests/registration/register-prior-year-data.spec.ts
+++ b/tests/registration/register-prior-year-data.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Verifies that prior-year registration data does not incorrectly affect
+ * current-year capacity calculations. Covers the bug where registrations
+ * from a previous year caused jobs to appear full and new registrations
+ * to be marked WAITLISTED even though the job had capacity for the
+ * current year.
+ *
+ * Depends on seed.e2e.ts having created a prior-year CONFIRMED registration
+ * on a 1-capacity job for the admin persona.
+ */
+import { test, expect } from '../helpers/fixtures';
+import { createAuthedApiClient, ApiClient } from '../helpers/api';
+import { getPrisma } from '../helpers/db';
+
+test.describe(
+  'Registration: prior-year data does not block current-year capacity',
+  { tag: ['@registration', '@capacity'] },
+  () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test('jobs API reports correct availability when prior-year registration exists', async () => {
+      const prisma = getPrisma();
+
+      // Find the job that has the prior-year registration from seed.e2e.ts
+      const config = await prisma.coreConfig.findFirst();
+      expect(config).not.toBeNull();
+      const currentYear = config!.registrationYear;
+      const priorYear = currentYear - 1;
+
+      // Find a job with maxRegistrations=1 that has a prior-year registration
+      const jobWithPriorYearReg = await prisma.job.findFirst({
+        where: {
+          maxRegistrations: 1,
+          category: { staffOnly: false },
+          registrations: {
+            some: {
+              registration: {
+                year: priorYear,
+                status: 'CONFIRMED',
+              },
+            },
+          },
+        },
+      });
+      expect(jobWithPriorYearReg).not.toBeNull();
+
+      // Authenticate as a fresh participant and call the jobs endpoint
+      const api: ApiClient = await createAuthedApiClient(
+        'e2e-staff@test.playaplan.local',
+      );
+
+      try {
+        const res = await api.context.get('/jobs');
+        expect(res.ok()).toBeTruthy();
+
+        const jobs = (await res.json()) as Array<{
+          id: string;
+          currentRegistrations: number;
+          maxRegistrations: number;
+        }>;
+
+        const targetJob = jobs.find((j) => j.id === jobWithPriorYearReg!.id);
+        expect(targetJob).toBeDefined();
+
+        // The job should show 0 current registrations for the current year,
+        // despite having a prior-year registration
+        const currentYearRegs = await prisma.registrationJob.count({
+          where: {
+            jobId: jobWithPriorYearReg!.id,
+            registration: {
+              year: currentYear,
+              status: { not: 'CANCELLED' },
+            },
+          },
+        });
+        expect(targetJob!.currentRegistrations).toBe(currentYearRegs);
+        expect(targetJob!.currentRegistrations).toBeLessThan(targetJob!.maxRegistrations);
+      } finally {
+        await api.dispose();
+      }
+    });
+
+    test('participant can register for a job that was full only in a prior year', async ({
+      freshParticipant,
+    }) => {
+      const prisma = getPrisma();
+      const config = await prisma.coreConfig.findFirst();
+      expect(config).not.toBeNull();
+      const currentYear = config!.registrationYear;
+      const priorYear = currentYear - 1;
+
+      // Find a 1-capacity non-staff job with a prior-year registration
+      const targetJob = await prisma.job.findFirst({
+        where: {
+          maxRegistrations: 1,
+          category: { staffOnly: false },
+          registrations: {
+            some: {
+              registration: {
+                year: priorYear,
+                status: 'CONFIRMED',
+              },
+            },
+          },
+        },
+      });
+      expect(targetJob).not.toBeNull();
+
+      // Verify no current-year registration for this job
+      const currentYearRegs = await prisma.registrationJob.count({
+        where: {
+          jobId: targetJob!.id,
+          registration: {
+            year: currentYear,
+            status: { not: 'CANCELLED' },
+          },
+        },
+      });
+      expect(currentYearRegs).toBe(0);
+
+      // Also pick a high-capacity job for the "Teardown" category requirement
+      const teardownJob = await prisma.job.findFirst({
+        where: { maxRegistrations: { gte: 20 } },
+      });
+      expect(teardownJob).not.toBeNull();
+
+      // Register the fresh participant via the API
+      const api: ApiClient = await createAuthedApiClient(freshParticipant.email);
+
+      try {
+        const res = await api.context.post('/registrations/camp', {
+          data: {
+            acceptedTerms: true,
+            jobs: [targetJob!.id, teardownJob!.id],
+            campingOptions: [],
+          },
+        });
+
+        expect(res.ok()).toBeTruthy();
+
+        // Verify the registration was created with PENDING status (not WAITLISTED)
+        const reg = await prisma.registration.findFirst({
+          where: {
+            userId: freshParticipant.id,
+            year: currentYear,
+          },
+        });
+        expect(reg).not.toBeNull();
+        expect(reg!.status).toBe('PENDING');
+      } finally {
+        await api.dispose();
+      }
+    });
+  },
+);


### PR DESCRIPTION
## Problem

On the test server (test.burningsky.org), registrations were completing as WAITLISTED after successful payment. The issue only appeared in environments with prior-year data in the database -- it could not be reproduced locally because local dev has no historical registrations.

## Root cause

The backend capacity checks in `registrations.service.ts` counted all non-cancelled registrations across all years when determining whether a job was full. Meanwhile, `jobs.service.ts` correctly filtered by the current year when reporting available slots to the frontend. This mismatch meant the frontend showed jobs as available while the backend waitlisted new registrations because prior-year entries consumed capacity.

## Approach

Scoped all capacity-related queries to `config.registrationYear` from `CoreConfigService`:

- **registrations.service.ts** -- Added year filter to 3 capacity-check sites: `create()`, `addJob()`, and `createCampRegistration()`
- **jobs.service.ts** -- Injected `CoreConfigService` and passed `registrationYear` to `addDerivedPropertiesWithRegistrations()` so the frontend count also uses config rather than `new Date().getFullYear()`
- **jobs.controller.ts** -- Replaced `new Date().getFullYear()` with `config.registrationYear` in the `POST /jobs/:id/register` endpoint
- **jobs.module.ts** -- Added `CoreConfigModule` import

## Testing

- Added unit tests for year-scoped capacity logic in both `registrations.service.spec.ts` and `jobs.service.spec.ts`
- Augmented e2e seed data (`seed.e2e.ts`) with a prior-year CONFIRMED registration on a 1-capacity job
- Created new e2e spec (`register-prior-year-data.spec.ts`) verifying that prior-year registrations don't block current-year capacity
- Full suite: 990 tests passing, lint clean

## Follow-up issues

- #182 -- Admin shift reports should filter by configured registration year
- #183 -- addJob() should reject modifications to cancelled registrations