### PR TITLE
Fix approved registration email link

### DIFF
--- a/apps/api/src/notifications/services/notifications.service.spec.ts
+++ b/apps/api/src/notifications/services/notifications.service.spec.ts
@@ -21,6 +21,7 @@ describe('NotificationsService', () => {
   const mockConfigService = {
     get: jest.fn((key: string, defaultValue?: unknown) => {
       if (key === 'app.baseUrl') return 'http://test.com';
+      if (key === 'frontend.url') return 'http://frontend.test/';
       if (key === 'nodeEnv') return 'test';
       return defaultValue;
     }),
@@ -447,6 +448,50 @@ describe('NotificationsService', () => {
           userId: 'user-123',
         }),
       );
+    });
+
+    it('should default application approved registration links to the frontend URL', async () => {
+      mockEmailService.sendEmail.mockResolvedValueOnce(true);
+
+      const result = await service.sendNotification(
+        'user@example.playaplan.app',
+        NotificationType.APPLICATION_APPROVED,
+        {
+          userId: 'user-123',
+          name: 'John Doe',
+          applicationDetails: {
+            year: 2025,
+          },
+        },
+      );
+
+      expect(result).toBeTruthy();
+      const callArgs = mockEmailService.sendEmail.mock.calls[0][0];
+      expect(callArgs.html).toContain('http://frontend.test/#/registration');
+      expect(callArgs.text).toContain('http://frontend.test/#/registration');
+      expect(callArgs.html).not.toContain('http://test.com/#/registration');
+      expect(callArgs.text).not.toContain('http://test.com/#/registration');
+    });
+
+    it('should preserve an explicit registration URL for application approved emails', async () => {
+      mockEmailService.sendEmail.mockResolvedValueOnce(true);
+
+      const result = await service.sendNotification(
+        'user@example.playaplan.app',
+        NotificationType.APPLICATION_APPROVED,
+        {
+          userId: 'user-123',
+          applicationDetails: {
+            year: 2025,
+            registrationUrl: 'https://camp.example/complete-registration',
+          },
+        },
+      );
+
+      expect(result).toBeTruthy();
+      const callArgs = mockEmailService.sendEmail.mock.calls[0][0];
+      expect(callArgs.html).toContain('https://camp.example/complete-registration');
+      expect(callArgs.text).toContain('https://camp.example/complete-registration');
     });
 
     it('should escape admin-provided test email values in HTML while preserving plain text', async () => {

--- a/apps/api/src/notifications/services/notifications.service.ts
+++ b/apps/api/src/notifications/services/notifications.service.ts
@@ -107,6 +107,7 @@ export interface TemplateData {
 export class NotificationsService {
   private readonly logger = new Logger(NotificationsService.name);
   private readonly baseUrl: string;
+  private readonly frontendUrl: string;
   private readonly isDebugMode: boolean;
   
   constructor(
@@ -115,8 +116,18 @@ export class NotificationsService {
     private readonly coreConfigService: CoreConfigService,
   ) {
     this.baseUrl = this.configService.get<string>('app.baseUrl', 'http://localhost:3000');
+    this.frontendUrl = this.configService.get<string>('frontend.url', 'http://localhost:5173');
     this.isDebugMode = this.configService.get<string>('nodeEnv') === 'development' || 
                         process.argv.includes('--debug');
+  }
+
+  private getRegistrationCompletionUrl(registrationUrl?: string): string {
+    if (registrationUrl) {
+      return registrationUrl;
+    }
+
+    const normalizedFrontendUrl = this.frontendUrl.replace(/\/$/, '');
+    return `${normalizedFrontendUrl}/#/registration`;
   }
 
   /**
@@ -1250,7 +1261,7 @@ This is an automated test email from ${campName}. If you received this unexpecte
   private getApplicationApprovedTemplate(data: TemplateData, campName: string): NotificationTemplate {
     const name = data.name || data.playaName || 'there';
     const year = data.applicationDetails?.year || new Date().getFullYear();
-    const registrationUrl = data.applicationDetails?.registrationUrl || `${this.baseUrl}/#/registration`;
+    const registrationUrl = this.getRegistrationCompletionUrl(data.applicationDetails?.registrationUrl);
     const decisionMessage = data.applicationDetails?.decisionMessage;
     const subject = `${campName} - Application Approved!`;
     const messageParagraph = decisionMessage


### PR DESCRIPTION
## Summary
This fixes approved-applicant emails that were sending the `Complete Registration` link to the API origin because the fallback URL was built from `app.baseUrl`.

The notification service now uses `frontend.url` for the default registration link, preserves any explicit `registrationUrl` override, and adds coverage for both cases. I also checked the related registration-facing email flows; this was the only fallback pointing at the API origin.

## Testing
- `npm run test --workspace=api -- src/notifications/services/notifications.service.spec.ts src/registrations/services/application-admin.service.spec.ts --runInBand`
- `npm run build --workspace=api`