### PR TITLE
Fix /run-e2e PR trigger and E2E CI throttling

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
   statuses: write
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
   statuses: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -19,6 +19,10 @@ on:
         default: ''
       head_sha:
         description: 'PR head commit SHA. Set automatically by /run-e2e; optional for manual runs.'
+        required: false
+        default: ''
+      trigger_actor:
+        description: 'GitHub username that triggered the run. Optional for manual runs.'
         required: false
         default: ''
   repository_dispatch:
@@ -64,6 +68,7 @@ jobs:
         WORKFLOW_TAGS: ${{ inputs.tags }}
         WORKFLOW_PR_NUMBER: ${{ inputs.pr_number }}
         WORKFLOW_HEAD_SHA: ${{ inputs.head_sha }}
+        WORKFLOW_TRIGGER_ACTOR: ${{ inputs.trigger_actor }}
       with:
         script: |
           const getString = (value) => value == null ? '' : String(value).trim();
@@ -77,7 +82,7 @@ jobs:
           let prNumber = getString(process.env.WORKFLOW_PR_NUMBER);
           let headSha = getString(process.env.WORKFLOW_HEAD_SHA);
           let headRef = '';
-          let triggerActor = context.actor;
+          let triggerActor = getString(process.env.WORKFLOW_TRIGGER_ACTOR) || context.actor;
 
           if (context.eventName === 'repository_dispatch') {
             const scope = getString(data.Scope ?? data.scope);
@@ -246,6 +251,8 @@ jobs:
         JWT_SECRET: test-secret-key-for-ci
         NODE_ENV: development
         PORT: 3000
+        THROTTLE_DEFAULT_LIMIT: 2000
+        THROTTLE_AUTH_LIMIT: 400
 
     - name: Wait for API server to be ready
       run: |

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
   statuses: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/e2e-comment-dispatch.yml
+++ b/.github/workflows/e2e-comment-dispatch.yml
@@ -38,9 +38,15 @@ jobs:
             permission = permResponse.data.permission;
           } catch (error) {
             core.warning(`Failed to resolve collaborator permission for @${actor}: ${error.message}`);
+            return;
           }
 
           if (!['admin', 'maintain', 'write'].includes(permission)) {
+            if (!['read', 'triage'].includes(permission)) {
+              core.info(`Ignoring /run-e2e from @${actor} with permission: ${permission}`);
+              return;
+            }
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/e2e-comment-dispatch.yml
+++ b/.github/workflows/e2e-comment-dispatch.yml
@@ -1,0 +1,104 @@
+name: E2E Comment Dispatch
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  dispatch-e2e:
+    name: Dispatch E2E workflow from /run-e2e comment
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    steps:
+    - name: Validate commenter and dispatch E2E workflow
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const commandLine = (context.payload.comment.body || '').split(/\r?\n/, 1)[0].trim();
+          const match = commandLine.match(/^\/run-e2e(?:\s+(.+))?$/i);
+          if (!match) {
+            core.info(`Ignoring non-matching command line: ${commandLine}`);
+            return;
+          }
+
+          const actor = context.payload.comment.user.login;
+          let permission = 'none';
+          try {
+            const permResponse = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: actor,
+            });
+            permission = permResponse.data.permission;
+          } catch (error) {
+            core.warning(`Failed to resolve collaborator permission for @${actor}: ${error.message}`);
+          }
+
+          if (!['admin', 'maintain', 'write'].includes(permission)) {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `@${actor} /run-e2e requires write access to this repository.`,
+            });
+            return;
+          }
+
+          const prNumber = context.payload.issue.number;
+          const { data: pr } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: prNumber,
+          });
+
+          const baseRepo = `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
+          const headRepo = (pr.head.repo?.full_name || '').toLowerCase();
+          if (headRepo !== baseRepo) {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `@${actor} /run-e2e only supports PR branches in \`${baseRepo}\`; got \`${headRepo || 'unknown'}\`.`,
+            });
+            return;
+          }
+
+          const rawArg = (match[1] || '').trim();
+          const scopeTags = {
+            all: '',
+            smoke: '@smoke',
+            auth: '@auth',
+            registration: '@registration',
+            admin: '@admin',
+          };
+
+          let tags = '';
+          if (rawArg) {
+            if (rawArg.startsWith('--grep=')) {
+              tags = rawArg.slice('--grep='.length).trim();
+            } else if (rawArg.startsWith('grep=')) {
+              tags = rawArg.slice('grep='.length).trim();
+            } else {
+              tags = scopeTags[rawArg.toLowerCase()] ?? rawArg;
+            }
+            tags = tags.replace(/^"(.*)"$/, '$1');
+          }
+
+          await github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'e2e-ci.yml',
+            ref: context.payload.repository.default_branch,
+            inputs: {
+              tags,
+              pr_number: String(prNumber),
+              head_sha: pr.head.sha,
+              trigger_actor: actor,
+            },
+          });

