### PR TITLE
fix(api): migrate package.json#prisma to prisma.config.ts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Monorepo layout:
 - Dev-mode email auth code is **always `123456`**
 - If local Postgres isn't running, prompt the user to start it
 - If tests fail with "Cannot read properties of undefined" on Prisma enums/types,
-  run `npx prisma generate --schema=apps/api/prisma/schema.prisma` (common in fresh worktrees)
+  run `cd apps/api && npx prisma generate` (common in fresh worktrees)
 - See `package.json` workspaces for the full script list
 
 ## Workflow rules

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,14 +19,14 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand --config jest.config.js",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "db:init": "npm run prisma:migrate:prod && npm run seed:dev",
-    "prisma:generate": "prisma generate --schema=./prisma/schema.prisma",
-    "prisma:migrate": "prisma migrate dev --schema=./prisma/schema.prisma",
-    "prisma:migrate:dev": "prisma migrate dev --name dev-migration --schema=./prisma/schema.prisma",
-    "prisma:migrate:test": "dotenv -e .env.test -- prisma migrate dev --name test-migration --schema=./prisma/schema.prisma",
-    "prisma:migrate:prod": "prisma migrate deploy --schema=./prisma/schema.prisma",
-    "prisma:reset": "prisma migrate reset --schema=./prisma/schema.prisma --force",
-    "prisma:reset:test": "dotenv -e .env.test -- prisma migrate reset --schema=./prisma/schema.prisma --force",
-    "prisma:studio": "prisma studio --schema=./prisma/schema.prisma",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:migrate:dev": "prisma migrate dev --name dev-migration",
+    "prisma:migrate:test": "dotenv -e .env.test -- prisma migrate dev --name test-migration",
+    "prisma:migrate:prod": "prisma migrate deploy",
+    "prisma:reset": "prisma migrate reset --force",
+    "prisma:reset:test": "dotenv -e .env.test -- prisma migrate reset --force",
+    "prisma:studio": "prisma studio",
     "seed": "ts-node ./prisma/seeds/seed.ts",
     "seed:dev": "ts-node ./prisma/seeds/seed.ts",
     "seed:dev:force": "FORCE_RESEED=true ts-node ./prisma/seeds/seed.ts",
@@ -38,9 +38,7 @@
     "db:setup": "npm run prisma:generate && npm run prisma:migrate:dev && npm run seed:dev",
     "db:setup:test": "npm run prisma:generate && npm run prisma:migrate:test && npm run seed:test"
   },
-  "prisma": {
-    "seed": "ts-node ./prisma/seeds/seed.ts"
-  },
+
   "dependencies": {
     "@nestjs/common": "^11.1.2",
     "@nestjs/config": "^4.0.2",

--- a/apps/api/prisma.config.ts
+++ b/apps/api/prisma.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "prisma/config";
+import { defineConfig } from 'prisma/config';
 
 export default defineConfig({
-  schema: "./prisma/schema.prisma",
+  schema: './prisma/schema.prisma',
   migrations: {
-    seed: "ts-node ./prisma/seeds/seed.ts",
+    seed: 'ts-node ./prisma/seeds/seed.ts',
   },
 });

--- a/apps/api/prisma.config.ts
+++ b/apps/api/prisma.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  schema: "./prisma/schema.prisma",
+  migrations: {
+    seed: "ts-node ./prisma/seeds/seed.ts",
+  },
+});


### PR DESCRIPTION
## Summary

Resolves the Prisma deprecation warning:

> warn The configuration property `package.json#prisma` is deprecated and will be removed in Prisma 7. Please migrate to a Prisma config file.

## Changes

- **Created `apps/api/prisma.config.ts`** using `defineConfig` with schema path and seed command
- **Removed deprecated `"prisma"` key** from `apps/api/package.json`
- **Removed redundant `--schema` flags** from package.json scripts (auto-discovered from `prisma.config.ts`)
- **Updated AGENTS.md** fresh-worktree guidance to use `cd apps/api && npx prisma generate`

## Verification

- `npx prisma generate` — ✅ config discovered, client generated
- `npx prisma migrate deploy` — ✅ migrations applied
- `npx prisma db seed` — ✅ seed command resolved from config
- `npm run build` — ✅ clean
- ESLint — ✅ clean

## Design Decisions

- **No `datasource.url` in config** — Schema.prisma already defines it. Adding it to config would require env loading logic and break `prisma generate` in environments without DATABASE_URL set.
- **Kept `ts-node` for seed** — already a dependency, no reason to change.

Closes #187