### PR TITLE
Clarify decline message email notice in admin applications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Monorepo layout:
 
 - Node.js **22 or higher**
 - `npm run dev` — start both API and web
+- If `npm`/`node` is "not found" in agent shells, run commands via login shell
+  (for example: `zsh -lic 'npm -v'`) so user PATH tools (e.g., Volta) are loaded
 - Dev-mode email auth code is **always `123456`**
 - If local Postgres isn't running, prompt the user to start it
 - If tests fail with "Cannot read properties of undefined" on Prisma enums/types,

--- a/apps/web/src/pages/AdminApplicationsPage.test.tsx
+++ b/apps/web/src/pages/AdminApplicationsPage.test.tsx
@@ -131,6 +131,7 @@ describe('AdminApplicationsPage', () => {
     fireEvent.click(screen.getByText('Decline'));
 
     expect(screen.getByRole('dialog', { name: 'Decline Application' })).toBeInTheDocument();
+    expect(screen.getByText(/This message is sent to the applicant by email\./i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Decline Application' }));
     expect(await screen.findByText('A decline message is required.')).toBeInTheDocument();

--- a/apps/web/src/pages/AdminApplicationsPage.tsx
+++ b/apps/web/src/pages/AdminApplicationsPage.tsx
@@ -619,6 +619,7 @@ export default function AdminApplicationsPage() {
               </h2>
               <p className="mt-1 text-sm text-gray-600">
                 Provide a message for {declineDialog.label}.
+                {' '}This message is sent to the applicant by email.
               </p>
             </div>
             <div className="space-y-4 px-6 py-5">


### PR DESCRIPTION
## Why
Admins entering a decline note from `#/admin/applications` were not clearly told that the note is sent to the applicant, even though the application details modal already communicates this. This update aligns the messaging so reviewers have consistent expectations.

## What changed
- Added a helper sentence in the admin applications decline dialog: "This message is sent to the applicant by email."
- Updated `AdminApplicationsPage` tests to assert the new guidance appears in the dialog.
- Added a short AGENTS.md troubleshooting note for `npm`/`node` not found in non-login agent shells (`zsh -lic`).

## Validation
- Ran `npm run test --workspace=web -- src/pages/AdminApplicationsPage.test.tsx` via login shell.
- Result: 5 tests passed.