### PR TITLE
feat(web): show full registration history below camping options

### DIFF
--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -5,7 +5,7 @@ import { useUserRegistrations } from '../hooks/useUserRegistrations';
 import { useCampRegistration } from '../hooks/useCampRegistration';
 import { useConfig } from '../hooks/useConfig';
 import { getFriendlyDayName, formatTime } from '../utils/shiftUtils';
-import { isRegistrationAccessible, getRegistrationStatusMessage, getActiveRegistrations, getCancelledRegistrations } from '../utils/registrationUtils';
+import { isRegistrationAccessible, getRegistrationStatusMessage, getActiveRegistrations } from '../utils/registrationUtils';
 import { PATHS } from '../routes';
 import PaymentButton from '../components/payment/PaymentButton';
 
@@ -36,9 +36,13 @@ const DashboardPage: React.FC = () => {
   const currentYear = config?.currentYear || new Date().getFullYear();
   const currentYearRegistrations = registrations?.filter(reg => reg.year === currentYear) || [];
   const activeCurrentRegistrations = getActiveRegistrations(currentYearRegistrations);
-  const cancelledCurrentRegistrations = getCancelledRegistrations(currentYearRegistrations);
   const currentRegistration = activeCurrentRegistrations[0]; // Get the most recent active registration
   
+  // Build registration history: all registrations except the current active one, sorted by year desc then date desc
+  const registrationHistory = (registrations || [])
+    .filter(reg => reg.id !== currentRegistration?.id)
+    .sort((a, b) => b.year !== a.year ? b.year - a.year : new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
   // Check registration access status
   const hasActiveRegistration = activeCurrentRegistrations.length > 0;
   const canAccessRegistration = isRegistrationAccessible(config, user);
@@ -309,67 +313,6 @@ const DashboardPage: React.FC = () => {
             )}
           </div>
 
-          {/* Registration History Section */}
-          {!registrationsLoading && !registrationsError && cancelledCurrentRegistrations.length > 0 && (
-            <div className="mb-8">
-              <h3 className="text-lg font-medium text-gray-900 mb-4">Registration History</h3>
-              <div className="space-y-4">
-                {cancelledCurrentRegistrations.map((registration) => (
-                  <div key={registration.id} className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-                    <div className="flex items-center justify-between mb-3">
-                      <h4 className="font-medium text-gray-900">Registration from {new Date(registration.createdAt).toLocaleDateString()}</h4>
-                      <span className="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-800">
-                        {registration.status}
-                      </span>
-                    </div>
-                    
-                    {registration.jobs.length > 0 && (
-                      <div className="mb-3">
-                        <h5 className="text-sm font-medium text-gray-700 mb-2">Work Shifts</h5>
-                        <div className="space-y-2">
-                          {registration.jobs.map((registrationJob) => (
-                            <div key={registrationJob.id} className="text-sm text-gray-600">
-                              <span className="font-medium">{registrationJob.job?.name}</span>
-                              {registrationJob.job?.shift && (
-                                <span className="ml-2">
-                                  - {getFriendlyDayName(registrationJob.job.shift.dayOfWeek)} 
-                                  {formatTime(registrationJob.job.shift.startTime)} - {formatTime(registrationJob.job.shift.endTime)}
-                                </span>
-                              )}
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    
-                    {registration.payments.length > 0 && (
-                      <div>
-                        <h5 className="text-sm font-medium text-gray-700 mb-2">Payments</h5>
-                        <div className="space-y-1">
-                          {registration.payments.map((payment) => (
-                            <div key={payment.id} className="flex items-center justify-between text-sm">
-                              <span className="text-gray-600">
-                                ${payment.amount.toFixed(2)} - {new Date(payment.createdAt).toLocaleDateString()}
-                              </span>
-                              <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                                payment.status === 'COMPLETED' ? 'bg-green-100 text-green-800' :
-                                payment.status === 'REFUNDED' ? 'bg-blue-100 text-blue-800' :
-                                payment.status === 'FAILED' ? 'bg-red-100 text-red-800' :
-                                'bg-gray-100 text-gray-800'
-                              }`}>
-                                {payment.status}
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
           {/* Camping Options Section */}
           <div className="mb-8">
             <h3 className="text-lg font-medium text-gray-900 mb-4">Camping</h3>
@@ -426,6 +369,74 @@ const DashboardPage: React.FC = () => {
               </div>
             )}
           </div>
+
+          {/* Registration History Section */}
+          {!registrationsLoading && !registrationsError && registrationHistory.length > 0 && (
+            <div className="mb-8">
+              <h3 className="text-lg font-medium text-gray-900 mb-4">Registration History</h3>
+              <div className="space-y-4">
+                {registrationHistory.map((registration) => (
+                  <div key={registration.id} className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                    <div className="flex items-center justify-between mb-3">
+                      <h4 className="font-medium text-gray-900">
+                        {registration.year} — {new Date(registration.createdAt).toLocaleDateString()}
+                      </h4>
+                      <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                        registration.status === 'CONFIRMED' ? 'bg-green-100 text-green-800' :
+                        registration.status === 'PENDING' ? 'bg-yellow-100 text-yellow-800' :
+                        registration.status === 'WAITLISTED' ? 'bg-orange-100 text-orange-800' :
+                        'bg-gray-100 text-gray-800'
+                      }`}>
+                        {registration.status}
+                      </span>
+                    </div>
+                    
+                    {registration.jobs.length > 0 && (
+                      <div className="mb-3">
+                        <h5 className="text-sm font-medium text-gray-700 mb-2">Work Shifts</h5>
+                        <div className="space-y-2">
+                          {registration.jobs.map((registrationJob) => (
+                            <div key={registrationJob.id} className="text-sm text-gray-600">
+                              <span className="font-medium">{registrationJob.job?.name}</span>
+                              {registrationJob.job?.shift && (
+                                <span className="ml-2">
+                                  — {getFriendlyDayName(registrationJob.job.shift.dayOfWeek)}{' '}
+                                  {formatTime(registrationJob.job.shift.startTime)} - {formatTime(registrationJob.job.shift.endTime)}
+                                </span>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    
+                    {registration.payments.length > 0 && (
+                      <div>
+                        <h5 className="text-sm font-medium text-gray-700 mb-2">Payments</h5>
+                        <div className="space-y-1">
+                          {registration.payments.map((payment) => (
+                            <div key={payment.id} className="flex items-center justify-between text-sm">
+                              <span className="text-gray-600">
+                                ${payment.amount.toFixed(2)} — {new Date(payment.createdAt).toLocaleDateString()}
+                              </span>
+                              <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                                payment.status === 'COMPLETED' ? 'bg-green-100 text-green-800' :
+                                payment.status === 'REFUNDED' ? 'bg-blue-100 text-blue-800' :
+                                payment.status === 'FAILED' ? 'bg-red-100 text-red-800' :
+                                'bg-gray-100 text-gray-800'
+                              }`}>
+                                {payment.status}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -385,6 +385,7 @@ const DashboardPage: React.FC = () => {
                         registration.status === 'CONFIRMED' ? 'bg-green-100 text-green-800' :
                         registration.status === 'PENDING' ? 'bg-yellow-100 text-yellow-800' :
                         registration.status === 'WAITLISTED' ? 'bg-orange-100 text-orange-800' :
+                        registration.status === 'CANCELLED' ? 'bg-red-100 text-red-800' :
                         'bg-gray-100 text-gray-800'
                       }`}>
                         {registration.status}

--- a/apps/web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/pages/__tests__/DashboardPage.test.tsx
@@ -960,7 +960,8 @@ describe('DashboardPage - Registration after cancellation', () => {
         expect(screen.getByText('CANCELLED')).toBeInTheDocument();
         
         // Should show year and date in history heading
-        expect(screen.getByText(/2024 — 1\/1\/2024/)).toBeInTheDocument();
+        const expectedDate = new Date('2024-01-01T10:00:00.000Z').toLocaleDateString();
+        expect(screen.getByText(new RegExp(`2024 — ${expectedDate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))).toBeInTheDocument();
         
         // Should show payment status
         expect(screen.getByText('REFUNDED')).toBeInTheDocument();
@@ -980,7 +981,8 @@ describe('DashboardPage - Registration after cancellation', () => {
       
       await waitFor(() => {
         expect(screen.getByText('CANCELLED')).toBeInTheDocument();
-        expect(screen.getByText(/2024 — 1\/1\/2024/)).toBeInTheDocument();
+        const expectedDate = new Date('2024-01-01T10:00:00.000Z').toLocaleDateString();
+        expect(screen.getByText(new RegExp(`2024 — ${expectedDate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))).toBeInTheDocument();
       });
     });
 
@@ -1035,6 +1037,78 @@ describe('DashboardPage - Registration after cancellation', () => {
         const cancelledElements = screen.getAllByText('CANCELLED');
         expect(cancelledElements).toHaveLength(2);
       });
+    });
+
+    it('should render registration history sorted by year desc then createdAt desc', async () => {
+      const reg2022 = {
+        ...mockCancelledRegistration,
+        id: 'reg-2022',
+        year: 2022,
+        createdAt: '2022-06-15T10:00:00.000Z',
+        updatedAt: '2022-06-15T10:00:00.000Z',
+      };
+      const reg2024Early = {
+        ...mockCancelledRegistration,
+        id: 'reg-2024-early',
+        year: 2024,
+        createdAt: '2024-02-01T10:00:00.000Z',
+        updatedAt: '2024-02-01T10:00:00.000Z',
+      };
+      const reg2024Late = {
+        ...mockCancelledRegistration,
+        id: 'reg-2024-late',
+        year: 2024,
+        createdAt: '2024-08-01T10:00:00.000Z',
+        updatedAt: '2024-08-01T10:00:00.000Z',
+      };
+      const reg2023 = {
+        ...mockCancelledRegistration,
+        id: 'reg-2023',
+        year: 2023,
+        createdAt: '2023-03-10T10:00:00.000Z',
+        updatedAt: '2023-03-10T10:00:00.000Z',
+      };
+
+      // Current active registration for 2025 to exclude from history
+      const currentReg = {
+        ...mockActiveRegistration,
+        id: 'active-2025',
+        year: 2025,
+        createdAt: '2025-01-01T10:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:00.000Z',
+      };
+
+      // Provide registrations in arbitrary order
+      mockUseUserRegistrations.mockReturnValue({
+        registrations: [reg2022, currentReg, reg2024Early, reg2023, reg2024Late],
+        loading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      vi.mocked(registrationUtils.getActiveRegistrations).mockReturnValue([currentReg]);
+
+      const Wrapper = createWrapper();
+      render(<DashboardPage />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText('Registration History')).toBeInTheDocument();
+      });
+
+      // Get all h4 headings that match the "year — date" pattern (history cards only)
+      const allH4s = screen.getAllByRole('heading', { level: 4 });
+      const historyHeadings = allH4s.filter(h => /^\d{4} — /.test(h.textContent || ''));
+
+      // Expected order: 2024 (Aug), 2024 (Feb), 2023, 2022
+      const expectedDates = [
+        `2024 — ${new Date('2024-08-01T10:00:00.000Z').toLocaleDateString()}`,
+        `2024 — ${new Date('2024-02-01T10:00:00.000Z').toLocaleDateString()}`,
+        `2023 — ${new Date('2023-03-10T10:00:00.000Z').toLocaleDateString()}`,
+        `2022 — ${new Date('2022-06-15T10:00:00.000Z').toLocaleDateString()}`,
+      ];
+
+      const headingTexts = historyHeadings.map(h => h.textContent);
+      expect(headingTexts).toEqual(expectedDates);
     });
   });
 

--- a/apps/web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/pages/__tests__/DashboardPage.test.tsx
@@ -54,7 +54,6 @@ const mockUseConfig = vi.mocked(useConfig);
 // Mock registration utils
 vi.spyOn(registrationUtils, 'canUserRegister');
 vi.spyOn(registrationUtils, 'getActiveRegistrations');
-vi.spyOn(registrationUtils, 'getCancelledRegistrations');
 
 // Helper component to wrap with router
 const DashboardPageWrapper: React.FC = () => (
@@ -826,14 +825,12 @@ describe('DashboardPage - Registration after cancellation', () => {
     // Mock registration utils with default implementations
     vi.mocked(registrationUtils.canUserRegister).mockReturnValue(true);
     vi.mocked(registrationUtils.getActiveRegistrations).mockReturnValue([]);
-    vi.mocked(registrationUtils.getCancelledRegistrations).mockReturnValue([]);
   });
 
   it('should use registration utilities correctly', () => {
     // Test that the registrationUtils functions are available for the dashboard
     expect(registrationUtils.canUserRegister).toBeDefined();
     expect(registrationUtils.getActiveRegistrations).toBeDefined();
-    expect(registrationUtils.getCancelledRegistrations).toBeDefined();
   });
 
   it('should validate registration utilities are properly imported', () => {
@@ -855,7 +852,6 @@ describe('DashboardPage - Registration after cancellation', () => {
 
       // Mock utils to reflect this state
       vi.mocked(registrationUtils.getActiveRegistrations).mockReturnValue([]);
-      vi.mocked(registrationUtils.getCancelledRegistrations).mockReturnValue([mockCancelledRegistration]);
       vi.mocked(registrationUtils.canUserRegister).mockReturnValue(true);
 
       const Wrapper = createWrapper();
@@ -892,7 +888,6 @@ describe('DashboardPage - Registration after cancellation', () => {
 
       // Mock utils to reflect this state  
       vi.mocked(registrationUtils.getActiveRegistrations).mockReturnValue([mockActiveRegistration]);
-      vi.mocked(registrationUtils.getCancelledRegistrations).mockReturnValue([]);
       vi.mocked(registrationUtils.canUserRegister).mockReturnValue(false);
 
       const Wrapper = createWrapper();
@@ -918,7 +913,6 @@ describe('DashboardPage - Registration after cancellation', () => {
 
       // For current year, no active registration exists
       vi.mocked(registrationUtils.getActiveRegistrations).mockReturnValue([]);
-      vi.mocked(registrationUtils.getCancelledRegistrations).mockReturnValue([mockCancelledRegistration]);
       vi.mocked(registrationUtils.canUserRegister).mockReturnValue(true);
 
       const Wrapper = createWrapper();
@@ -931,7 +925,7 @@ describe('DashboardPage - Registration after cancellation', () => {
   });
 
   describe('Registration History section', () => {
-    it('should show registration history section when user has cancelled registrations', async () => {
+    it('should show registration history section when user has past registrations', async () => {
       mockUseUserRegistrations.mockReturnValue({
         registrations: [mockActiveRegistration, mockCancelledRegistration],
         loading: false,
@@ -941,7 +935,6 @@ describe('DashboardPage - Registration after cancellation', () => {
 
       // Mock utils
       vi.mocked(registrationUtils.getActiveRegistrations).mockReturnValue([mockActiveRegistration]);
-      vi.mocked(registrationUtils.getCancelledRegistrations).mockReturnValue([mockCancelledRegistration]);
 
       const Wrapper = createWrapper();
       render(<DashboardPage />, { wrapper: Wrapper });
@@ -959,8 +952,6 @@ describe('DashboardPage - Registration after cancellation', () => {
         refetch: vi.fn(),
       });
 
-      vi.mocked(registrationUtils.getCancelledRegistrations).mockReturnValue([mockCancelledRegistration]);
-
       const Wrapper = createWrapper();
       render(<DashboardPage />, { wrapper: Wrapper });
       
@@ -968,8 +959,8 @@ describe('DashboardPage - Registration after cancellation', () => {
         // Should show status
         expect(screen.getByText('CANCELLED')).toBeInTheDocument();
         
-        // Should show year in date format
-        expect(screen.getByText('Registration from 1/1/2024')).toBeInTheDocument();
+        // Should show year and date in history heading
+        expect(screen.getByText(/2024 — 1\/1\/2024/)).toBeInTheDocument();
         
         // Should show payment status
         expect(screen.getByText('REFUNDED')).toBeInTheDocument();
@@ -984,19 +975,16 @@ describe('DashboardPage - Registration after cancellation', () => {
         refetch: vi.fn(),
       });
 
-      vi.mocked(registrationUtils.getCancelledRegistrations).mockReturnValue([mockCancelledRegistration]);
-
       const Wrapper = createWrapper();
       render(<DashboardPage />, { wrapper: Wrapper });
       
       await waitFor(() => {
         expect(screen.getByText('CANCELLED')).toBeInTheDocument();
-        // The year appears in a formatted date like "1/1/2024"
-        expect(screen.getByText('Registration from 1/1/2024')).toBeInTheDocument();
+        expect(screen.getByText(/2024 — 1\/1\/2024/)).toBeInTheDocument();
       });
     });
 
-    it('should not show registration history section when no cancelled registrations exist', async () => {
+    it('should not show registration history section when only current active registration exists', async () => {
       mockUseUserRegistrations.mockReturnValue({
         registrations: [mockActiveRegistration],
         loading: false,
@@ -1005,7 +993,6 @@ describe('DashboardPage - Registration after cancellation', () => {
       });
 
       vi.mocked(registrationUtils.getActiveRegistrations).mockReturnValue([mockActiveRegistration]);
-      vi.mocked(registrationUtils.getCancelledRegistrations).mockReturnValue([]);
 
       const Wrapper = createWrapper();
       render(<DashboardPage />, { wrapper: Wrapper });
@@ -1015,7 +1002,7 @@ describe('DashboardPage - Registration after cancellation', () => {
       });
     });
 
-    it('should handle multiple cancelled registrations in history', async () => {
+    it('should handle multiple registrations from different years in history', async () => {
       const cancelledRegistration2023 = {
         ...mockCancelledRegistration,
         id: 'cancelled-2023',
@@ -1036,20 +1023,13 @@ describe('DashboardPage - Registration after cancellation', () => {
         refetch: vi.fn(),
       });
 
-      vi.mocked(registrationUtils.getCancelledRegistrations).mockReturnValue([
-        mockCancelledRegistration,
-        cancelledRegistration2023
-      ]);
+      vi.mocked(registrationUtils.getActiveRegistrations).mockReturnValue([mockActiveRegistration]);
 
       const Wrapper = createWrapper();
       render(<DashboardPage />, { wrapper: Wrapper });
       
       await waitFor(() => {
         expect(screen.getByText('Registration History')).toBeInTheDocument();
-        
-        // Should show both years in date format - match the actual date formatting
-        expect(screen.getByText('Registration from 1/1/2024')).toBeInTheDocument();
-        expect(screen.getByText('Registration from 1/1/2023')).toBeInTheDocument();
         
         // Should show multiple cancelled statuses
         const cancelledElements = screen.getAllByText('CANCELLED');


### PR DESCRIPTION
## Why

The dashboard previously showed only cancelled current-year registrations in a "Registration History" section wedged between the current registration and camping options. Users want to see their full registration history from all years in one place, positioned at the bottom of the view where it's accessible without obscuring the primary content.

## Approach

- Moved the Registration History section below Camping Options (bottom of the dashboard)
- Changed the data source from `getCancelledRegistrations(currentYearRegistrations)` to a computed list of all registrations excluding the current active one
- Sorted entries by year descending, then by creation date descending
- Added color-coded status badges (CONFIRMED, PENDING, WAITLISTED, CANCELLED) instead of the previous grey-only style
- Updated the heading format to show "Year -- Date" for each entry

## Changes

- `apps/web/src/pages/DashboardPage.tsx` -- relocated and expanded the history section, removed unused `getCancelledRegistrations` import
- `apps/web/src/pages/__tests__/DashboardPage.test.tsx` -- updated tests to match new behavior and more specific assertions; all 27 tests pass