--- a/apps/api/src/common/throttling/throttling.module.spec.ts
+++ b/apps/api/src/common/throttling/throttling.module.spec.ts
@@ -1,0 +1,46 @@
+import { resolveThrottleLimits } from './throttling.module';
+
+describe('resolveThrottleLimits', () => {
+  it('should keep legacy capped defaults when overrides are not provided', () => {
+    const getNumber = (key: string): number | undefined => {
+      void key;
+      return undefined;
+    };
+
+    const actualLimits = resolveThrottleLimits(getNumber, 1000);
+
+    expect(actualLimits).toEqual({
+      defaultLimit: 300,
+      authLimit: 30,
+    });
+  });
+
+  it('should use explicit default and auth limit overrides when provided', () => {
+    const configValues: Record<string, number> = {
+      THROTTLE_DEFAULT_LIMIT: 2500,
+      THROTTLE_AUTH_LIMIT: 500,
+    };
+    const getNumber = (key: string): number | undefined => configValues[key];
+
+    const actualLimits = resolveThrottleLimits(getNumber, 200);
+
+    expect(actualLimits).toEqual({
+      defaultLimit: 2500,
+      authLimit: 500,
+    });
+  });
+
+  it('should allow overriding only one throttle bucket', () => {
+    const configValues: Record<string, number> = {
+      THROTTLE_AUTH_LIMIT: 120,
+    };
+    const getNumber = (key: string): number | undefined => configValues[key];
+
+    const actualLimits = resolveThrottleLimits(getNumber, 280);
+
+    expect(actualLimits).toEqual({
+      defaultLimit: 280,
+      authLimit: 120,
+    });
+  });
+});

--- a/apps/api/src/common/throttling/throttling.module.ts
+++ b/apps/api/src/common/throttling/throttling.module.ts
@@ -11,6 +11,21 @@ import { ThrottlingGuard } from './throttling.guard';
 import { APP_GUARD } from '@nestjs/core';
 import { Reflector } from '@nestjs/core';
 
+interface ThrottleLimits {
+  defaultLimit: number;
+  authLimit: number;
+}
+
+export function resolveThrottleLimits(
+  getNumber: (key: string) => number | undefined,
+  sharedLimit: number
+): ThrottleLimits {
+  const defaultLimit = getNumber('THROTTLE_DEFAULT_LIMIT') ?? Math.min(sharedLimit, 300);
+  const authLimit = getNumber('THROTTLE_AUTH_LIMIT') ?? Math.min(sharedLimit, 30);
+
+  return { defaultLimit, authLimit };
+}
+
 /**
  * Configuration options for the ThrottlingModule
  */
@@ -78,6 +93,11 @@ export class ThrottlingModule {
             const limit = options?.limit ||
               configService.get<number>('THROTTLE_LIMIT') || 100; // Default: 100 requests
 
+            const throttleLimits = resolveThrottleLimits(
+              (key: string) => configService.get<number>(key),
+              limit
+            );
+
             // Convert to milliseconds for the newer Throttler API version
             const ttlMs = ttl * 1000;
 
@@ -86,13 +106,13 @@ export class ThrottlingModule {
                 {
                   name: 'default',
                   ttl: ttlMs,
-                  limit: Math.min(limit, 300), // 300 requests per minute for normal usage
+                  limit: throttleLimits.defaultLimit,
                   skipIf: skipIfAuth,
                 },
                 {
                   name: 'auth',
                   ttl: ttlMs,
-                  limit: Math.min(limit, 30), // 30 requests per minute for auth endpoints
+                  limit: throttleLimits.authLimit,
                   skipIf: skipIfNotAuth,
                 },
               ],

--- a/apps/api/src/config/validation.schema.ts
+++ b/apps/api/src/config/validation.schema.ts
@@ -90,6 +90,8 @@ const validationSchema = Joi.object({
   // Throttling configuration
   THROTTLE_TTL: Joi.number().default(60),
   THROTTLE_LIMIT: Joi.number().default(300),
+  THROTTLE_DEFAULT_LIMIT: Joi.number().integer().min(1),
+  THROTTLE_AUTH_LIMIT: Joi.number().integer().min(1),
   
   // Admin defaults
   DEFAULT_ADMIN_EMAIL: Joi.string().email().default('webadmin@example.playaplan.app'),


### PR DESCRIPTION
## Summary
- add a dedicated issue_comment dispatcher workflow so posting `/run-e2e` on a PR reliably starts E2E
- pass PR/head context into `e2e-ci.yml` workflow_dispatch and preserve triggering actor metadata
- allow explicit API throttling overrides with `THROTTLE_DEFAULT_LIMIT` and `THROTTLE_AUTH_LIMIT`
- set higher throttling limits in E2E CI API startup to reduce auth-flow throttling flakes
- keep E2E results as append-only PR comments via `issues.createComment`, with updated workflow permissions for PR comment posting
- add throttling unit tests for fallback and override behavior

## Validation
- `npm run lint`
- `npm run test --workspace=api -- throttling.module.spec.ts throttling.guard.spec.ts`
