### PR TITLE
Fix status badge colors in registration management view

### DIFF
--- a/apps/web/src/components/admin/registrations/RegistrationSearchTable.tsx
+++ b/apps/web/src/components/admin/registrations/RegistrationSearchTable.tsx
@@ -119,6 +119,12 @@ export function RegistrationSearchTable({
                   ? 'bg-yellow-100 text-yellow-800'
                   : row.status === 'WAITLISTED'
                   ? 'bg-blue-100 text-blue-800'
+                  : row.status === 'APPLICATION_SUBMITTED'
+                  ? 'bg-yellow-100 text-yellow-800'
+                  : row.status === 'APPLICATION_APPROVED'
+                  ? 'bg-yellow-100 text-yellow-800'
+                  : row.status === 'APPLICATION_DECLINED'
+                  ? 'bg-red-100 text-red-800'
                   : 'bg-red-100 text-red-800'
               }`}
             >


### PR DESCRIPTION
## Problem
In the admin manage-registrations view, application statuses were displaying with unclear colors. `Application Approved` and `Application Submitted` were both showing red (like a rejection), while `Application Declined` lacked distinct visual treatment.

## Solution
Updated the status badge color mapping to reflect the semantic meaning of each application status:

- **Application Submitted** → Yellow (indicates pending review)
- **Application Approved** → Yellow (indicates positive but incomplete, requires next steps)
- **Application Declined** → Red (clearly indicates rejection)

This visual hierarchy helps admins quickly understand the status of each application without ambiguity.

## Changes
- Updated `RegistrationSearchTable.tsx` to add explicit conditions for all three application statuses in the status badge className chain