### PR TITLE
Disable wheel changes on registration custom numeric fields

### DIFF
--- a/apps/web/src/pages/registration/RegistrationPage.test.tsx
+++ b/apps/web/src/pages/registration/RegistrationPage.test.tsx
@@ -188,6 +188,33 @@ describe('RegistrationPage', () => {
     },
   ];
 
+  const mockNumericFields = [
+    {
+      id: 'integer-field',
+      displayName: 'Number of Bikes',
+      description: 'How many bikes are you bringing?',
+      dataType: 'INTEGER' as const,
+      required: false,
+      campingOptionId: 'option1',
+      createdAt: '2025-05-01T00:00:00Z',
+      updatedAt: '2025-05-01T00:00:00Z',
+      minValue: 0,
+      maxValue: 10,
+    },
+    {
+      id: 'number-field',
+      displayName: 'Generator Hours',
+      description: 'Estimated generator usage hours',
+      dataType: 'NUMBER' as const,
+      required: false,
+      campingOptionId: 'option1',
+      createdAt: '2025-05-01T00:00:00Z',
+      updatedAt: '2025-05-01T00:00:00Z',
+      minValue: 0,
+      maxValue: 100,
+    },
+  ];
+
   // Setup mocks before each test
   beforeEach(() => {
     // Clear all mocks to ensure test isolation
@@ -604,6 +631,65 @@ describe('RegistrationPage', () => {
     expect(screen.getByLabelText('Last Name*')).toBeInTheDocument();
     expect(screen.getByLabelText('Phone Number*')).toBeInTheDocument();
     expect(screen.getByLabelText('Emergency Contact(s)*')).toBeInTheDocument();
+  });
+
+  it('blurs INTEGER and NUMBER custom-field inputs on mouse wheel', async () => {
+    vi.spyOn(useCampingOptionsModule, 'useCampingOptions').mockReturnValue({
+      options: [],
+      selectedOption: null,
+      fields: mockNumericFields,
+      loading: false,
+      error: null,
+      loadCampingOptions: vi.fn(),
+      loadCampingOption: vi.fn(),
+      createCampingOption: vi.fn(),
+      updateCampingOption: vi.fn(),
+      deleteCampingOption: vi.fn(),
+      loadCampingOptionFields: vi.fn().mockResolvedValue(mockNumericFields),
+      createCampingOptionField: vi.fn(),
+      updateCampingOptionField: vi.fn(),
+      deleteCampingOptionField: vi.fn(),
+    });
+
+    renderWithAuth();
+
+    fireEvent.change(screen.getByLabelText('First Name*'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByLabelText('Last Name*'), { target: { value: 'User' } });
+    fireEvent.change(screen.getByLabelText('Phone Number*'), { target: { value: '555-1234' } });
+    fireEvent.change(screen.getByLabelText('Emergency Contact(s)*'), { target: { value: 'Emergency Contact' } });
+    fireEvent.click(screen.getByText('Continue'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Select Camping Options')).toBeInTheDocument();
+    });
+
+    const campingCheckboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(campingCheckboxes[0]);
+    fireEvent.click(screen.getByText('Continue'));
+
+    const integerFieldContainer = await screen.findByText('Number of Bikes');
+    const numberFieldContainer = await screen.findByText('Generator Hours');
+    const integerInput = integerFieldContainer.parentElement?.querySelector('input[type="number"]');
+    const numberInput = numberFieldContainer.parentElement?.querySelector('input[type="number"]');
+
+    expect(integerInput).not.toBeNull();
+    expect(numberInput).not.toBeNull();
+
+    const integerNumberInput = integerInput as HTMLInputElement;
+    const decimalNumberInput = numberInput as HTMLInputElement;
+
+    fireEvent.change(integerNumberInput, { target: { value: '3' } });
+    fireEvent.change(decimalNumberInput, { target: { value: '12.5' } });
+
+    integerNumberInput.focus();
+    fireEvent.wheel(integerNumberInput, { deltaY: 100 });
+    expect(integerNumberInput).not.toHaveFocus();
+    expect(integerNumberInput).toHaveValue(3);
+
+    decimalNumberInput.focus();
+    fireEvent.wheel(decimalNumberInput, { deltaY: 100 });
+    expect(decimalNumberInput).not.toHaveFocus();
+    expect(decimalNumberInput).toHaveValue(12.5);
   });
 
   // Add more tests as needed for other steps in the registration flow

--- a/apps/web/src/pages/registration/RegistrationPage.tsx
+++ b/apps/web/src/pages/registration/RegistrationPage.tsx
@@ -655,6 +655,10 @@ export default function RegistrationPage() {
     }));
   };
 
+  const handleNumberInputWheel = (event: React.WheelEvent<HTMLInputElement>) => {
+    event.currentTarget.blur();
+  };
+
   const handleProfileFormChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
     setProfileFormData(prev => ({
@@ -1018,6 +1022,7 @@ export default function RegistrationPage() {
                     className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                     min={field.minValue !== null ? field.minValue : undefined}
                     max={field.maxValue !== null ? field.maxValue : undefined}
+                    onWheel={handleNumberInputWheel}
                   />
                 )}
                 
@@ -1038,6 +1043,7 @@ export default function RegistrationPage() {
                     className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                     min={field.minValue !== null ? field.minValue : undefined}
                     max={field.maxValue !== null ? field.maxValue : undefined}
+                    onWheel={handleNumberInputWheel}
                   />
                 )}
                 


### PR DESCRIPTION
Accidental mouse-wheel scrolling on focused numeric custom fields in registration could silently change entered values. This update prevents those unintended edits for camping option custom fields.

### What changed
- Added a shared wheel handler in `RegistrationPage` that blurs focused numeric inputs on wheel events.
- Applied the handler to both numeric custom-field types used in registration:
  - `INTEGER`
  - `NUMBER`
- Added regression coverage in `RegistrationPage.test.tsx` to verify wheel interaction blurs both numeric custom-field inputs and preserves the entered values.

### Notes
- Scope is intentionally limited to participant-facing camping option custom-field value inputs in the registration flow.