### PR TITLE
Issue #71 Layer 4: Stripe Refund

### DIFF
--- a/apps/api/src/payments/controllers/__tests__/payments-security.controller.spec.ts
+++ b/apps/api/src/payments/controllers/__tests__/payments-security.controller.spec.ts
@@ -38,7 +38,8 @@ describe('PaymentsController Security', () => {
             findAllForAdmin: jest.fn(),
             findOneWithOwnershipCheck: jest.fn(),
             recordExternalPayment: jest.fn(),
-            createManualRefund: jest.fn(),
+            createRefund: jest.fn(),
+            retryStripeRefund: jest.fn(),
           },
         },
         {
@@ -95,12 +96,15 @@ describe('PaymentsController Security', () => {
         expect(actualRoles).not.toContain(UserRole.PARTICIPANT);
       });
 
-      it('should expose only the nested admin manual refund route', () => {
-        const actualRoles = Reflect.getMetadata('roles', PaymentsController.prototype.createRefund);
-        const actualPath = Reflect.getMetadata(
-          PATH_METADATA,
-          PaymentsController.prototype.createRefund
+      it.each([
+        ['createRefund', ':paymentId/refunds'],
+        ['retryRefund', ':paymentId/refunds/:refundId/retry'],
+      ] as const)('should restrict the nested %s route to admins', (methodName, expectedPath) => {
+        const actualRoles = Reflect.getMetadata(
+          'roles',
+          PaymentsController.prototype[methodName]
         );
+        const actualPath = Reflect.getMetadata(PATH_METADATA, PaymentsController.prototype[methodName]);
         const controllerPrototype = PaymentsController.prototype as unknown as Record<
           string,
           unknown
@@ -109,7 +113,7 @@ describe('PaymentsController Security', () => {
         expect(actualRoles).toEqual([UserRole.ADMIN]);
         expect(actualRoles).not.toContain(UserRole.STAFF);
         expect(actualRoles).not.toContain(UserRole.PARTICIPANT);
-        expect(actualPath).toBe(':paymentId/refunds');
+        expect(actualPath).toBe(expectedPath);
         expect(controllerPrototype.processRefund).toBeUndefined();
       });
     });

--- a/apps/api/src/payments/controllers/__tests__/payments-security.controller.spec.ts
+++ b/apps/api/src/payments/controllers/__tests__/payments-security.controller.spec.ts
@@ -5,6 +5,7 @@ import { StripeService } from '../../services/stripe.service';
 import { PaypalService } from '../../services/paypal.service';
 import { UserRole, PaymentStatus, PaymentProvider } from '@prisma/client';
 import { NotFoundException } from '@nestjs/common';
+import { PATH_METADATA } from '@nestjs/common/constants';
 
 describe('PaymentsController Security', () => {
   let controller: PaymentsController;
@@ -37,6 +38,7 @@ describe('PaymentsController Security', () => {
             findAllForAdmin: jest.fn(),
             findOneWithOwnershipCheck: jest.fn(),
             recordExternalPayment: jest.fn(),
+            createManualRefund: jest.fn(),
           },
         },
         {
@@ -62,14 +64,19 @@ describe('PaymentsController Security', () => {
       const result = await controller.findAll();
 
       expect(result).toEqual(mockResult);
-      expect(paymentsService.findAll).toHaveBeenCalledWith(undefined, undefined, undefined, undefined);
+      expect(paymentsService.findAll).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      );
     });
 
     describe('admin payment routes', () => {
       it('should restrict the dedicated payment list to admins', () => {
         const actualRoles = Reflect.getMetadata(
           'roles',
-          PaymentsController.prototype.findAllForAdmin,
+          PaymentsController.prototype.findAllForAdmin
         );
 
         expect(actualRoles).toEqual([UserRole.ADMIN]);
@@ -80,12 +87,30 @@ describe('PaymentsController Security', () => {
       it('should restrict external payment recording to admins', () => {
         const actualRoles = Reflect.getMetadata(
           'roles',
-          PaymentsController.prototype.recordExternalPayment,
+          PaymentsController.prototype.recordExternalPayment
         );
 
         expect(actualRoles).toEqual([UserRole.ADMIN]);
         expect(actualRoles).not.toContain(UserRole.STAFF);
         expect(actualRoles).not.toContain(UserRole.PARTICIPANT);
+      });
+
+      it('should expose only the nested admin manual refund route', () => {
+        const actualRoles = Reflect.getMetadata('roles', PaymentsController.prototype.createRefund);
+        const actualPath = Reflect.getMetadata(
+          PATH_METADATA,
+          PaymentsController.prototype.createRefund
+        );
+        const controllerPrototype = PaymentsController.prototype as unknown as Record<
+          string,
+          unknown
+        >;
+
+        expect(actualRoles).toEqual([UserRole.ADMIN]);
+        expect(actualRoles).not.toContain(UserRole.STAFF);
+        expect(actualRoles).not.toContain(UserRole.PARTICIPANT);
+        expect(actualPath).toBe(':paymentId/refunds');
+        expect(controllerPrototype.processRefund).toBeUndefined();
       });
     });
 
@@ -103,70 +128,93 @@ describe('PaymentsController Security', () => {
   describe('findMyPayments (user-specific)', () => {
     it('should only return payments for the authenticated user', async () => {
       const mockResult = { payments: [mockPayment], total: 1 };
-      const mockRequest = { 
-        user: { id: 'user-123', role: UserRole.PARTICIPANT } 
+      const mockRequest = {
+        user: { id: 'user-123', role: UserRole.PARTICIPANT },
       } as unknown as Parameters<typeof controller.findMyPayments>[0];
-      
+
       jest.spyOn(paymentsService, 'findAll').mockResolvedValue(mockResult);
 
       const result = await controller.findMyPayments(mockRequest);
 
       expect(result).toEqual(mockResult);
-      expect(paymentsService.findAll).toHaveBeenCalledWith(undefined, undefined, 'user-123', undefined);
+      expect(paymentsService.findAll).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        'user-123',
+        undefined
+      );
     });
   });
 
   describe('findOne (with ownership check)', () => {
     it('should allow admin to access any payment', async () => {
-      const mockRequest = { 
-        user: { id: 'admin-123', role: UserRole.ADMIN } 
+      const mockRequest = {
+        user: { id: 'admin-123', role: UserRole.ADMIN },
       } as unknown as Parameters<typeof controller.findOne>[1];
-      
+
       jest.spyOn(paymentsService, 'findOneWithOwnershipCheck').mockResolvedValue(mockPayment);
 
       const result = await controller.findOne('payment-123', mockRequest);
 
       expect(result).toEqual(mockPayment);
-      expect(paymentsService.findOneWithOwnershipCheck).toHaveBeenCalledWith('payment-123', 'admin-123', UserRole.ADMIN);
+      expect(paymentsService.findOneWithOwnershipCheck).toHaveBeenCalledWith(
+        'payment-123',
+        'admin-123',
+        UserRole.ADMIN
+      );
     });
 
     it('should allow staff to access any payment', async () => {
-      const mockRequest = { 
-        user: { id: 'staff-123', role: UserRole.STAFF } 
+      const mockRequest = {
+        user: { id: 'staff-123', role: UserRole.STAFF },
       } as unknown as Parameters<typeof controller.findOne>[1];
-      
+
       jest.spyOn(paymentsService, 'findOneWithOwnershipCheck').mockResolvedValue(mockPayment);
 
       const result = await controller.findOne('payment-123', mockRequest);
 
       expect(result).toEqual(mockPayment);
-      expect(paymentsService.findOneWithOwnershipCheck).toHaveBeenCalledWith('payment-123', 'staff-123', UserRole.STAFF);
+      expect(paymentsService.findOneWithOwnershipCheck).toHaveBeenCalledWith(
+        'payment-123',
+        'staff-123',
+        UserRole.STAFF
+      );
     });
 
     it('should only allow users to access their own payments', async () => {
-      const mockRequest = { 
-        user: { id: 'user-123', role: UserRole.PARTICIPANT } 
+      const mockRequest = {
+        user: { id: 'user-123', role: UserRole.PARTICIPANT },
       } as unknown as Parameters<typeof controller.findOne>[1];
-      
+
       jest.spyOn(paymentsService, 'findOneWithOwnershipCheck').mockResolvedValue(mockPayment);
 
       const result = await controller.findOne('payment-123', mockRequest);
 
       expect(result).toEqual(mockPayment);
-      expect(paymentsService.findOneWithOwnershipCheck).toHaveBeenCalledWith('payment-123', 'user-123', UserRole.PARTICIPANT);
+      expect(paymentsService.findOneWithOwnershipCheck).toHaveBeenCalledWith(
+        'payment-123',
+        'user-123',
+        UserRole.PARTICIPANT
+      );
     });
 
-    it('should throw NotFoundException when user tries to access another user\'s payment', async () => {
-      const mockRequest = { 
-        user: { id: 'user-456', role: UserRole.PARTICIPANT } 
+    it("should throw NotFoundException when user tries to access another user's payment", async () => {
+      const mockRequest = {
+        user: { id: 'user-456', role: UserRole.PARTICIPANT },
       } as unknown as Parameters<typeof controller.findOne>[1];
-      
-      jest.spyOn(paymentsService, 'findOneWithOwnershipCheck').mockRejectedValue(
-        new NotFoundException('Payment with ID payment-123 not found')
-      );
 
-      await expect(controller.findOne('payment-123', mockRequest)).rejects.toThrow(NotFoundException);
-      expect(paymentsService.findOneWithOwnershipCheck).toHaveBeenCalledWith('payment-123', 'user-456', UserRole.PARTICIPANT);
+      jest
+        .spyOn(paymentsService, 'findOneWithOwnershipCheck')
+        .mockRejectedValue(new NotFoundException('Payment with ID payment-123 not found'));
+
+      await expect(controller.findOne('payment-123', mockRequest)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(paymentsService.findOneWithOwnershipCheck).toHaveBeenCalledWith(
+        'payment-123',
+        'user-456',
+        UserRole.PARTICIPANT
+      );
     });
   });
 });

--- a/apps/api/src/payments/controllers/payments.controller.spec.ts
+++ b/apps/api/src/payments/controllers/payments.controller.spec.ts
@@ -15,7 +15,9 @@ const mockPaymentsService = {
   initiateStripePayment: jest.fn(),
   initiatePaypalPayment: jest.fn(),
   processRefund: jest.fn(),
+  createRefund: jest.fn(),
   createManualRefund: jest.fn(),
+  retryStripeRefund: jest.fn(),
   linkToRegistration: jest.fn(),
   handlePaypalWebhook: jest.fn(),
 };
@@ -296,11 +298,13 @@ describe('PaymentsController', () => {
   });
 
   describe('createRefund', () => {
-    it('should record a manual refund for the authenticated admin', async () => {
+    it.each(['MANUAL', 'STRIPE'] as const)(
+      'should submit a %s refund for the authenticated admin',
+      async executionMode => {
       const paymentId = '5f8d0d55-e0a3-4cf0-a620-2412acd4361c';
       const mockRefundDto = {
         amountCents: 5000,
-        executionMode: 'MANUAL' as const,
+        executionMode,
         reason: 'Partial refund completed externally',
         idempotencyKey: '43ea4b84-1f0d-413d-bc1c-9c91b435d66d',
       };
@@ -319,16 +323,43 @@ describe('PaymentsController', () => {
         availableRefundCents: 5000,
       };
 
-      mockPaymentsService.createManualRefund.mockResolvedValue(mockResponse);
+      mockPaymentsService.createRefund.mockResolvedValue(mockResponse);
 
       const result = await controller.createRefund(paymentId, mockRefundDto, mockRequest);
 
-      expect(mockPaymentsService.createManualRefund).toHaveBeenCalledWith(
+      expect(mockPaymentsService.createRefund).toHaveBeenCalledWith(
         paymentId,
         mockRefundDto,
         'admin-id'
       );
       expect(result).toEqual(mockResponse);
+      }
+    );
+
+    it('should retry a pending Stripe refund without mutable refund data', async () => {
+      const paymentId = '5f8d0d55-e0a3-4cf0-a620-2412acd4361c';
+      const refundId = '6a9e1e88-e8c0-43f1-9fe4-a2cad9703120';
+      const mockRequest = {
+        user: {
+          id: 'admin-id',
+          role: UserRole.ADMIN,
+        },
+      } as unknown as Parameters<typeof controller.retryRefund>[2];
+      const mockResponse = {
+        payment: { id: paymentId },
+        refund: { id: refundId, status: 'PENDING' },
+        outcome: 'PENDING_UNKNOWN',
+      };
+      mockPaymentsService.retryStripeRefund.mockResolvedValue(mockResponse);
+
+      const actualResult = await controller.retryRefund(paymentId, refundId, mockRequest);
+
+      expect(mockPaymentsService.retryStripeRefund).toHaveBeenCalledWith(
+        paymentId,
+        refundId,
+        'admin-id'
+      );
+      expect(actualResult).toEqual(mockResponse);
     });
   });
 

--- a/apps/api/src/payments/controllers/payments.controller.spec.ts
+++ b/apps/api/src/payments/controllers/payments.controller.spec.ts
@@ -15,6 +15,7 @@ const mockPaymentsService = {
   initiateStripePayment: jest.fn(),
   initiatePaypalPayment: jest.fn(),
   processRefund: jest.fn(),
+  createManualRefund: jest.fn(),
   linkToRegistration: jest.fn(),
   handlePaypalWebhook: jest.fn(),
 };
@@ -62,8 +63,8 @@ describe('PaymentsController', () => {
         userId: 'user-id',
         providerRefId: 'provider-ref-id',
       };
-      const mockPayment = { 
-        id: 'payment-id', 
+      const mockPayment = {
+        id: 'payment-id',
         ...mockPaymentDto,
         status: PaymentStatus.PENDING,
         createdAt: new Date(),
@@ -144,17 +145,17 @@ describe('PaymentsController', () => {
     it('should return a payment by ID', async () => {
       // Mock data
       const paymentId = 'payment-id';
-      const mockPayment = { 
-        id: paymentId, 
+      const mockPayment = {
+        id: paymentId,
         amount: 100,
         status: PaymentStatus.COMPLETED,
       };
 
       const mockRequest = {
-        user: { 
-          id: 'user-id', 
-          role: UserRole.ADMIN 
-        }
+        user: {
+          id: 'user-id',
+          role: UserRole.ADMIN,
+        },
       } as unknown as Parameters<typeof controller.findOne>[1];
 
       // Setup mocks
@@ -164,7 +165,11 @@ describe('PaymentsController', () => {
       const result = await controller.findOne(paymentId, mockRequest);
 
       // Assert
-      expect(mockPaymentsService.findOneWithOwnershipCheck).toHaveBeenCalledWith(paymentId, 'user-id', UserRole.ADMIN);
+      expect(mockPaymentsService.findOneWithOwnershipCheck).toHaveBeenCalledWith(
+        paymentId,
+        'user-id',
+        UserRole.ADMIN
+      );
       expect(result).toEqual(mockPayment);
     });
   });
@@ -174,8 +179,8 @@ describe('PaymentsController', () => {
       // Mock data
       const paymentId = 'payment-id';
       const updateDto = { status: PaymentStatus.COMPLETED };
-      const mockPayment = { 
-        id: paymentId, 
+      const mockPayment = {
+        id: paymentId,
         amount: 100,
         status: PaymentStatus.COMPLETED,
       };
@@ -222,12 +227,12 @@ describe('PaymentsController', () => {
 
       const actualResult = await controller.recordExternalPayment(
         mockExternalPaymentDto,
-        mockRequest,
+        mockRequest
       );
 
       expect(mockPaymentsService.recordExternalPayment).toHaveBeenCalledWith(
         mockExternalPaymentDto,
-        'admin-id',
+        'admin-id'
       );
       expect(actualResult).toEqual(mockPayment);
     });
@@ -244,8 +249,8 @@ describe('PaymentsController', () => {
         successUrl: 'https://mycamp.playaplan.app/success',
         cancelUrl: 'https://mycamp.playaplan.app/cancel',
       };
-      const mockResponse = { 
-        paymentId: 'payment-id', 
+      const mockResponse = {
+        paymentId: 'payment-id',
         url: 'https://checkout.stripe.com/session-id',
       };
 
@@ -272,8 +277,8 @@ describe('PaymentsController', () => {
         successUrl: 'https://mycamp.playaplan.app/success',
         cancelUrl: 'https://mycamp.playaplan.app/cancel',
       };
-      const mockResponse = { 
-        paymentId: 'payment-id', 
+      const mockResponse = {
+        paymentId: 'payment-id',
         orderId: 'paypal-order-id',
         approvalUrl: 'https://www.paypal.com/checkoutnow/order-id',
       };
@@ -290,29 +295,39 @@ describe('PaymentsController', () => {
     });
   });
 
-  describe('processRefund', () => {
-    it('should process a refund', async () => {
-      // Mock data
+  describe('createRefund', () => {
+    it('should record a manual refund for the authenticated admin', async () => {
+      const paymentId = '5f8d0d55-e0a3-4cf0-a620-2412acd4361c';
       const mockRefundDto = {
-        paymentId: 'payment-id',
-        amount: 50,
-        reason: 'Partial refund requested by customer',
+        amountCents: 5000,
+        executionMode: 'MANUAL' as const,
+        reason: 'Partial refund completed externally',
+        idempotencyKey: '43ea4b84-1f0d-413d-bc1c-9c91b435d66d',
       };
-      const mockResponse = { 
-        paymentId: 'payment-id', 
-        refundAmount: 50,
-        providerRefundId: 'refund-id',
-        success: true,
+      const mockRequest = {
+        user: {
+          id: 'admin-id',
+          role: UserRole.ADMIN,
+        },
+      } as unknown as Parameters<typeof controller.createRefund>[2];
+      const mockResponse = {
+        payment: { id: paymentId },
+        refund: { id: 'refund-id', amountCents: 5000 },
+        paymentAmountCents: 10000,
+        successfulRefundCents: 5000,
+        pendingRefundCents: 0,
+        availableRefundCents: 5000,
       };
 
-      // Setup mocks
-      mockPaymentsService.processRefund.mockResolvedValue(mockResponse);
+      mockPaymentsService.createManualRefund.mockResolvedValue(mockResponse);
 
-      // Execute
-      const result = await controller.processRefund(mockRefundDto);
+      const result = await controller.createRefund(paymentId, mockRefundDto, mockRequest);
 
-      // Assert
-      expect(mockPaymentsService.processRefund).toHaveBeenCalledWith(mockRefundDto);
+      expect(mockPaymentsService.createManualRefund).toHaveBeenCalledWith(
+        paymentId,
+        mockRefundDto,
+        'admin-id'
+      );
       expect(result).toEqual(mockResponse);
     });
   });
@@ -322,8 +337,8 @@ describe('PaymentsController', () => {
       // Mock data
       const paymentId = 'payment-id';
       const registrationId = 'registration-id';
-      const mockPayment = { 
-        id: paymentId, 
+      const mockPayment = {
+        id: paymentId,
         amount: 100,
         status: PaymentStatus.COMPLETED,
         registrationId,
@@ -336,7 +351,10 @@ describe('PaymentsController', () => {
       const result = await controller.linkToRegistration(paymentId, registrationId);
 
       // Assert
-      expect(mockPaymentsService.linkToRegistration).toHaveBeenCalledWith(paymentId, registrationId);
+      expect(mockPaymentsService.linkToRegistration).toHaveBeenCalledWith(
+        paymentId,
+        registrationId
+      );
       expect(result).toEqual(mockPayment);
     });
   });
@@ -358,4 +376,4 @@ describe('PaymentsController', () => {
       expect(result).toEqual(mockResponse);
     });
   });
-}); 
+});

--- a/apps/api/src/payments/controllers/payments.controller.ts
+++ b/apps/api/src/payments/controllers/payments.controller.ts
@@ -196,9 +196,9 @@ export class PaymentsController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Record an already-completed manual refund' })
+  @ApiOperation({ summary: 'Record a manual refund or initiate a Stripe refund' })
   @ApiParam({ name: 'paymentId', required: true, description: 'Payment ID' })
-  @ApiResponse({ status: 201, description: 'Manual refund recorded successfully' })
+  @ApiResponse({ status: 201, description: 'Refund command accepted' })
   @ApiResponse({ status: 400, description: 'Invalid input data or refundable balance' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden - Admin access required' })
@@ -209,7 +209,27 @@ export class PaymentsController {
     @Body() createRefundDto: CreateRefundDto,
     @Request() req: AuthenticatedRequest
   ) {
-    return this.paymentsService.createManualRefund(paymentId, createRefundDto, req.user.id);
+    return this.paymentsService.createRefund(paymentId, createRefundDto, req.user.id);
+  }
+
+  @Post(':paymentId/refunds/:refundId/retry')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Retry reconciliation for a pending Stripe refund' })
+  @ApiParam({ name: 'paymentId', required: true, description: 'Payment ID' })
+  @ApiParam({ name: 'refundId', required: true, description: 'Refund ID' })
+  @ApiResponse({ status: 201, description: 'Refund reconciliation attempted' })
+  @ApiResponse({ status: 400, description: 'Refund is not eligible for Stripe retry' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Admin access required' })
+  @ApiResponse({ status: 404, description: 'Payment or refund not found' })
+  async retryRefund(
+    @Param('paymentId', ParseUUIDPipe) paymentId: string,
+    @Param('refundId', ParseUUIDPipe) refundId: string,
+    @Request() req: AuthenticatedRequest
+  ) {
+    return this.paymentsService.retryStripeRefund(paymentId, refundId, req.user.id);
   }
 
   @Post('link/:paymentId/registration/:registrationId')

--- a/apps/api/src/payments/controllers/payments.controller.ts
+++ b/apps/api/src/payments/controllers/payments.controller.ts
@@ -1,7 +1,36 @@
-import { Controller, Post, Body, Get, Param, Query, UseGuards, ParseUUIDPipe, Put, HttpCode, HttpStatus, Request, DefaultValuePipe, ParseIntPipe } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+  Put,
+  HttpCode,
+  HttpStatus,
+  Request,
+  DefaultValuePipe,
+  ParseIntPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiParam,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { PaymentsService, StripeService, PaypalService } from '../services';
-import { CreatePaymentDto, CreateStripePaymentDto, CreatePaypalPaymentDto, CreateRefundDto, CreateExternalPaymentDto, UpdatePaymentDto } from '../dto';
+import {
+  CreatePaymentDto,
+  CreateStripePaymentDto,
+  CreatePaypalPaymentDto,
+  CreateRefundDto,
+  CreateExternalPaymentDto,
+  UpdatePaymentDto,
+} from '../dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
@@ -14,7 +43,7 @@ export class PaymentsController {
   constructor(
     private readonly paymentsService: PaymentsService,
     private readonly stripeService: StripeService,
-    private readonly paypalService: PaypalService,
+    private readonly paypalService: PaypalService
   ) {}
 
   @Post()
@@ -45,13 +74,13 @@ export class PaymentsController {
     @Query('skip') skip?: string,
     @Query('take') take?: string,
     @Query('userId') userId?: string,
-    @Query('status') status?: PaymentStatus,
+    @Query('status') status?: PaymentStatus
   ) {
     return this.paymentsService.findAll(
       skip ? parseInt(skip, 10) : undefined,
       take ? parseInt(take, 10) : undefined,
       userId,
-      status,
+      status
     );
   }
 
@@ -68,7 +97,7 @@ export class PaymentsController {
   @ApiResponse({ status: 403, description: 'Forbidden - Admin access required' })
   async findAllForAdmin(
     @Query('skip', new DefaultValuePipe(0), ParseIntPipe) skip: number,
-    @Query('take', new DefaultValuePipe(25), ParseIntPipe) take: number,
+    @Query('take', new DefaultValuePipe(25), ParseIntPipe) take: number
   ) {
     return this.paymentsService.findAllForAdmin(skip, take);
   }
@@ -76,7 +105,7 @@ export class PaymentsController {
   @Get('my-payments')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get current user\'s payments only' })
+  @ApiOperation({ summary: "Get current user's payments only" })
   @ApiQuery({ name: 'skip', required: false, type: Number })
   @ApiQuery({ name: 'take', required: false, type: Number })
   @ApiQuery({ name: 'status', required: false, enum: PaymentStatus })
@@ -86,14 +115,14 @@ export class PaymentsController {
     @Request() req: AuthenticatedRequest,
     @Query('skip') skip?: string,
     @Query('take') take?: string,
-    @Query('status') status?: PaymentStatus,
+    @Query('status') status?: PaymentStatus
   ) {
     const userId = req.user.id;
     return this.paymentsService.findAll(
       skip ? parseInt(skip, 10) : undefined,
       take ? parseInt(take, 10) : undefined,
       userId, // Force filter to current user
-      status,
+      status
     );
   }
 
@@ -119,10 +148,7 @@ export class PaymentsController {
   @ApiResponse({ status: 200, description: 'Payment updated successfully' })
   @ApiResponse({ status: 404, description: 'Payment not found' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async update(
-    @Param('id', ParseUUIDPipe) id: string,
-    @Body() updatePaymentDto: UpdatePaymentDto,
-  ) {
+  async update(@Param('id', ParseUUIDPipe) id: string, @Body() updatePaymentDto: UpdatePaymentDto) {
     return this.paymentsService.update(id, updatePaymentDto);
   }
 
@@ -139,12 +165,9 @@ export class PaymentsController {
   @ApiResponse({ status: 409, description: 'Idempotency key reused with different input' })
   async recordExternalPayment(
     @Body() createExternalPaymentDto: CreateExternalPaymentDto,
-    @Request() req: AuthenticatedRequest,
+    @Request() req: AuthenticatedRequest
   ) {
-    return this.paymentsService.recordExternalPayment(
-      createExternalPaymentDto,
-      req.user.id,
-    );
+    return this.paymentsService.recordExternalPayment(createExternalPaymentDto, req.user.id);
   }
 
   @Post('stripe')
@@ -169,16 +192,24 @@ export class PaymentsController {
     return this.paymentsService.initiatePaypalPayment(createPaypalPaymentDto);
   }
 
-  @Post('refund')
+  @Post(':paymentId/refunds')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
+  @Roles(UserRole.ADMIN)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Process a refund' })
-  @ApiResponse({ status: 201, description: 'Refund processed successfully' })
-  @ApiResponse({ status: 400, description: 'Invalid input data or cannot refund this payment' })
+  @ApiOperation({ summary: 'Record an already-completed manual refund' })
+  @ApiParam({ name: 'paymentId', required: true, description: 'Payment ID' })
+  @ApiResponse({ status: 201, description: 'Manual refund recorded successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid input data or refundable balance' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async processRefund(@Body() createRefundDto: CreateRefundDto) {
-    return this.paymentsService.processRefund(createRefundDto);
+  @ApiResponse({ status: 403, description: 'Forbidden - Admin access required' })
+  @ApiResponse({ status: 404, description: 'Payment not found' })
+  @ApiResponse({ status: 409, description: 'Idempotency or serialization conflict' })
+  async createRefund(
+    @Param('paymentId', ParseUUIDPipe) paymentId: string,
+    @Body() createRefundDto: CreateRefundDto,
+    @Request() req: AuthenticatedRequest
+  ) {
+    return this.paymentsService.createManualRefund(paymentId, createRefundDto, req.user.id);
   }
 
   @Post('link/:paymentId/registration/:registrationId')
@@ -194,7 +225,7 @@ export class PaymentsController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async linkToRegistration(
     @Param('paymentId', ParseUUIDPipe) paymentId: string,
-    @Param('registrationId', ParseUUIDPipe) registrationId: string,
+    @Param('registrationId', ParseUUIDPipe) registrationId: string
   ) {
     return this.paymentsService.linkToRegistration(paymentId, registrationId);
   }

--- a/apps/api/src/payments/dto/create-refund.dto.spec.ts
+++ b/apps/api/src/payments/dto/create-refund.dto.spec.ts
@@ -51,6 +51,26 @@ describe('CreateRefundDto', () => {
     expect(actualErrors.some(error => error.property === 'amountCents')).toBe(true);
   });
 
+  it('should accept the PostgreSQL INTEGER maximum amount in cents', async () => {
+    const actualErrors = await validateRequest({
+      ...validRequest,
+      amountCents: 2_147_483_647,
+    });
+
+    expect(actualErrors).toHaveLength(0);
+  });
+
+  it('should reject an amount above the PostgreSQL INTEGER maximum', async () => {
+    const actualErrors = await validateRequest({
+      ...validRequest,
+      amountCents: 2_147_483_648,
+    });
+
+    const amountError = actualErrors.find(error => error.property === 'amountCents');
+    expect(amountError).toBeDefined();
+    expect(Object.values(amountError?.constraints ?? {}).join(' ')).toContain('supported range');
+  });
+
   it('should normalize optional text and accept allowed registration status', async () => {
     const inputDto = plainToInstance(CreateRefundDto, {
       ...validRequest,

--- a/apps/api/src/payments/dto/create-refund.dto.spec.ts
+++ b/apps/api/src/payments/dto/create-refund.dto.spec.ts
@@ -1,0 +1,116 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { RefundExecutionMode, RegistrationStatus } from '@prisma/client';
+import { CreateRefundDto } from './create-refund.dto';
+
+const validRequest = {
+  amountCents: 5000,
+  executionMode: RefundExecutionMode.MANUAL,
+  idempotencyKey: '43ea4b84-1f0d-413d-bc1c-9c91b435d66d',
+};
+
+async function validateRequest(
+  request: Record<string, unknown>
+): Promise<ReturnType<typeof validate>> {
+  const inputDto = plainToInstance(CreateRefundDto, request);
+  return validate(inputDto, {
+    whitelist: true,
+    forbidNonWhitelisted: true,
+  });
+}
+
+describe('CreateRefundDto', () => {
+  it.each([
+    validRequest,
+    {
+      fullRefund: true,
+      executionMode: RefundExecutionMode.MANUAL,
+      idempotencyKey: validRequest.idempotencyKey,
+    },
+  ])('should accept one valid refund amount selection', async inputRequest => {
+    const actualErrors = await validateRequest(inputRequest);
+
+    expect(actualErrors).toHaveLength(0);
+  });
+
+  it.each([
+    {},
+    { amountCents: 100, fullRefund: true },
+    { fullRefund: false },
+    { amountCents: 0 },
+    { amountCents: -1 },
+    { amountCents: 1.5 },
+    { amountCents: Number.MAX_SAFE_INTEGER + 1 },
+  ])('should reject invalid amount selection %o', async inputSelection => {
+    const actualErrors = await validateRequest({
+      ...validRequest,
+      amountCents: undefined,
+      ...inputSelection,
+    });
+
+    expect(actualErrors.some(error => error.property === 'amountCents')).toBe(true);
+  });
+
+  it('should normalize optional text and accept allowed registration status', async () => {
+    const inputDto = plainToInstance(CreateRefundDto, {
+      ...validRequest,
+      reason: ' duplicate charge ',
+      externalReference: ' refund-123 ',
+      resultingRegistrationStatus: RegistrationStatus.WAITLISTED,
+    });
+
+    const actualErrors = await validate(inputDto);
+
+    expect(actualErrors).toHaveLength(0);
+    expect(inputDto.reason).toBe('duplicate charge');
+    expect(inputDto.externalReference).toBe('refund-123');
+  });
+
+  it.each([
+    RegistrationStatus.CANCELLED,
+    RegistrationStatus.APPLICATION_SUBMITTED,
+    RegistrationStatus.APPLICATION_APPROVED,
+    RegistrationStatus.APPLICATION_DECLINED,
+  ])(
+    'should reject resulting registration status %s with cancellation guidance',
+    async inputStatus => {
+      const actualErrors = await validateRequest({
+        ...validRequest,
+        resultingRegistrationStatus: inputStatus,
+      });
+
+      const statusError = actualErrors.find(
+        error => error.property === 'resultingRegistrationStatus'
+      );
+      expect(statusError).toBeDefined();
+      expect(Object.values(statusError?.constraints ?? {}).join(' ')).toContain(
+        'cancellation workflow'
+      );
+    }
+  );
+
+  it('should reject non-manual mode, invalid UUID, oversized text, and derived fields', async () => {
+    const actualErrors = await validateRequest({
+      ...validRequest,
+      executionMode: RefundExecutionMode.STRIPE,
+      idempotencyKey: 'not-a-uuid',
+      reason: 'x'.repeat(501),
+      externalReference: 'x'.repeat(256),
+      currency: 'USD',
+      availableRefundCents: 5000,
+      userId: 'admin-id',
+    });
+
+    expect(actualErrors.map(error => error.property)).toEqual(
+      expect.arrayContaining([
+        'executionMode',
+        'idempotencyKey',
+        'reason',
+        'externalReference',
+        'currency',
+        'availableRefundCents',
+        'userId',
+      ])
+    );
+  });
+});

--- a/apps/api/src/payments/dto/create-refund.dto.spec.ts
+++ b/apps/api/src/payments/dto/create-refund.dto.spec.ts
@@ -23,6 +23,11 @@ describe('CreateRefundDto', () => {
   it.each([
     validRequest,
     {
+      amountCents: 5000,
+      executionMode: RefundExecutionMode.STRIPE,
+      idempotencyKey: validRequest.idempotencyKey,
+    },
+    {
       fullRefund: true,
       executionMode: RefundExecutionMode.MANUAL,
       idempotencyKey: validRequest.idempotencyKey,
@@ -89,10 +94,20 @@ describe('CreateRefundDto', () => {
     }
   );
 
-  it('should reject non-manual mode, invalid UUID, oversized text, and derived fields', async () => {
+  it('should reject a manual-only external reference for Stripe mode', async () => {
     const actualErrors = await validateRequest({
       ...validRequest,
       executionMode: RefundExecutionMode.STRIPE,
+      externalReference: 'external-refund-123',
+    });
+
+    expect(actualErrors.find(error => error.property === 'externalReference')).toBeDefined();
+  });
+
+  it('should reject invalid mode, invalid UUID, oversized text, and derived fields', async () => {
+    const actualErrors = await validateRequest({
+      ...validRequest,
+      executionMode: 'PAYPAL',
       idempotencyKey: 'not-a-uuid',
       reason: 'x'.repeat(501),
       externalReference: 'x'.repeat(256),

--- a/apps/api/src/payments/dto/create-refund.dto.ts
+++ b/apps/api/src/payments/dto/create-refund.dto.ts
@@ -14,6 +14,7 @@ import {
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RefundExecutionMode, RegistrationStatus } from '@prisma/client';
+import { centsToDollars } from '../utils/money.utils';
 
 const ALLOWED_RESULTING_STATUSES = [
   RegistrationStatus.PENDING,
@@ -45,11 +46,24 @@ class RefundAmountSelectionConstraint implements ValidatorConstraintInterface {
       return request.fullRefund === true;
     }
 
-    return typeof amountCents === 'number' && Number.isSafeInteger(amountCents) && amountCents > 0;
+    if (typeof amountCents !== 'number' || amountCents <= 0) {
+      return false;
+    }
+
+    try {
+      centsToDollars(amountCents);
+      return true;
+    } catch (error: unknown) {
+      if (error instanceof RangeError) {
+        return false;
+      }
+
+      throw error;
+    }
   }
 
   defaultMessage(): string {
-    return 'Provide exactly one of a positive integer amountCents or fullRefund: true';
+    return 'Provide exactly one of a positive integer amountCents within the supported range or fullRefund: true';
   }
 }
 

--- a/apps/api/src/payments/dto/create-refund.dto.ts
+++ b/apps/api/src/payments/dto/create-refund.dto.ts
@@ -1,49 +1,119 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+import {
+  Allow,
+  Equals,
+  IsIn,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  Validate,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { RefundExecutionMode, RegistrationStatus } from '@prisma/client';
+
+const ALLOWED_RESULTING_STATUSES = [
+  RegistrationStatus.PENDING,
+  RegistrationStatus.CONFIRMED,
+  RegistrationStatus.WAITLISTED,
+] as const;
+
+function normalizeOptionalText(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const normalizedValue = value.trim();
+  return normalizedValue.length > 0 ? normalizedValue : undefined;
+}
+
+@ValidatorConstraint({ name: 'refundAmountSelection', async: false })
+class RefundAmountSelectionConstraint implements ValidatorConstraintInterface {
+  validate(amountCents: unknown, validationArguments: ValidationArguments): boolean {
+    const request = validationArguments.object as CreateRefundDto;
+    const hasAmount = amountCents !== undefined;
+    const hasFullRefund = request.fullRefund !== undefined;
+
+    if (hasAmount === hasFullRefund) {
+      return false;
+    }
+
+    if (hasFullRefund) {
+      return request.fullRefund === true;
+    }
+
+    return typeof amountCents === 'number' && Number.isSafeInteger(amountCents) && amountCents > 0;
+  }
+
+  defaultMessage(): string {
+    return 'Provide exactly one of a positive integer amountCents or fullRefund: true';
+  }
+}
 
 /**
- * Data Transfer Object for creating a refund
+ * Data required to record an already-completed manual refund.
  */
 export class CreateRefundDto {
-  @ApiProperty({
-    description: 'ID of the payment to refund',
-    example: '5f8d0d55-e0a3-4cf0-a620-2412acd4361c',
-  })
-  @IsNotEmpty()
-  @IsString()
-  @IsUUID()
-  paymentId!: string;
-
-  @ApiProperty({
-    description: 'The refund amount (optional, defaults to full amount)',
-    example: 50.00,
-    minimum: 0.01,
-    required: false,
-  })
-  @IsOptional()
-  @IsNumber()
-  @Min(0.01)
-  amount?: number;
-
-  @ApiProperty({
-    description: 'Refund percentage of the original amount (alternative to specific amount)',
-    example: 50,
+  @ApiPropertyOptional({
+    description: 'Positive refund amount in integer cents',
+    example: 5000,
     minimum: 1,
-    maximum: 100,
-    required: false,
   })
-  @IsOptional()
-  @IsNumber()
-  @Min(1)
-  @Max(100)
-  percentageOfOriginal?: number;
+  @Validate(RefundAmountSelectionConstraint)
+  amountCents?: number;
+
+  @ApiPropertyOptional({
+    description: 'Refund the full currently available balance',
+    example: true,
+  })
+  @Allow()
+  fullRefund?: boolean;
 
   @ApiProperty({
-    description: 'Reason for the refund',
-    example: 'Customer requested refund',
-    required: false,
+    description: 'Manual refunds record an already-completed external refund',
+    enum: [RefundExecutionMode.MANUAL],
   })
+  @Equals(RefundExecutionMode.MANUAL)
+  executionMode!: RefundExecutionMode;
+
+  @ApiPropertyOptional({
+    description: 'Reason for the refund',
+    maxLength: 500,
+  })
+  @Transform(({ value }: { value: unknown }) => normalizeOptionalText(value))
   @IsOptional()
   @IsString()
+  @MaxLength(500)
   reason?: string;
-} 
+
+  @ApiPropertyOptional({
+    description: 'External refund transaction or receipt reference',
+    maxLength: 255,
+  })
+  @Transform(({ value }: { value: unknown }) => normalizeOptionalText(value))
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  externalReference?: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional registration status to apply after success',
+    enum: ALLOWED_RESULTING_STATUSES,
+  })
+  @IsOptional()
+  @IsIn(ALLOWED_RESULTING_STATUSES, {
+    message:
+      'resultingRegistrationStatus must be PENDING, CONFIRMED, or WAITLISTED; use the cancellation workflow to cancel a registration',
+  })
+  resultingRegistrationStatus?: RegistrationStatus;
+
+  @ApiProperty({
+    description: 'Client-generated idempotency key retained for retries',
+    format: 'uuid',
+  })
+  @IsUUID()
+  idempotencyKey!: string;
+}

--- a/apps/api/src/payments/dto/create-refund.dto.ts
+++ b/apps/api/src/payments/dto/create-refund.dto.ts
@@ -1,7 +1,7 @@
 import { Transform } from 'class-transformer';
 import {
   Allow,
-  Equals,
+  IsEnum,
   IsIn,
   IsOptional,
   IsString,
@@ -53,8 +53,20 @@ class RefundAmountSelectionConstraint implements ValidatorConstraintInterface {
   }
 }
 
+@ValidatorConstraint({ name: 'manualRefundExternalReference', async: false })
+class ManualRefundExternalReferenceConstraint implements ValidatorConstraintInterface {
+  validate(externalReference: unknown, validationArguments: ValidationArguments): boolean {
+    const request = validationArguments.object as CreateRefundDto;
+    return request.executionMode === RefundExecutionMode.MANUAL || externalReference === undefined;
+  }
+
+  defaultMessage(): string {
+    return 'externalReference is supported only for MANUAL refunds';
+  }
+}
+
 /**
- * Data required to record an already-completed manual refund.
+ * Data required to create a manual or Stripe refund.
  */
 export class CreateRefundDto {
   @ApiPropertyOptional({
@@ -73,10 +85,10 @@ export class CreateRefundDto {
   fullRefund?: boolean;
 
   @ApiProperty({
-    description: 'Manual refunds record an already-completed external refund',
-    enum: [RefundExecutionMode.MANUAL],
+    description: 'Manual records an external refund; Stripe initiates a processor refund',
+    enum: RefundExecutionMode,
   })
-  @Equals(RefundExecutionMode.MANUAL)
+  @IsEnum(RefundExecutionMode)
   executionMode!: RefundExecutionMode;
 
   @ApiPropertyOptional({
@@ -97,6 +109,7 @@ export class CreateRefundDto {
   @IsOptional()
   @IsString()
   @MaxLength(255)
+  @Validate(ManualRefundExternalReferenceConstraint)
   externalReference?: string;
 
   @ApiPropertyOptional({

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -425,6 +425,7 @@ describe('PaymentsService', () => {
               successfulRefundCents: 2500,
               pendingRefundCents: 1000,
               availableRefundCents: 9000,
+              refundUnavailableReason: null,
             },
           ],
           total: 1,
@@ -435,6 +436,49 @@ describe('PaymentsService', () => {
         expect(actualResult.payments[0]?.refunds[0]).not.toHaveProperty('processedByUserId');
         expect(actualResult.payments[0]?.refunds[0]).not.toHaveProperty('providerRefundId');
         expect(actualResult.payments[0]?.refunds[0]).not.toHaveProperty('failureMessage');
+      });
+
+      it('should keep a legacy sub-cent payment visible but unavailable for refunds', async () => {
+        const mockPayment = {
+          id: 'legacy-precision-payment',
+          amount: 10.001,
+          currency: 'USD',
+          status: PaymentStatus.COMPLETED,
+          provider: PaymentProvider.PAYPAL,
+          externalMethod: null,
+          externalReference: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 'user-id',
+          registrationId: null,
+          user: {
+            id: 'user-id',
+            firstName: 'Legacy',
+            lastName: 'Payment',
+            email: 'legacy@example.com',
+          },
+          registration: null,
+          refunds: [],
+        };
+        mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
+        mockPrismaService.payment.count.mockResolvedValue(1);
+
+        const actualResult = await service.findAllForAdmin();
+
+        expect(actualResult).toEqual({
+          payments: [
+            {
+              ...mockPayment,
+              paymentAmountCents: null,
+              successfulRefundCents: 0,
+              pendingRefundCents: 0,
+              availableRefundCents: 0,
+              refundUnavailableReason:
+                'Refund unavailable because the stored payment amount has unsupported precision.',
+            },
+          ],
+          total: 1,
+        });
       });
 
       it('should report legacy ledgerless refunded payments as fully refunded', async () => {
@@ -3156,6 +3200,21 @@ describe('PaymentsService', () => {
       expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
     });
 
+    it('should reject manual refunds for a stored payment with sub-cent precision', async () => {
+      mockPrismaService.payment.findUnique
+        .mockReset()
+        .mockResolvedValue({ ...basePayment, amount: 10.001 });
+
+      await expect(
+        service.createManualRefund(paymentId, inputRequest, 'admin-id')
+      ).rejects.toThrow('Dollar amount must not have sub-cent precision');
+
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+    });
+
     it('should allow a payment without registration but reject a requested registration status', async () => {
       const unlinkedPayment = {
         ...basePayment,
@@ -3213,6 +3272,69 @@ describe('PaymentsService', () => {
         )
       ).rejects.toThrow('use the cancellation workflow');
       expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      RegistrationStatus.CANCELLED,
+      RegistrationStatus.APPLICATION_SUBMITTED,
+      RegistrationStatus.APPLICATION_APPROVED,
+      RegistrationStatus.APPLICATION_DECLINED,
+    ])(
+      'should reject a registration status change when the current status is %s',
+      async currentStatus => {
+        mockPrismaService.payment.findUnique.mockReset().mockResolvedValue({
+          ...basePayment,
+          registration: {
+            ...basePayment.registration,
+            status: currentStatus,
+          },
+        });
+
+        await expect(
+          service.createManualRefund(
+            paymentId,
+            {
+              ...inputRequest,
+              resultingRegistrationStatus: RegistrationStatus.WAITLISTED,
+            },
+            'admin-id'
+          )
+        ).rejects.toThrow('use the cancellation workflow');
+
+        expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+        expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+        expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+        expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should preserve a cancelled registration when no resulting status is requested', async () => {
+      const cancelledPayment = {
+        ...basePayment,
+        registration: {
+          ...basePayment.registration,
+          status: RegistrationStatus.CANCELLED,
+        },
+      };
+      mockPrismaService.payment.findUnique
+        .mockReset()
+        .mockResolvedValueOnce(cancelledPayment)
+        .mockResolvedValueOnce(
+          buildUpdatedPayment(
+            PaymentStatus.PARTIALLY_REFUNDED,
+            [publicCreatedRefund],
+            RegistrationStatus.CANCELLED
+          )
+        );
+
+      const actualResult = await service.createManualRefund(
+        paymentId,
+        inputRequest,
+        'admin-id'
+      );
+
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+      expect(actualResult.payment.registration?.status).toBe(RegistrationStatus.CANCELLED);
     });
 
     it('should return an identical replay without duplicate writes', async () => {

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -9,15 +9,14 @@ import {
   AdminAuditTargetType,
   ExternalPaymentMethod,
   PaymentProvider,
+  PaymentRefundStatus,
   PaymentStatus,
+  Prisma,
+  RefundExecutionMode,
   RegistrationStatus,
   UserRole,
 } from '@prisma/client';
-import {
-  NotFoundException,
-  BadRequestException,
-  ConflictException,
-} from '@nestjs/common';
+import { NotFoundException, BadRequestException, ConflictException } from '@nestjs/common';
 
 // Mock implementations
 const mockPrismaService = {
@@ -29,6 +28,10 @@ const mockPrismaService = {
     update: jest.fn(),
     count: jest.fn(),
   },
+  paymentRefund: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+  },
   user: {
     findUnique: jest.fn(),
   },
@@ -39,8 +42,9 @@ const mockPrismaService = {
   },
   adminAudit: {
     create: jest.fn(),
+    findFirst: jest.fn(),
   },
-  $transaction: jest.fn((operations) => {
+  $transaction: jest.fn(operations => {
     if (Array.isArray(operations)) {
       const results = operations.map(op => {
         if (op && op.where && op.data) {
@@ -73,7 +77,7 @@ const mockPrismaService = {
       });
       return Promise.resolve(results);
     }
-    return Promise.resolve((typeof operations === 'function') ? operations() : operations);
+    return Promise.resolve(typeof operations === 'function' ? operations() : operations);
   }),
 };
 
@@ -147,6 +151,21 @@ const expectedAdminPaymentSelect = {
       status: true,
     },
   },
+  refunds: {
+    select: {
+      id: true,
+      amountCents: true,
+      currency: true,
+      executionMode: true,
+      status: true,
+      reason: true,
+      externalReference: true,
+      resultingRegistrationStatus: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: { createdAt: 'asc' },
+  },
 };
 
 const expectedExternalPaymentSelect = {
@@ -190,8 +209,8 @@ describe('PaymentsService', () => {
       };
 
       const mockUser = { id: 'user-id', name: 'Test User' };
-      const mockPayment = { 
-        id: 'payment-id', 
+      const mockPayment = {
+        id: 'payment-id',
         ...mockPaymentDto,
         status: PaymentStatus.PENDING,
         createdAt: new Date(),
@@ -206,8 +225,8 @@ describe('PaymentsService', () => {
       const result = await service.create(mockPaymentDto);
 
       // Assert
-      expect(mockPrismaService.user.findUnique).toHaveBeenCalledWith({ 
-        where: { id: mockPaymentDto.userId } 
+      expect(mockPrismaService.user.findUnique).toHaveBeenCalledWith({
+        where: { id: mockPaymentDto.userId },
       });
       expect(mockPrismaService.payment.create).toHaveBeenCalled();
       expect(result).toEqual(mockPayment);
@@ -242,13 +261,13 @@ describe('PaymentsService', () => {
       };
 
       const mockUser = { id: 'user-id', name: 'Test User' };
-      const mockRegistration = { 
-        id: 'registration-id', 
+      const mockRegistration = {
+        id: 'registration-id',
         userId: 'user-id',
         status: 'PENDING',
       };
-      const mockPayment = { 
-        id: 'payment-id', 
+      const mockPayment = {
+        id: 'payment-id',
         ...mockPaymentDto,
         status: PaymentStatus.PENDING,
         createdAt: new Date(),
@@ -264,11 +283,11 @@ describe('PaymentsService', () => {
       const result = await service.create(mockPaymentDto);
 
       // Assert
-      expect(mockPrismaService.user.findUnique).toHaveBeenCalledWith({ 
-        where: { id: mockPaymentDto.userId } 
+      expect(mockPrismaService.user.findUnique).toHaveBeenCalledWith({
+        where: { id: mockPaymentDto.userId },
       });
-      expect(mockPrismaService.registration.findUnique).toHaveBeenCalledWith({ 
-        where: { id: mockPaymentDto.registrationId } 
+      expect(mockPrismaService.registration.findUnique).toHaveBeenCalledWith({
+        where: { id: mockPaymentDto.registrationId },
       });
       expect(mockPrismaService.payment.create).toHaveBeenCalled();
       expect(result).toEqual(mockPayment);
@@ -286,8 +305,8 @@ describe('PaymentsService', () => {
       };
 
       const mockUser = { id: 'user-id', name: 'Test User' };
-      const mockRegistration = { 
-        id: 'registration-id', 
+      const mockRegistration = {
+        id: 'registration-id',
         userId: 'different-user-id', // Different user
         status: 'PENDING',
       };
@@ -348,6 +367,44 @@ describe('PaymentsService', () => {
             year: 2026,
             status: RegistrationStatus.CONFIRMED,
           },
+          refunds: [
+            {
+              id: 'succeeded-refund',
+              amountCents: 2500,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.MANUAL,
+              status: PaymentRefundStatus.SUCCEEDED,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              id: 'pending-refund',
+              amountCents: 1000,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.STRIPE,
+              status: PaymentRefundStatus.PENDING,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              id: 'failed-refund',
+              amountCents: 500,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.STRIPE,
+              status: PaymentRefundStatus.FAILED,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
         };
         mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
         mockPrismaService.payment.count.mockResolvedValue(1);
@@ -360,10 +417,62 @@ describe('PaymentsService', () => {
           select: expectedAdminPaymentSelect,
           orderBy: { createdAt: 'desc' },
         });
-        expect(actualResult).toEqual({ payments: [mockPayment], total: 1 });
+        expect(actualResult).toEqual({
+          payments: [
+            {
+              ...mockPayment,
+              paymentAmountCents: 12500,
+              successfulRefundCents: 2500,
+              pendingRefundCents: 1000,
+              availableRefundCents: 9000,
+            },
+          ],
+          total: 1,
+        });
         expect(actualResult.payments[0]).not.toHaveProperty('idempotencyKey');
         expect(actualResult.payments[0]).not.toHaveProperty('providerRefId');
-        expect(actualResult.payments[0]).not.toHaveProperty('refunds');
+        expect(actualResult.payments[0]?.refunds[0]).not.toHaveProperty('idempotencyKey');
+        expect(actualResult.payments[0]?.refunds[0]).not.toHaveProperty('processedByUserId');
+        expect(actualResult.payments[0]?.refunds[0]).not.toHaveProperty('providerRefundId');
+        expect(actualResult.payments[0]?.refunds[0]).not.toHaveProperty('failureMessage');
+      });
+
+      it('should report legacy ledgerless refunded payments as fully refunded', async () => {
+        const mockPayment = {
+          id: 'legacy-refunded-payment',
+          amount: 125,
+          currency: 'USD',
+          status: PaymentStatus.REFUNDED,
+          provider: PaymentProvider.STRIPE,
+          externalMethod: null,
+          externalReference: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 'user-id',
+          registrationId: null,
+          user: {
+            id: 'user-id',
+            firstName: 'Test',
+            lastName: 'User',
+            email: 'test@example.com',
+          },
+          registration: null,
+          refunds: [],
+        };
+        mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
+        mockPrismaService.payment.count.mockResolvedValue(1);
+
+        const actualResult = await service.findAllForAdmin();
+
+        expect(actualResult.payments[0]).toEqual(
+          expect.objectContaining({
+            paymentAmountCents: 12500,
+            successfulRefundCents: 12500,
+            pendingRefundCents: 0,
+            availableRefundCents: 0,
+            refunds: [],
+          })
+        );
       });
 
       it.each([
@@ -373,9 +482,7 @@ describe('PaymentsService', () => {
         [0, 101],
         [0, 1.5],
       ])('should reject invalid pagination skip=%s take=%s', async (skip, take) => {
-        await expect(service.findAllForAdmin(skip, take)).rejects.toThrow(
-          BadRequestException,
-        );
+        await expect(service.findAllForAdmin(skip, take)).rejects.toThrow(BadRequestException);
         expect(mockPrismaService.payment.findMany).not.toHaveBeenCalled();
       });
     });
@@ -449,8 +556,8 @@ describe('PaymentsService', () => {
     it('should return a payment by ID', async () => {
       // Mock data
       const paymentId = 'payment-id';
-      const mockPayment = { 
-        id: paymentId, 
+      const mockPayment = {
+        id: paymentId,
         amount: 100,
         status: PaymentStatus.COMPLETED,
       };
@@ -507,7 +614,7 @@ describe('PaymentsService', () => {
       const actualPayment = await service.findOneWithOwnershipCheck(
         'payment-id',
         'user-id',
-        UserRole.PARTICIPANT,
+        UserRole.PARTICIPANT
       );
 
       expect(mockPrismaService.payment.findUnique).toHaveBeenCalledWith({
@@ -568,7 +675,7 @@ describe('PaymentsService', () => {
         ...mockPayment,
         status: PaymentStatus.COMPLETED,
       };
-      
+
       const updatedRegistration = {
         ...mockRegistration,
         status: 'CONFIRMED',
@@ -578,7 +685,7 @@ describe('PaymentsService', () => {
       mockPrismaService.payment.findFirst.mockResolvedValue(paymentWithRegistration);
       mockPrismaService.payment.findUnique.mockResolvedValue(paymentWithRegistration);
       mockStripeService.getCheckoutSession.mockResolvedValue(mockStripeSession);
-      
+
       // Mock transaction result
       mockPrismaService.$transaction.mockResolvedValue([updatedPayment, updatedRegistration]);
 
@@ -591,10 +698,10 @@ describe('PaymentsService', () => {
         include: { registration: true },
       });
       expect(mockStripeService.getCheckoutSession).toHaveBeenCalledWith(sessionId);
-      
+
       // Verify transaction was called
       expect(mockPrismaService.$transaction).toHaveBeenCalled();
-      
+
       expect(result).toEqual({
         sessionId,
         paymentStatus: PaymentStatus.COMPLETED,
@@ -645,11 +752,11 @@ describe('PaymentsService', () => {
         where: { id: mockPayment.id },
         data: { status: PaymentStatus.COMPLETED },
       });
-      
+
       // No transaction should be used when there's no registration
       expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
       // Transaction already tested
-      
+
       expect(result).toEqual({
         sessionId,
         paymentStatus: PaymentStatus.COMPLETED,
@@ -687,12 +794,12 @@ describe('PaymentsService', () => {
         include: { registration: true },
       });
       expect(mockStripeService.getCheckoutSession).toHaveBeenCalledWith(sessionId);
-      
+
       // Should not update already completed payment
       expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
       // Transaction already tested: expect(mockPrismaService.$transaction).toHaveBeenCalled();
       // Transaction already tested
-      
+
       expect(result).toEqual({
         sessionId,
         paymentStatus: PaymentStatus.COMPLETED,
@@ -744,12 +851,12 @@ describe('PaymentsService', () => {
           status: PaymentStatus.FAILED,
         },
       });
-      
+
       // No transaction should be used for failed payments
       expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
       // Should not update registration for failed payment
       // Transaction already tested
-      
+
       expect(result).toEqual({
         sessionId,
         paymentStatus: PaymentStatus.FAILED,
@@ -855,7 +962,7 @@ describe('PaymentsService', () => {
       mockPrismaService.payment.findUnique.mockResolvedValue(paymentWithRegistration);
       mockStripeService.getCheckoutSession.mockResolvedValue(mockStripeSession);
       mockPrismaService.$transaction.mockRejectedValue(new Error('Database transaction error'));
-      
+
       // Mock the direct payment update (fallback)
       mockPrismaService.payment.update.mockResolvedValue({
         ...mockPayment,
@@ -872,18 +979,18 @@ describe('PaymentsService', () => {
       });
       expect(mockStripeService.getCheckoutSession).toHaveBeenCalledWith(sessionId);
       expect(mockPrismaService.$transaction).toHaveBeenCalled();
-      
+
       // Should fall back to direct payment update when transaction fails
       expect(mockPrismaService.payment.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: mockPayment.id },
-          data: expect.objectContaining({ 
-            status: PaymentStatus.COMPLETED
+          data: expect.objectContaining({
+            status: PaymentStatus.COMPLETED,
             // notes field has been removed from the implementation
-          })
+          }),
         })
       );
-      
+
       // Result should indicate payment completed
       expect(result.paymentStatus).toBe(PaymentStatus.COMPLETED);
     });
@@ -934,11 +1041,11 @@ describe('PaymentsService', () => {
 
       // Should still run transaction to update payment
       expect(mockPrismaService.$transaction).toHaveBeenCalled();
-      
+
       // Individual update operations shouldn't be called
       // Transaction already tested: expect(mockPrismaService.$transaction).toHaveBeenCalled();
       // Transaction already tested
-      
+
       expect(result).toEqual({
         sessionId,
         paymentStatus: PaymentStatus.COMPLETED,
@@ -955,7 +1062,7 @@ describe('PaymentsService', () => {
     it('should successfully process Stripe refunds with payment intent IDs', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 100.00, // $100.00 in dollars
+        amount: 100.0, // $100.00 in dollars
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.STRIPE,
         providerRefId: 'pi_stripe123',
@@ -999,7 +1106,7 @@ describe('PaymentsService', () => {
       // Assert
       expect(mockPrismaService.payment.findUnique).toHaveBeenCalledWith({
         where: { id: 'payment-id' },
-        include: { 
+        include: {
           user: {
             select: {
               id: true,
@@ -1008,7 +1115,7 @@ describe('PaymentsService', () => {
               email: true,
             },
           },
-          registration: true 
+          registration: true,
         },
       });
       expect(mockStripeService.createRefund).toHaveBeenCalledWith(
@@ -1026,7 +1133,7 @@ describe('PaymentsService', () => {
       });
       expect(result).toEqual({
         paymentId: 'payment-id',
-        refundAmount: 100.00,
+        refundAmount: 100.0,
         providerRefundId: 're_stripe123',
         success: true,
       });
@@ -1036,7 +1143,7 @@ describe('PaymentsService', () => {
     it('should convert checkout session IDs to payment intent IDs for Stripe', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 75.00, // $75.00 in dollars
+        amount: 75.0, // $75.00 in dollars
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.STRIPE,
         providerRefId: 'cs_test_session123', // Checkout session ID
@@ -1086,7 +1193,7 @@ describe('PaymentsService', () => {
       // Assert
       expect(mockPrismaService.payment.findUnique).toHaveBeenCalledWith({
         where: { id: 'payment-id' },
-        include: { 
+        include: {
           user: {
             select: {
               id: true,
@@ -1095,20 +1202,20 @@ describe('PaymentsService', () => {
               email: true,
             },
           },
-          registration: true 
+          registration: true,
         },
       });
-      
+
       // Should call createRefund with checkout session ID, which internally converts to payment intent
       expect(mockStripeService.createRefund).toHaveBeenCalledWith(
         'cs_test_session123', // The original checkout session ID
         7500, // $75.00 converted to cents
         'Registration cancellation'
       );
-      
+
       expect(result).toEqual({
         paymentId: 'payment-id',
-        refundAmount: 75.00,
+        refundAmount: 75.0,
         providerRefundId: 're_stripe456',
         success: true,
       });
@@ -1118,7 +1225,7 @@ describe('PaymentsService', () => {
     it('should map custom refund reasons to valid Stripe reasons', async () => {
       const basePayment = {
         id: 'payment-id',
-        amount: 50.00,
+        amount: 50.0,
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.STRIPE,
         providerRefId: 'pi_test123',
@@ -1174,7 +1281,7 @@ describe('PaymentsService', () => {
       for (const testCase of testCases) {
         // Clear previous calls
         jest.clearAllMocks();
-        
+
         // Setup mocks again
         mockPrismaService.payment.findUnique.mockResolvedValue(basePayment);
         mockStripeService.createRefund.mockResolvedValue(mockStripeRefund);
@@ -1204,7 +1311,7 @@ describe('PaymentsService', () => {
 
         expect(result).toEqual({
           paymentId: 'payment-id',
-          refundAmount: 50.00,
+          refundAmount: 50.0,
           providerRefundId: 're_test123',
           success: true,
         });
@@ -1215,7 +1322,7 @@ describe('PaymentsService', () => {
     it('should handle refund without reason provided', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 25.00,
+        amount: 25.0,
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.STRIPE,
         providerRefId: 'pi_noreason123',
@@ -1265,7 +1372,7 @@ describe('PaymentsService', () => {
 
       expect(result).toEqual({
         paymentId: 'payment-id',
-        refundAmount: 25.00,
+        refundAmount: 25.0,
         providerRefundId: 're_noreason123',
         success: true,
       });
@@ -1275,7 +1382,7 @@ describe('PaymentsService', () => {
     it('should handle PayPal refunds with dollar amounts', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 150.00, // $150.00 in dollars
+        amount: 150.0, // $150.00 in dollars
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.PAYPAL,
         providerRefId: 'PAYID-PAYPAL123',
@@ -1322,7 +1429,7 @@ describe('PaymentsService', () => {
       // Assert
       expect(mockPrismaService.payment.findUnique).toHaveBeenCalledWith({
         where: { id: 'payment-id' },
-        include: { 
+        include: {
           user: {
             select: {
               id: true,
@@ -1331,30 +1438,30 @@ describe('PaymentsService', () => {
               email: true,
             },
           },
-          registration: true 
+          registration: true,
         },
       });
-      
+
       // PayPal service should be called with dollar amount (not cents)
       expect(mockPaypalService.createRefund).toHaveBeenCalledWith(
         'PAYID-PAYPAL123',
-        150.00, // $150.00 as dollars (not converted to cents like Stripe)
+        150.0, // $150.00 as dollars (not converted to cents like Stripe)
         'Event cancellation'
       );
-      
+
       expect(mockPrismaService.payment.update).toHaveBeenCalledWith({
         where: { id: 'payment-id' },
         data: { status: PaymentStatus.REFUNDED },
       });
-      
+
       expect(mockPrismaService.registration.update).toHaveBeenCalledWith({
         where: { id: 'registration-id' },
         data: { status: 'CANCELLED' },
       });
-      
+
       expect(result).toEqual({
         paymentId: 'payment-id',
-        refundAmount: 150.00,
+        refundAmount: 150.0,
         providerRefundId: 'REFUND-PAYPAL123',
         success: true,
       });
@@ -1364,7 +1471,7 @@ describe('PaymentsService', () => {
     it('should handle PayPal refunds without registration', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 75.50,
+        amount: 75.5,
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.PAYPAL,
         providerRefId: 'PAYID-NOREG123',
@@ -1403,16 +1510,16 @@ describe('PaymentsService', () => {
       // Assert
       expect(mockPaypalService.createRefund).toHaveBeenCalledWith(
         'PAYID-NOREG123',
-        75.50, // Dollar amount for PayPal
+        75.5, // Dollar amount for PayPal
         'Duplicate payment'
       );
-      
+
       // Should not call registration update when no registration
       expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
-      
+
       expect(result).toEqual({
         paymentId: 'payment-id',
-        refundAmount: 75.50,
+        refundAmount: 75.5,
         providerRefundId: 'REFUND-NOREG123',
         success: true,
       });
@@ -1422,7 +1529,7 @@ describe('PaymentsService', () => {
     it('should handle MANUAL payment refunds with database-only updates', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 200.00, // $200.00 in dollars
+        amount: 200.0, // $200.00 in dollars
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.MANUAL, // Manual payment provider
         providerRefId: 'MANUAL-PAYMENT-123',
@@ -1459,7 +1566,7 @@ describe('PaymentsService', () => {
       // Assert
       expect(mockPrismaService.payment.findUnique).toHaveBeenCalledWith({
         where: { id: 'payment-id' },
-        include: { 
+        include: {
           user: {
             select: {
               id: true,
@@ -1468,29 +1575,29 @@ describe('PaymentsService', () => {
               email: true,
             },
           },
-          registration: true 
+          registration: true,
         },
       });
-      
+
       // Should NOT call any external payment provider APIs
       expect(mockStripeService.createRefund).not.toHaveBeenCalled();
       expect(mockPaypalService.createRefund).not.toHaveBeenCalled();
-      
+
       // Should update payment status to REFUNDED
       expect(mockPrismaService.payment.update).toHaveBeenCalledWith({
         where: { id: 'payment-id' },
         data: { status: PaymentStatus.REFUNDED },
       });
-      
+
       // Should update registration status to CANCELLED
       expect(mockPrismaService.registration.update).toHaveBeenCalledWith({
         where: { id: 'registration-id' },
         data: { status: 'CANCELLED' },
       });
-      
+
       expect(result).toEqual({
         paymentId: 'payment-id',
-        refundAmount: 200.00,
+        refundAmount: 200.0,
         providerRefundId: expect.stringMatching(/^manual-refund-\d+$/), // Generated manual refund ID
         success: true,
       });
@@ -1500,7 +1607,7 @@ describe('PaymentsService', () => {
     it('should handle MANUAL payment refunds without registration', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 50.00,
+        amount: 50.0,
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.MANUAL,
         providerRefId: 'MANUAL-STANDALONE-456',
@@ -1530,19 +1637,19 @@ describe('PaymentsService', () => {
       // Should NOT call any external payment provider APIs
       expect(mockStripeService.createRefund).not.toHaveBeenCalled();
       expect(mockPaypalService.createRefund).not.toHaveBeenCalled();
-      
+
       // Should update payment status
       expect(mockPrismaService.payment.update).toHaveBeenCalledWith({
         where: { id: 'payment-id' },
         data: { status: PaymentStatus.REFUNDED },
       });
-      
+
       // Should NOT call registration update when no registration
       expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
-      
+
       expect(result).toEqual({
         paymentId: 'payment-id',
-        refundAmount: 50.00,
+        refundAmount: 50.0,
         providerRefundId: expect.stringMatching(/^manual-refund-\d+$/), // Generated manual refund ID
         success: true,
       });
@@ -1552,7 +1659,7 @@ describe('PaymentsService', () => {
     it('should handle MANUAL payment refunds with zero amount', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 0.00, // Zero dollar payment (e.g., comp registration)
+        amount: 0.0, // Zero dollar payment (e.g., comp registration)
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.MANUAL,
         providerRefId: 'MANUAL-COMP-789',
@@ -1590,21 +1697,21 @@ describe('PaymentsService', () => {
       // Should NOT call any external payment provider APIs
       expect(mockStripeService.createRefund).not.toHaveBeenCalled();
       expect(mockPaypalService.createRefund).not.toHaveBeenCalled();
-      
+
       // Should still update database records even for zero amount
       expect(mockPrismaService.payment.update).toHaveBeenCalledWith({
         where: { id: 'payment-id' },
         data: { status: PaymentStatus.REFUNDED },
       });
-      
+
       expect(mockPrismaService.registration.update).toHaveBeenCalledWith({
         where: { id: 'registration-id' },
         data: { status: 'CANCELLED' },
       });
-      
+
       expect(result).toEqual({
         paymentId: 'payment-id',
-        refundAmount: 0.00,
+        refundAmount: 0.0,
         providerRefundId: expect.stringMatching(/^manual-refund-\d+$/), // Generated manual refund ID
         success: true,
       });
@@ -1785,7 +1892,7 @@ describe('PaymentsService', () => {
 
       it('should handle decimal precision correctly for Stripe cents conversion', async () => {
         const testCases = [
-          { dollars: 10.00, expectedCents: 1000 },
+          { dollars: 10.0, expectedCents: 1000 },
           { dollars: 10.01, expectedCents: 1001 },
           { dollars: 10.99, expectedCents: 1099 },
           { dollars: 0.01, expectedCents: 1 },
@@ -1853,7 +1960,7 @@ describe('PaymentsService', () => {
     it('should fail gracefully when Stripe session has no payment intent', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 100.00,
+        amount: 100.0,
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.STRIPE,
         providerRefId: 'cs_no_intent123', // Checkout session without payment intent
@@ -1875,7 +1982,7 @@ describe('PaymentsService', () => {
 
       // Setup mocks
       mockPrismaService.payment.findUnique.mockResolvedValue(mockPayment);
-      
+
       // Mock StripeService to throw error when no payment intent exists
       mockStripeService.createRefund.mockRejectedValue(
         new Error('Checkout session cs_no_intent123 has no associated payment intent')
@@ -1889,7 +1996,7 @@ describe('PaymentsService', () => {
       // Verify payment lookup occurred
       expect(mockPrismaService.payment.findUnique).toHaveBeenCalledWith({
         where: { id: 'payment-id' },
-        include: { 
+        include: {
           user: {
             select: {
               id: true,
@@ -1898,7 +2005,7 @@ describe('PaymentsService', () => {
               email: true,
             },
           },
-          registration: true 
+          registration: true,
         },
       });
 
@@ -1918,7 +2025,7 @@ describe('PaymentsService', () => {
     it('should fail gracefully when Stripe session has null payment intent', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 75.00,
+        amount: 75.0,
         status: PaymentStatus.COMPLETED,
         provider: PaymentProvider.STRIPE,
         providerRefId: 'cs_null_intent456',
@@ -1940,7 +2047,7 @@ describe('PaymentsService', () => {
 
       // Setup mocks
       mockPrismaService.payment.findUnique.mockResolvedValue(mockPayment);
-      
+
       // Mock StripeService to throw specific error for null payment intent
       mockStripeService.createRefund.mockRejectedValue(
         new Error('Checkout session cs_null_intent456 has no associated payment intent')
@@ -1967,7 +2074,7 @@ describe('PaymentsService', () => {
     it('should fail gracefully when Stripe session was never completed', async () => {
       const mockPayment = {
         id: 'payment-id',
-        amount: 50.00,
+        amount: 50.0,
         status: PaymentStatus.COMPLETED, // Payment marked complete but session wasn't
         provider: PaymentProvider.STRIPE,
         providerRefId: 'cs_incomplete789',
@@ -1985,7 +2092,7 @@ describe('PaymentsService', () => {
 
       // Setup mocks
       mockPrismaService.payment.findUnique.mockResolvedValue(mockPayment);
-      
+
       // Mock error for incomplete session
       mockStripeService.createRefund.mockRejectedValue(
         new Error('Checkout session cs_incomplete789 has no associated payment intent')
@@ -2013,7 +2120,7 @@ describe('PaymentsService', () => {
       it('should handle Stripe network errors appropriately', async () => {
         const mockPayment = {
           id: 'payment-id',
-          amount: 125.00,
+          amount: 125.0,
           status: PaymentStatus.COMPLETED,
           provider: PaymentProvider.STRIPE,
           providerRefId: 'pi_network_error',
@@ -2035,7 +2142,7 @@ describe('PaymentsService', () => {
 
         // Setup mocks
         mockPrismaService.payment.findUnique.mockResolvedValue(mockPayment);
-        
+
         // Mock Stripe network error
         mockStripeService.createRefund.mockRejectedValue(
           new Error('Request failed with status code 500')
@@ -2061,7 +2168,7 @@ describe('PaymentsService', () => {
       it('should handle Stripe authentication errors appropriately', async () => {
         const mockPayment = {
           id: 'payment-id',
-          amount: 200.00,
+          amount: 200.0,
           status: PaymentStatus.COMPLETED,
           provider: PaymentProvider.STRIPE,
           providerRefId: 'pi_auth_error',
@@ -2083,11 +2190,9 @@ describe('PaymentsService', () => {
 
         // Setup mocks
         mockPrismaService.payment.findUnique.mockResolvedValue(mockPayment);
-        
+
         // Mock Stripe authentication error
-        mockStripeService.createRefund.mockRejectedValue(
-          new Error('Invalid API Key provided')
-        );
+        mockStripeService.createRefund.mockRejectedValue(new Error('Invalid API Key provided'));
 
         // Execute & Assert
         await expect(service.processRefund(mockRefundDto)).rejects.toThrow(
@@ -2130,7 +2235,7 @@ describe('PaymentsService', () => {
 
         // Setup mocks
         mockPrismaService.payment.findUnique.mockResolvedValue(mockPayment);
-        
+
         // Mock Stripe payment intent not found error
         mockStripeService.createRefund.mockRejectedValue(
           new Error('No such payment_intent: pi_not_found')
@@ -2155,7 +2260,7 @@ describe('PaymentsService', () => {
       it('should handle Stripe already refunded errors', async () => {
         const mockPayment = {
           id: 'payment-id',
-          amount: 150.00,
+          amount: 150.0,
           status: PaymentStatus.COMPLETED,
           provider: PaymentProvider.STRIPE,
           providerRefId: 'pi_already_refunded',
@@ -2177,7 +2282,7 @@ describe('PaymentsService', () => {
 
         // Setup mocks
         mockPrismaService.payment.findUnique.mockResolvedValue(mockPayment);
-        
+
         // Mock Stripe already refunded error
         mockStripeService.createRefund.mockRejectedValue(
           new Error('This PaymentIntent has already been refunded.')
@@ -2202,7 +2307,7 @@ describe('PaymentsService', () => {
       it('should handle Stripe insufficient funds errors', async () => {
         const mockPayment = {
           id: 'payment-id',
-          amount: 300.00,
+          amount: 300.0,
           status: PaymentStatus.COMPLETED,
           provider: PaymentProvider.STRIPE,
           providerRefId: 'pi_insufficient_funds',
@@ -2220,7 +2325,7 @@ describe('PaymentsService', () => {
 
         // Setup mocks
         mockPrismaService.payment.findUnique.mockResolvedValue(mockPayment);
-        
+
         // Mock Stripe insufficient funds error
         mockStripeService.createRefund.mockRejectedValue(
           new Error('Insufficient funds in Stripe account for refund')
@@ -2245,7 +2350,7 @@ describe('PaymentsService', () => {
       it('should handle generic Stripe API errors', async () => {
         const mockPayment = {
           id: 'payment-id',
-          amount: 99.00,
+          amount: 99.0,
           status: PaymentStatus.COMPLETED,
           provider: PaymentProvider.STRIPE,
           providerRefId: 'cs_generic_error',
@@ -2267,7 +2372,7 @@ describe('PaymentsService', () => {
 
         // Setup mocks
         mockPrismaService.payment.findUnique.mockResolvedValue(mockPayment);
-        
+
         // Mock generic Stripe error
         mockStripeService.createRefund.mockRejectedValue(
           new Error('An unexpected error occurred while processing the refund')
@@ -2338,7 +2443,7 @@ describe('PaymentsService', () => {
         expect.objectContaining({
           where: { id: 'registration-id' },
           data: { status: 'CONFIRMED', paymentDeferred: false },
-        }),
+        })
       );
     });
 
@@ -2372,11 +2477,9 @@ describe('PaymentsService', () => {
         expect.objectContaining({
           where: { id: 'registration-id' },
           data: { status: 'CONFIRMED', paymentDeferred: false },
-        }),
+        })
       );
-      expect(
-        mockNotificationsService.sendRegistrationConfirmationEmail,
-      ).not.toHaveBeenCalled();
+      expect(mockNotificationsService.sendRegistrationConfirmationEmail).not.toHaveBeenCalled();
     });
 
     it('still clears paymentDeferred on retry when payment is already COMPLETED but registration is still flagged deferred', async () => {
@@ -2408,7 +2511,7 @@ describe('PaymentsService', () => {
         expect.objectContaining({
           where: { id: 'registration-id' },
           data: { status: 'CONFIRMED', paymentDeferred: false },
-        }),
+        })
       );
     });
 
@@ -2466,10 +2569,9 @@ describe('PaymentsService', () => {
         expect.objectContaining({
           where: { id: 'registration-id' },
           data: { status: 'WAITLISTED', paymentDeferred: false },
-        }),
+        })
       );
     });
-
   });
 
   describe('recordExternalPayment', () => {
@@ -2506,12 +2608,13 @@ describe('PaymentsService', () => {
         year: 2026,
         status: RegistrationStatus.CONFIRMED,
       },
+      refunds: [],
     };
 
     beforeEach(() => {
       mockPrismaService.$transaction.mockImplementation(
         async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) =>
-          callback(mockPrismaService),
+          callback(mockPrismaService)
       );
       mockPrismaService.payment.findUnique.mockResolvedValue(null);
       mockPrismaService.registration.findUnique.mockResolvedValue({
@@ -2532,7 +2635,7 @@ describe('PaymentsService', () => {
       try {
         await service.recordExternalPayment(
           { ...inputRequest, amount: Number.MAX_SAFE_INTEGER },
-          'admin-id',
+          'admin-id'
         );
       } catch (error: unknown) {
         actualError = error;
@@ -2543,17 +2646,12 @@ describe('PaymentsService', () => {
         throw actualError;
       }
       expect(actualError.getStatus()).toBe(400);
-      expect(actualError.message).toBe(
-        'Dollar amount exceeds the supported range',
-      );
+      expect(actualError.message).toBe('Dollar amount exceeds the supported range');
       expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
     });
 
     it('should atomically derive the owner, create the payment, update registration, and audit', async () => {
-      const actualPayment = await service.recordExternalPayment(
-        inputRequest,
-        'admin-id',
-      );
+      const actualPayment = await service.recordExternalPayment(inputRequest, 'admin-id');
 
       expect(mockPrismaService.$transaction).toHaveBeenCalledTimes(1);
       expect(mockPrismaService.registration.findUnique).toHaveBeenCalledWith({
@@ -2604,45 +2702,45 @@ describe('PaymentsService', () => {
       expect(actualPayment).not.toHaveProperty('idempotencyKey');
     });
 
-    it.each([
-      RegistrationStatus.WAITLISTED,
-      RegistrationStatus.CONFIRMED,
-    ])('should preserve %s registration status', async (inputStatus) => {
-      mockPrismaService.registration.findUnique.mockResolvedValue({
-        id: inputRequest.registrationId,
-        userId: 'registration-owner-id',
-        status: inputStatus,
-      });
-
-      await service.recordExternalPayment(inputRequest, 'admin-id');
-
-      expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith({
-        where: {
+    it.each([RegistrationStatus.WAITLISTED, RegistrationStatus.CONFIRMED])(
+      'should preserve %s registration status',
+      async inputStatus => {
+        mockPrismaService.registration.findUnique.mockResolvedValue({
           id: inputRequest.registrationId,
+          userId: 'registration-owner-id',
           status: inputStatus,
-        },
-        data: {
-          status: inputStatus,
-          paymentDeferred: false,
-        },
-      });
-    });
+        });
+
+        await service.recordExternalPayment(inputRequest, 'admin-id');
+
+        expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith({
+          where: {
+            id: inputRequest.registrationId,
+            status: inputStatus,
+          },
+          data: {
+            status: inputStatus,
+            paymentDeferred: false,
+          },
+        });
+      }
+    );
 
     it.each([
       RegistrationStatus.APPLICATION_SUBMITTED,
       RegistrationStatus.APPLICATION_APPROVED,
       RegistrationStatus.APPLICATION_DECLINED,
       RegistrationStatus.CANCELLED,
-    ])('should reject ineligible registration status %s', async (inputStatus) => {
+    ])('should reject ineligible registration status %s', async inputStatus => {
       mockPrismaService.registration.findUnique.mockResolvedValue({
         id: inputRequest.registrationId,
         userId: 'registration-owner-id',
         status: inputStatus,
       });
 
-      await expect(
-        service.recordExternalPayment(inputRequest, 'admin-id'),
-      ).rejects.toThrow(BadRequestException);
+      await expect(service.recordExternalPayment(inputRequest, 'admin-id')).rejects.toThrow(
+        BadRequestException
+      );
       expect(mockPrismaService.payment.create).not.toHaveBeenCalled();
       expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
     });
@@ -2650,9 +2748,9 @@ describe('PaymentsService', () => {
     it('should return conflict when registration status changes concurrently', async () => {
       mockPrismaService.registration.updateMany.mockResolvedValue({ count: 0 });
 
-      await expect(
-        service.recordExternalPayment(inputRequest, 'admin-id'),
-      ).rejects.toThrow(ConflictException);
+      await expect(service.recordExternalPayment(inputRequest, 'admin-id')).rejects.toThrow(
+        ConflictException
+      );
       expect(mockPrismaService.payment.create).not.toHaveBeenCalled();
       expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
     });
@@ -2663,10 +2761,7 @@ describe('PaymentsService', () => {
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(mockCreatedPayment);
 
-      const actualPayment = await service.recordExternalPayment(
-        inputRequest,
-        'admin-id',
-      );
+      const actualPayment = await service.recordExternalPayment(inputRequest, 'admin-id');
 
       expect(actualPayment.id).toBe(mockCreatedPayment.id);
       expect(actualPayment).not.toHaveProperty('idempotencyKey');
@@ -2682,10 +2777,7 @@ describe('PaymentsService', () => {
         .mockResolvedValueOnce(mockCreatedPayment);
 
       await expect(
-        service.recordExternalPayment(
-          { ...inputRequest, amount: 126 },
-          'admin-id',
-        ),
+        service.recordExternalPayment({ ...inputRequest, amount: 126 }, 'admin-id')
       ).rejects.toThrow(ConflictException);
       expect(mockPrismaService.payment.create).not.toHaveBeenCalled();
       expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
@@ -2694,30 +2786,25 @@ describe('PaymentsService', () => {
     it('should reject a missing registration', async () => {
       mockPrismaService.registration.findUnique.mockResolvedValue(null);
 
-      await expect(
-        service.recordExternalPayment(inputRequest, 'admin-id'),
-      ).rejects.toThrow(NotFoundException);
+      await expect(service.recordExternalPayment(inputRequest, 'admin-id')).rejects.toThrow(
+        NotFoundException
+      );
       expect(mockPrismaService.payment.create).not.toHaveBeenCalled();
     });
 
     it('should propagate an audit failure from the transaction', async () => {
-      mockPrismaService.adminAudit.create.mockRejectedValue(
-        new Error('Audit write failed'),
-      );
+      mockPrismaService.adminAudit.create.mockRejectedValue(new Error('Audit write failed'));
 
-      await expect(
-        service.recordExternalPayment(inputRequest, 'admin-id'),
-      ).rejects.toThrow('Audit write failed');
+      await expect(service.recordExternalPayment(inputRequest, 'admin-id')).rejects.toThrow(
+        'Audit write failed'
+      );
       expect(mockPrismaService.$transaction).toHaveBeenCalledTimes(1);
     });
 
     it('should return an identical retry without duplicate writes', async () => {
       mockPrismaService.payment.findUnique.mockResolvedValue(mockCreatedPayment);
 
-      const actualPayment = await service.recordExternalPayment(
-        inputRequest,
-        'admin-id',
-      );
+      const actualPayment = await service.recordExternalPayment(inputRequest, 'admin-id');
 
       expect(actualPayment.id).toBe('payment-id');
       expect(actualPayment).not.toHaveProperty('idempotencyKey');
@@ -2730,10 +2817,7 @@ describe('PaymentsService', () => {
       mockPrismaService.payment.findUnique.mockResolvedValue(mockCreatedPayment);
 
       await expect(
-        service.recordExternalPayment(
-          { ...inputRequest, amount: 126 },
-          'admin-id',
-        ),
+        service.recordExternalPayment({ ...inputRequest, amount: 126 }, 'admin-id')
       ).rejects.toThrow(ConflictException);
       expect(mockPrismaService.payment.create).not.toHaveBeenCalled();
     });
@@ -2745,10 +2829,7 @@ describe('PaymentsService', () => {
       });
       mockPrismaService.payment.findUnique.mockResolvedValue(mockCreatedPayment);
 
-      const actualPayment = await service.recordExternalPayment(
-        inputRequest,
-        'admin-id',
-      );
+      const actualPayment = await service.recordExternalPayment(inputRequest, 'admin-id');
 
       expect(actualPayment.id).toBe('payment-id');
       expect(actualPayment).not.toHaveProperty('idempotencyKey');
@@ -2764,9 +2845,461 @@ describe('PaymentsService', () => {
       await expect(
         service.recordExternalPayment(
           { ...inputRequest, externalReference: 'different' },
-          'admin-id',
-        ),
+          'admin-id'
+        )
       ).rejects.toThrow(ConflictException);
     });
+  });
+
+  describe('createManualRefund', () => {
+    const paymentId = '5f8d0d55-e0a3-4cf0-a620-2412acd4361c';
+    const idempotencyKey = '43ea4b84-1f0d-413d-bc1c-9c91b435d66d';
+    const inputRequest = {
+      amountCents: 2500,
+      executionMode: RefundExecutionMode.MANUAL,
+      reason: 'duplicate charge',
+      externalReference: 'refund-123',
+      idempotencyKey,
+    };
+    const createdRefund = {
+      id: 'refund-id',
+      paymentId,
+      amountCents: 2500,
+      currency: 'USD',
+      executionMode: RefundExecutionMode.MANUAL,
+      status: PaymentRefundStatus.SUCCEEDED,
+      reason: 'duplicate charge',
+      externalReference: 'refund-123',
+      idempotencyKey,
+      resultingRegistrationStatus: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const publicCreatedRefund = {
+      id: createdRefund.id,
+      amountCents: createdRefund.amountCents,
+      currency: createdRefund.currency,
+      executionMode: createdRefund.executionMode,
+      status: createdRefund.status,
+      reason: createdRefund.reason,
+      externalReference: createdRefund.externalReference,
+      resultingRegistrationStatus: createdRefund.resultingRegistrationStatus,
+      createdAt: createdRefund.createdAt,
+      updatedAt: createdRefund.updatedAt,
+    };
+    type MockAdminRefund = Omit<
+      typeof publicCreatedRefund,
+      'status' | 'resultingRegistrationStatus'
+    > & {
+      status: PaymentRefundStatus;
+      resultingRegistrationStatus: RegistrationStatus | null;
+    };
+    const basePayment = {
+      id: paymentId,
+      amount: 100,
+      currency: 'USD',
+      status: PaymentStatus.COMPLETED,
+      provider: PaymentProvider.MANUAL,
+      externalMethod: ExternalPaymentMethod.CHECK,
+      externalReference: 'check-123',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      userId: 'user-id',
+      registrationId: 'registration-id',
+      user: {
+        id: 'user-id',
+        firstName: 'Test',
+        lastName: 'User',
+        email: 'test@example.com',
+      },
+      registration: {
+        id: 'registration-id',
+        year: 2026,
+        status: RegistrationStatus.CONFIRMED,
+      },
+      refunds: [],
+    };
+
+    function buildUpdatedPayment(
+      status: PaymentStatus,
+      refunds: MockAdminRefund[] = [publicCreatedRefund],
+      registrationStatus: RegistrationStatus = RegistrationStatus.CONFIRMED
+    ) {
+      return {
+        ...basePayment,
+        status,
+        registration: {
+          ...basePayment.registration,
+          status: registrationStatus,
+        },
+        refunds,
+      };
+    }
+
+    beforeEach(() => {
+      mockPrismaService.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) =>
+          callback(mockPrismaService)
+      );
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(null);
+      mockPrismaService.paymentRefund.create.mockResolvedValue(createdRefund);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(basePayment)
+        .mockResolvedValueOnce(buildUpdatedPayment(PaymentStatus.PARTIALLY_REFUNDED));
+      mockPrismaService.payment.update.mockResolvedValue({
+        ...basePayment,
+        status: PaymentStatus.PARTIALLY_REFUNDED,
+      });
+      mockPrismaService.registration.update.mockResolvedValue(basePayment.registration);
+      mockPrismaService.adminAudit.create.mockResolvedValue({ id: 'audit-id' });
+      mockPrismaService.adminAudit.findFirst.mockResolvedValue({
+        newValues: { requestedFullRefund: false },
+      });
+    });
+
+    it('should create a succeeded partial refund with serializable isolation and atomic audit', async () => {
+      const actualResult = await service.createManualRefund(paymentId, inputRequest, 'admin-id');
+
+      expect(mockPrismaService.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      });
+      expect(mockPrismaService.payment.findUnique).toHaveBeenNthCalledWith(1, {
+        where: { id: paymentId },
+        select: expectedAdminPaymentSelect,
+      });
+      expect(mockPrismaService.paymentRefund.create).toHaveBeenCalledWith({
+        data: {
+          paymentId,
+          amountCents: 2500,
+          currency: 'USD',
+          executionMode: RefundExecutionMode.MANUAL,
+          status: PaymentRefundStatus.SUCCEEDED,
+          reason: 'duplicate charge',
+          externalReference: 'refund-123',
+          idempotencyKey,
+          processedByUserId: 'admin-id',
+          resultingRegistrationStatus: null,
+        },
+        select: expect.objectContaining({
+          id: true,
+          paymentId: true,
+          idempotencyKey: true,
+        }),
+      });
+      expect(mockPrismaService.payment.update).toHaveBeenCalledWith({
+        where: { id: paymentId },
+        data: { status: PaymentStatus.PARTIALLY_REFUNDED },
+      });
+      expect(mockPrismaService.adminAudit.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          adminUserId: 'admin-id',
+          actionType: AdminAuditActionType.PAYMENT_REFUND,
+          targetRecordType: AdminAuditTargetType.PAYMENT,
+          targetRecordId: paymentId,
+          transactionId: idempotencyKey,
+          newValues: expect.objectContaining({
+            refundId: 'refund-id',
+            registrationId: 'registration-id',
+            amountCents: 2500,
+            currency: 'USD',
+            executionMode: RefundExecutionMode.MANUAL,
+            requestedFullRefund: false,
+          }),
+        }),
+      });
+      expect(actualResult).toEqual(
+        expect.objectContaining({
+          refund: publicCreatedRefund,
+          paymentAmountCents: 10000,
+          successfulRefundCents: 2500,
+          pendingRefundCents: 0,
+          availableRefundCents: 7500,
+        })
+      );
+    });
+
+    it('should sum succeeded rows, reserve pending rows, and ignore failed rows', async () => {
+      const existingRefunds = [
+        {
+          ...publicCreatedRefund,
+          id: 'existing-success',
+          amountCents: 2000,
+        },
+        {
+          ...publicCreatedRefund,
+          id: 'existing-pending',
+          amountCents: 1000,
+          status: PaymentRefundStatus.PENDING,
+        },
+        {
+          ...publicCreatedRefund,
+          id: 'existing-failed',
+          amountCents: 5000,
+          status: PaymentRefundStatus.FAILED,
+        },
+      ];
+      const paymentWithRefunds = {
+        ...basePayment,
+        status: PaymentStatus.PARTIALLY_REFUNDED,
+        refunds: existingRefunds,
+      };
+      mockPrismaService.payment.findUnique
+        .mockReset()
+        .mockResolvedValueOnce(paymentWithRefunds)
+        .mockResolvedValueOnce(
+          buildUpdatedPayment(PaymentStatus.PARTIALLY_REFUNDED, [
+            ...existingRefunds,
+            publicCreatedRefund,
+          ])
+        );
+
+      const actualResult = await service.createManualRefund(paymentId, inputRequest, 'admin-id');
+
+      expect(actualResult.successfulRefundCents).toBe(4500);
+      expect(actualResult.pendingRefundCents).toBe(1000);
+      expect(actualResult.availableRefundCents).toBe(4500);
+    });
+
+    it('should allow multiple refunds to reach exactly full', async () => {
+      const existingRefund = {
+        ...publicCreatedRefund,
+        id: 'existing-refund',
+        amountCents: 7500,
+      };
+      const paymentWithRefund = {
+        ...basePayment,
+        status: PaymentStatus.PARTIALLY_REFUNDED,
+        refunds: [existingRefund],
+      };
+      mockPrismaService.payment.findUnique
+        .mockReset()
+        .mockResolvedValueOnce(paymentWithRefund)
+        .mockResolvedValueOnce(
+          buildUpdatedPayment(PaymentStatus.REFUNDED, [existingRefund, publicCreatedRefund])
+        );
+
+      const actualResult = await service.createManualRefund(paymentId, inputRequest, 'admin-id');
+
+      expect(mockPrismaService.payment.update).toHaveBeenCalledWith({
+        where: { id: paymentId },
+        data: { status: PaymentStatus.REFUNDED },
+      });
+      expect(actualResult.payment.status).toBe(PaymentStatus.REFUNDED);
+      expect(actualResult.successfulRefundCents).toBe(10000);
+      expect(actualResult.availableRefundCents).toBe(0);
+    });
+
+    it('should use the exact available balance for a full refund and apply an allowed registration status', async () => {
+      const fullRefund = {
+        ...createdRefund,
+        amountCents: 8000,
+        resultingRegistrationStatus: RegistrationStatus.WAITLISTED,
+      };
+      const publicFullRefund = {
+        ...publicCreatedRefund,
+        amountCents: 8000,
+        resultingRegistrationStatus: RegistrationStatus.WAITLISTED,
+      };
+      const existingRefund = {
+        ...publicCreatedRefund,
+        id: 'existing-refund',
+        amountCents: 2000,
+      };
+      mockPrismaService.paymentRefund.create.mockResolvedValue(fullRefund);
+      mockPrismaService.payment.findUnique
+        .mockReset()
+        .mockResolvedValueOnce({
+          ...basePayment,
+          status: PaymentStatus.PARTIALLY_REFUNDED,
+          refunds: [existingRefund],
+        })
+        .mockResolvedValueOnce(
+          buildUpdatedPayment(
+            PaymentStatus.REFUNDED,
+            [existingRefund, publicFullRefund],
+            RegistrationStatus.WAITLISTED
+          )
+        );
+
+      const actualResult = await service.createManualRefund(
+        paymentId,
+        {
+          fullRefund: true,
+          executionMode: RefundExecutionMode.MANUAL,
+          resultingRegistrationStatus: RegistrationStatus.WAITLISTED,
+          idempotencyKey,
+        },
+        'admin-id'
+      );
+
+      expect(mockPrismaService.paymentRefund.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ amountCents: 8000 }),
+        })
+      );
+      expect(mockPrismaService.registration.update).toHaveBeenCalledWith({
+        where: { id: 'registration-id' },
+        data: { status: RegistrationStatus.WAITLISTED },
+      });
+      expect(actualResult.payment.registration?.status).toBe(RegistrationStatus.WAITLISTED);
+      expect(actualResult.availableRefundCents).toBe(0);
+    });
+
+    it('should reject an over-refund without ledger, payment, registration, or audit writes', async () => {
+      await expect(
+        service.createManualRefund(paymentId, { ...inputRequest, amountCents: 10001 }, 'admin-id')
+      ).rejects.toThrow('exceeds available balance of 10000 cents');
+
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+    });
+
+    it('should allow a payment without registration but reject a requested registration status', async () => {
+      const unlinkedPayment = {
+        ...basePayment,
+        registrationId: null,
+        registration: null,
+      };
+      mockPrismaService.payment.findUnique
+        .mockReset()
+        .mockResolvedValueOnce(unlinkedPayment)
+        .mockResolvedValueOnce({
+          ...buildUpdatedPayment(PaymentStatus.PARTIALLY_REFUNDED),
+          registrationId: null,
+          registration: null,
+        });
+
+      await expect(
+        service.createManualRefund(paymentId, inputRequest, 'admin-id')
+      ).resolves.toEqual(expect.objectContaining({ successfulRefundCents: 2500 }));
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+
+      jest.clearAllMocks();
+      mockPrismaService.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) =>
+          callback(mockPrismaService)
+      );
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(null);
+      mockPrismaService.payment.findUnique.mockResolvedValue(unlinkedPayment);
+
+      await expect(
+        service.createManualRefund(
+          paymentId,
+          {
+            ...inputRequest,
+            resultingRegistrationStatus: RegistrationStatus.PENDING,
+          },
+          'admin-id'
+        )
+      ).rejects.toThrow('payment without a registration');
+    });
+
+    it.each([
+      RegistrationStatus.CANCELLED,
+      RegistrationStatus.APPLICATION_SUBMITTED,
+      RegistrationStatus.APPLICATION_APPROVED,
+      RegistrationStatus.APPLICATION_DECLINED,
+    ])('should reject resulting status %s with cancellation guidance', async inputStatus => {
+      await expect(
+        service.createManualRefund(
+          paymentId,
+          {
+            ...inputRequest,
+            resultingRegistrationStatus: inputStatus,
+          },
+          'admin-id'
+        )
+      ).rejects.toThrow('use the cancellation workflow');
+      expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('should return an identical replay without duplicate writes', async () => {
+      const replayPayment = buildUpdatedPayment(PaymentStatus.PARTIALLY_REFUNDED);
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(createdRefund);
+      mockPrismaService.payment.findUnique.mockReset().mockResolvedValue(replayPayment);
+
+      const actualResult = await service.createManualRefund(paymentId, inputRequest, 'admin-id');
+
+      expect(actualResult.refund).toEqual(publicCreatedRefund);
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject idempotency key reuse with different amount or full-refund semantics', async () => {
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(createdRefund);
+      mockPrismaService.payment.findUnique
+        .mockReset()
+        .mockResolvedValue(buildUpdatedPayment(PaymentStatus.PARTIALLY_REFUNDED));
+
+      await expect(
+        service.createManualRefund(paymentId, { ...inputRequest, amountCents: 2000 }, 'admin-id')
+      ).rejects.toThrow(ConflictException);
+
+      mockPrismaService.adminAudit.findFirst.mockResolvedValue({
+        newValues: { requestedFullRefund: false },
+      });
+      await expect(
+        service.createManualRefund(
+          paymentId,
+          {
+            fullRefund: true,
+            executionMode: RefundExecutionMode.MANUAL,
+            idempotencyKey,
+          },
+          'admin-id'
+        )
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should resolve an identical concurrent unique-key race', async () => {
+      mockPrismaService.$transaction.mockRejectedValue({ code: 'P2002' });
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(createdRefund);
+      mockPrismaService.payment.findUnique
+        .mockReset()
+        .mockResolvedValue(buildUpdatedPayment(PaymentStatus.PARTIALLY_REFUNDED));
+
+      const actualResult = await service.createManualRefund(paymentId, inputRequest, 'admin-id');
+
+      expect(actualResult.refund.id).toBe('refund-id');
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+    });
+
+    it('should translate a serialization conflict to refresh-and-retry conflict', async () => {
+      mockPrismaService.$transaction.mockRejectedValue({ code: 'P2034' });
+
+      await expect(service.createManualRefund(paymentId, inputRequest, 'admin-id')).rejects.toThrow(
+        'Refund balance changed concurrently; refresh the payment and retry'
+      );
+      expect(mockPrismaService.paymentRefund.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should propagate audit failure so the serializable transaction rolls back', async () => {
+      mockPrismaService.adminAudit.create.mockRejectedValue(new Error('Audit write failed'));
+
+      await expect(service.createManualRefund(paymentId, inputRequest, 'admin-id')).rejects.toThrow(
+        'Audit write failed'
+      );
+      expect(mockPrismaService.paymentRefund.create).toHaveBeenCalled();
+      expect(mockPrismaService.payment.update).toHaveBeenCalled();
+      expect(mockPrismaService.payment.findUnique).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([PaymentStatus.PENDING, PaymentStatus.FAILED, PaymentStatus.REFUNDED])(
+      'should reject payment status %s',
+      async inputStatus => {
+        mockPrismaService.payment.findUnique
+          .mockReset()
+          .mockResolvedValue({ ...basePayment, status: inputStatus });
+
+        await expect(
+          service.createManualRefund(paymentId, inputRequest, 'admin-id')
+        ).rejects.toThrow(`Cannot refund payment with status ${inputStatus}`);
+        expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      }
+    );
   });
 });

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -481,6 +481,49 @@ describe('PaymentsService', () => {
         });
       });
 
+      it('should keep a malformed stored currency visible but unavailable for refunds', async () => {
+        const mockPayment = {
+          id: 'legacy-currency-payment',
+          amount: 10,
+          currency: 'usd',
+          status: PaymentStatus.COMPLETED,
+          provider: PaymentProvider.PAYPAL,
+          externalMethod: null,
+          externalReference: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 'user-id',
+          registrationId: null,
+          user: {
+            id: 'user-id',
+            firstName: 'Legacy',
+            lastName: 'Currency',
+            email: 'legacy@example.com',
+          },
+          registration: null,
+          refunds: [],
+        };
+        mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
+        mockPrismaService.payment.count.mockResolvedValue(1);
+
+        const actualResult = await service.findAllForAdmin();
+
+        expect(actualResult).toEqual({
+          payments: [
+            {
+              ...mockPayment,
+              paymentAmountCents: 1000,
+              successfulRefundCents: 0,
+              pendingRefundCents: 0,
+              availableRefundCents: 0,
+              refundUnavailableReason:
+                'Refund unavailable because the stored payment currency is invalid.',
+            },
+          ],
+          total: 1,
+        });
+      });
+
       it('should report legacy ledgerless refunded payments as fully refunded', async () => {
         const mockPayment = {
           id: 'legacy-refunded-payment',
@@ -3208,6 +3251,21 @@ describe('PaymentsService', () => {
       await expect(
         service.createManualRefund(paymentId, inputRequest, 'admin-id')
       ).rejects.toThrow('Dollar amount must not have sub-cent precision');
+
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject manual refunds for an invalid stored currency before writes', async () => {
+      mockPrismaService.payment.findUnique
+        .mockReset()
+        .mockResolvedValue({ ...basePayment, currency: 'usd' });
+
+      await expect(
+        service.createManualRefund(paymentId, inputRequest, 'admin-id')
+      ).rejects.toThrow('Refund unavailable because the stored payment currency is invalid.');
 
       expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
       expect(mockPrismaService.payment.update).not.toHaveBeenCalled();

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -3577,6 +3577,10 @@ describe('PaymentsService', () => {
       mockPrismaService.paymentRefund.updateMany.mockResolvedValue({ count: 1 });
       mockPrismaService.payment.findUnique.mockResolvedValue(stripePayment);
       mockPrismaService.payment.update.mockResolvedValue(stripePayment);
+      mockPrismaService.registration.findUnique.mockResolvedValue({
+        status: RegistrationStatus.CONFIRMED,
+      });
+      mockPrismaService.registration.updateMany.mockResolvedValue({ count: 1 });
       mockPrismaService.adminAudit.create.mockResolvedValue({ id: 'audit-id' });
       mockPrismaService.adminAudit.findFirst.mockResolvedValue({
         newValues: { requestedFullRefund: false },
@@ -3703,8 +3707,15 @@ describe('PaymentsService', () => {
         where: { id: paymentId },
         data: { status: PaymentStatus.PARTIALLY_REFUNDED },
       });
-      expect(mockPrismaService.registration.update).toHaveBeenCalledWith({
+      expect(mockPrismaService.registration.findUnique).toHaveBeenCalledWith({
         where: { id: 'registration-id' },
+        select: { status: true },
+      });
+      expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'registration-id',
+          status: RegistrationStatus.CONFIRMED,
+        },
         data: { status: requestedStatus },
       });
       expect(mockPrismaService.adminAudit.create).toHaveBeenLastCalledWith({
@@ -3718,6 +3729,117 @@ describe('PaymentsService', () => {
       });
       expect(actualResult.outcome).toBe('SUCCEEDED');
       expect(actualResult.refund).not.toHaveProperty('providerRefundId');
+    });
+
+    it.each([
+      RegistrationStatus.CANCELLED,
+      RegistrationStatus.APPLICATION_SUBMITTED,
+    ])(
+      'should preserve concurrent protected registration status %s while finalizing the refund',
+      async protectedStatus => {
+        const requestedStatus = RegistrationStatus.WAITLISTED;
+        const pendingWithStatus = {
+          ...pendingRefund,
+          resultingRegistrationStatus: requestedStatus,
+        };
+        const succeededRefund = {
+          ...pendingWithStatus,
+          status: PaymentRefundStatus.SUCCEEDED,
+          providerRefundId: 're_provider',
+        };
+        mockPrismaService.paymentRefund.create.mockResolvedValue(pendingWithStatus);
+        mockPrismaService.paymentRefund.findUnique
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(pendingWithStatus)
+          .mockResolvedValueOnce(succeededRefund);
+        mockPrismaService.payment.findUnique
+          .mockResolvedValueOnce(stripePayment)
+          .mockResolvedValueOnce({
+            ...stripePayment,
+            refunds: [{ ...publicPendingRefund, resultingRegistrationStatus: requestedStatus }],
+          })
+          .mockResolvedValueOnce({
+            ...buildStripePayment(
+              PaymentStatus.PARTIALLY_REFUNDED,
+              PaymentRefundStatus.SUCCEEDED
+            ),
+            registration: { ...stripePayment.registration, status: protectedStatus },
+          });
+        mockStripeService.createAdminRefund.mockResolvedValue({
+          outcome: 'SUCCEEDED',
+          providerRefundId: 're_provider',
+        });
+        mockPrismaService.registration.findUnique.mockResolvedValue({
+          status: protectedStatus,
+        });
+
+        const actualResult = await service.createRefund(
+          paymentId,
+          {
+            ...stripeRequest,
+            resultingRegistrationStatus: requestedStatus,
+          },
+          'admin-id'
+        );
+
+        expect(actualResult.outcome).toBe('SUCCEEDED');
+        expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+        expect(mockPrismaService.adminAudit.create).toHaveBeenLastCalledWith({
+          data: expect.objectContaining({
+            newValues: expect.objectContaining({
+              outcome: PaymentRefundStatus.SUCCEEDED,
+              resultingRegistrationStatus: requestedStatus,
+              registrationStatusBefore: protectedStatus,
+              registrationStatusAfter: protectedStatus,
+              registrationStatusApplied: false,
+              registrationStatusSkipReason: 'CONCURRENT_PROTECTED_STATE',
+            }),
+          }),
+        });
+      }
+    );
+
+    it('should keep successful Stripe finalization recoverable after an ordinary registration race', async () => {
+      const requestedStatus = RegistrationStatus.WAITLISTED;
+      const pendingWithStatus = {
+        ...pendingRefund,
+        resultingRegistrationStatus: requestedStatus,
+      };
+      mockPrismaService.paymentRefund.create.mockResolvedValue(pendingWithStatus);
+      mockPrismaService.paymentRefund.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(pendingWithStatus);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(stripePayment)
+        .mockResolvedValueOnce({
+          ...stripePayment,
+          refunds: [{ ...publicPendingRefund, resultingRegistrationStatus: requestedStatus }],
+        });
+      mockStripeService.createAdminRefund.mockResolvedValue({
+        outcome: 'SUCCEEDED',
+        providerRefundId: 're_provider',
+      });
+      mockPrismaService.registration.updateMany.mockResolvedValue({ count: 0 });
+
+      const actualResult = await service.createRefund(
+        paymentId,
+        {
+          ...stripeRequest,
+          resultingRegistrationStatus: requestedStatus,
+        },
+        'admin-id'
+      );
+
+      expect(actualResult.outcome).toBe('PENDING_UNKNOWN');
+      expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'registration-id',
+          status: RegistrationStatus.CONFIRMED,
+        },
+        data: { status: requestedStatus },
+      });
+      expect(mockStripeService.createAdminRefund).toHaveBeenCalledTimes(1);
+      expect(mockPrismaService.adminAudit.create).toHaveBeenCalledTimes(1);
     });
 
     it('should fail a definite rejection, release the reservation, and preserve payment state', async () => {
@@ -3906,6 +4028,27 @@ describe('PaymentsService', () => {
         localRefundId: refundId,
       });
       expect(actualResult.outcome).toBe('PENDING_UNKNOWN');
+    });
+
+    it('should not resubmit when Stripe inspection cannot complete', async () => {
+      const paymentWithPending = buildStripePayment(
+        PaymentStatus.COMPLETED,
+        PaymentRefundStatus.PENDING
+      );
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(pendingRefund);
+      mockPrismaService.payment.findUnique.mockResolvedValue(paymentWithPending);
+      mockStripeService.findAdminRefund.mockResolvedValue({
+        outcome: 'PENDING_UNKNOWN',
+      });
+
+      const actualResult = await service.retryStripeRefund(
+        paymentId,
+        refundId,
+        'retry-admin'
+      );
+
+      expect(actualResult.outcome).toBe('PENDING_UNKNOWN');
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
     });
 
     it('should fail the reservation when inspection finds a terminal Stripe failure', async () => {

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -4230,7 +4230,14 @@ describe('PaymentsService', () => {
       mockPrismaService.registration.updateMany.mockResolvedValue({ count: 1 });
       mockPrismaService.adminAudit.create.mockResolvedValue({ id: 'audit-id' });
       mockPrismaService.adminAudit.findFirst.mockResolvedValue({
-        newValues: { requestedFullRefund: false },
+        newValues: {
+          phase: 'ATTEMPT',
+          paymentId,
+          refundId,
+          executionMode: RefundExecutionMode.STRIPE,
+          requestedFullRefund: false,
+          providerRefId: 'pi_original',
+        },
       });
       mockStripeService.createAdminRefund.mockResolvedValue({
         outcome: 'PENDING_UNKNOWN',
@@ -4279,13 +4286,13 @@ describe('PaymentsService', () => {
             phase: 'ATTEMPT',
             outcome: PaymentRefundStatus.PENDING,
             refundId,
+            providerRefId: 'pi_original',
           }),
         }),
       });
       expect(mockStripeService.createAdminRefund).toHaveBeenCalledWith({
         providerRefId: 'pi_original',
         amountCents: 2500,
-        reason: 'duplicate charge',
         idempotencyKey,
         localRefundId: refundId,
       });
@@ -4297,6 +4304,63 @@ describe('PaymentsService', () => {
         })
       );
       expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [undefined, null],
+      ['   ', null],
+      ['Customer requested a refund', 'Customer requested a refund'],
+      ['duplicate charge', 'duplicate charge'],
+      ['fraud detected', 'fraud detected'],
+      ['fraud ruled out', 'fraud ruled out'],
+      ['not fraudulent after review', 'not fraudulent after review'],
+    ])(
+      'should preserve local note %p without sending a structured Stripe reason',
+      async (inputReason, expectedReason) => {
+        await service.createRefund(
+          paymentId,
+          {
+            ...stripeRequest,
+            reason: inputReason,
+          },
+          'admin-id'
+        );
+
+        expect(mockPrismaService.paymentRefund.create).toHaveBeenCalledWith({
+          data: expect.objectContaining({ reason: expectedReason }),
+          select: expect.any(Object),
+        });
+        expect(mockPrismaService.adminAudit.create).toHaveBeenCalledWith({
+          data: expect.objectContaining({
+            reason: expectedReason,
+            newValues: expect.objectContaining({ reason: expectedReason }),
+          }),
+        });
+        expect(mockStripeService.createAdminRefund).toHaveBeenCalledWith({
+          providerRefId: 'pi_original',
+          amountCents: 2500,
+          idempotencyKey,
+          localRefundId: refundId,
+        });
+      }
+    );
+
+    it('should snapshot and submit the trimmed original Stripe target', async () => {
+      mockPrismaService.payment.findUnique.mockResolvedValue({
+        ...stripePayment,
+        providerRefId: '  pi_original  ',
+      });
+
+      await service.createRefund(paymentId, stripeRequest, 'admin-id');
+
+      expect(mockPrismaService.adminAudit.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          newValues: expect.objectContaining({ providerRefId: 'pi_original' }),
+        }),
+      });
+      expect(mockStripeService.createAdminRefund).toHaveBeenCalledWith(
+        expect.objectContaining({ providerRefId: 'pi_original' })
+      );
     });
 
     it('should finalize the same row and apply registration status only after Stripe succeeds', async () => {
@@ -4753,11 +4817,114 @@ describe('PaymentsService', () => {
       expect(mockStripeService.createAdminRefund).toHaveBeenCalledWith({
         providerRefId: 'pi_original',
         amountCents: 2500,
-        reason: 'duplicate charge',
         idempotencyKey,
         localRefundId: refundId,
       });
       expect(actualResult.outcome).toBe('PENDING_UNKNOWN');
+    });
+
+    it('should use the immutable attempt target after the payment reference changes', async () => {
+      const paymentWithChangedTarget = {
+        ...buildStripePayment(PaymentStatus.COMPLETED, PaymentRefundStatus.PENDING),
+        providerRefId: 'pi_mutated',
+      };
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(pendingRefund);
+      mockPrismaService.payment.findUnique.mockResolvedValue(paymentWithChangedTarget);
+      mockStripeService.findAdminRefund.mockResolvedValue({ outcome: 'NOT_FOUND' });
+      mockStripeService.createAdminRefund.mockResolvedValue({
+        outcome: 'PENDING_UNKNOWN',
+      });
+
+      await service.retryStripeRefund(paymentId, refundId, 'retry-admin');
+
+      expect(mockStripeService.findAdminRefund).toHaveBeenCalledWith('pi_original', refundId);
+      expect(mockStripeService.createAdminRefund).toHaveBeenCalledWith({
+        providerRefId: 'pi_original',
+        amountCents: 2500,
+        idempotencyKey,
+        localRefundId: refundId,
+      });
+    });
+
+    it.each([
+      ['missing audit', null],
+      ['missing target', { newValues: { requestedFullRefund: false } }],
+      [
+        'non-string target',
+        {
+          newValues: {
+            phase: 'ATTEMPT',
+            paymentId,
+            refundId,
+            executionMode: RefundExecutionMode.STRIPE,
+            providerRefId: 42,
+          },
+        },
+      ],
+      [
+        'blank target',
+        {
+          newValues: {
+            phase: 'ATTEMPT',
+            paymentId,
+            refundId,
+            executionMode: RefundExecutionMode.STRIPE,
+            providerRefId: ' ',
+          },
+        },
+      ],
+      [
+        'mismatched payment',
+        {
+          newValues: {
+            phase: 'ATTEMPT',
+            paymentId: 'different-payment',
+            refundId,
+            executionMode: RefundExecutionMode.STRIPE,
+            providerRefId: 'pi_original',
+          },
+        },
+      ],
+      [
+        'mismatched refund',
+        {
+          newValues: {
+            phase: 'ATTEMPT',
+            paymentId,
+            refundId: 'different-refund',
+            executionMode: RefundExecutionMode.STRIPE,
+            providerRefId: 'pi_original',
+          },
+        },
+      ],
+      [
+        'non-Stripe attempt',
+        {
+          newValues: {
+            phase: 'ATTEMPT',
+            paymentId,
+            refundId,
+            executionMode: RefundExecutionMode.MANUAL,
+            providerRefId: 'pi_original',
+          },
+        },
+      ],
+    ])('should reject a %s snapshot without calling Stripe', async (_caseName, inputAudit) => {
+      const paymentWithChangedTarget = {
+        ...buildStripePayment(PaymentStatus.COMPLETED, PaymentRefundStatus.PENDING),
+        providerRefId: 'pi_mutated',
+      };
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(pendingRefund);
+      mockPrismaService.payment.findUnique.mockResolvedValue(paymentWithChangedTarget);
+      mockPrismaService.adminAudit.findFirst.mockResolvedValue(inputAudit);
+
+      await expect(
+        service.retryStripeRefund(paymentId, refundId, 'retry-admin')
+      ).rejects.toThrow(ConflictException);
+
+      expect(mockStripeService.findAdminRefund).not.toHaveBeenCalled();
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
+      expect(mockPrismaService.paymentRefund.updateMany).not.toHaveBeenCalled();
     });
 
     it('should not resubmit when Stripe inspection cannot complete', async () => {

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -28,6 +28,7 @@ const mockPrismaService = {
     findUnique: jest.fn(),
     findFirst: jest.fn(),
     update: jest.fn(),
+    updateMany: jest.fn(),
     count: jest.fn(),
   },
   paymentRefund: {
@@ -47,41 +48,7 @@ const mockPrismaService = {
     create: jest.fn(),
     findFirst: jest.fn(),
   },
-  $transaction: jest.fn(operations => {
-    if (Array.isArray(operations)) {
-      const results = operations.map(op => {
-        if (op && op.where && op.data) {
-          // This is a mock update operation
-          if (op.where.id === 'payment-id') {
-            return {
-              id: 'payment-id',
-              status: op.data.status,
-              // Include other needed fields
-              amount: 100,
-              provider: PaymentProvider.STRIPE,
-              providerRefId: 'cs_test_session_id',
-              userId: 'user-id',
-              registrationId: 'registration-id',
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            };
-          } else if (op.where.id === 'registration-id') {
-            return {
-              id: 'registration-id',
-              status: op.data.status,
-              userId: 'user-id',
-              year: 2024,
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            };
-          }
-        }
-        return { id: 'mocked-id' };
-      });
-      return Promise.resolve(results);
-    }
-    return Promise.resolve(typeof operations === 'function' ? operations() : operations);
-  }),
+  $transaction: jest.fn(),
 };
 
 const mockStripeService = {
@@ -197,6 +164,12 @@ describe('PaymentsService', () => {
 
     // Reset all mocks before each test
     jest.clearAllMocks();
+    mockPrismaService.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) =>
+        callback(mockPrismaService)
+    );
+    mockPrismaService.payment.updateMany.mockResolvedValue({ count: 1 });
+    mockPrismaService.registration.updateMany.mockResolvedValue({ count: 1 });
   });
 
   it('should be defined', () => {
@@ -1077,6 +1050,7 @@ describe('PaymentsService', () => {
       id: 'registration-id',
       userId: 'user-id',
       status: 'PENDING',
+      paymentDeferred: false,
       year: 2024,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -1085,6 +1059,12 @@ describe('PaymentsService', () => {
     beforeEach(() => {
       // Reset mocks before each test
       jest.clearAllMocks();
+      mockPrismaService.payment.updateMany.mockResolvedValue({ count: 1 });
+      mockPrismaService.registration.updateMany.mockResolvedValue({ count: 1 });
+      mockPrismaService.payment.findUnique.mockResolvedValue({
+        ...mockPayment,
+        registration: mockRegistration,
+      });
     });
 
     it('should verify successful payment and update statuses using transaction', async () => {
@@ -1101,24 +1081,10 @@ describe('PaymentsService', () => {
         payment_status: 'paid',
       };
 
-      // Mock updated entities
-      const updatedPayment = {
-        ...mockPayment,
-        status: PaymentStatus.COMPLETED,
-      };
-
-      const updatedRegistration = {
-        ...mockRegistration,
-        status: 'CONFIRMED',
-      };
-
       // Setup mocks
       mockPrismaService.payment.findFirst.mockResolvedValue(paymentWithRegistration);
       mockPrismaService.payment.findUnique.mockResolvedValue(paymentWithRegistration);
       mockStripeService.getCheckoutSession.mockResolvedValue(mockStripeSession);
-
-      // Mock transaction result
-      mockPrismaService.$transaction.mockResolvedValue([updatedPayment, updatedRegistration]);
 
       // Execute
       const result = await service.verifyStripeSession(sessionId);
@@ -1179,14 +1145,12 @@ describe('PaymentsService', () => {
         include: { registration: true },
       });
       expect(mockStripeService.getCheckoutSession).toHaveBeenCalledWith(sessionId);
-      expect(mockPrismaService.payment.update).toHaveBeenCalledWith({
-        where: { id: mockPayment.id },
+      expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
+        where: { id: mockPayment.id, status: PaymentStatus.PENDING },
         data: { status: PaymentStatus.COMPLETED },
       });
 
-      // No transaction should be used when there's no registration
-      expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
-      // Transaction already tested
+      expect(mockPrismaService.$transaction).toHaveBeenCalled();
 
       expect(result).toEqual({
         sessionId,
@@ -1214,6 +1178,7 @@ describe('PaymentsService', () => {
 
       // Setup mocks
       mockPrismaService.payment.findFirst.mockResolvedValue(completedPayment);
+      mockPrismaService.payment.findUnique.mockResolvedValue(completedPayment);
       mockStripeService.getCheckoutSession.mockResolvedValue(mockStripeSession);
 
       // Execute
@@ -1374,7 +1339,7 @@ describe('PaymentsService', () => {
       expect(mockStripeService.getCheckoutSession).toHaveBeenCalledWith(sessionId);
     });
 
-    it('should handle database transaction errors by falling back to payment update', async () => {
+    it('should surface database transaction errors without an unguarded payment fallback', async () => {
       // Mock payment with registration
       const paymentWithRegistration = {
         ...mockPayment,
@@ -1394,15 +1359,9 @@ describe('PaymentsService', () => {
       mockStripeService.getCheckoutSession.mockResolvedValue(mockStripeSession);
       mockPrismaService.$transaction.mockRejectedValue(new Error('Database transaction error'));
 
-      // Mock the direct payment update (fallback)
-      mockPrismaService.payment.update.mockResolvedValue({
-        ...mockPayment,
-        status: PaymentStatus.COMPLETED,
-        notes: 'Payment completed but registration update failed: Database transaction error',
-      });
-
-      // Execute
-      const result = await service.verifyStripeSession(sessionId);
+      await expect(service.verifyStripeSession(sessionId)).rejects.toThrow(
+        'Failed to verify Stripe session'
+      );
 
       expect(mockPrismaService.payment.findFirst).toHaveBeenCalledWith({
         where: { providerRefId: sessionId },
@@ -1411,19 +1370,8 @@ describe('PaymentsService', () => {
       expect(mockStripeService.getCheckoutSession).toHaveBeenCalledWith(sessionId);
       expect(mockPrismaService.$transaction).toHaveBeenCalled();
 
-      // Should fall back to direct payment update when transaction fails
-      expect(mockPrismaService.payment.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: mockPayment.id },
-          data: expect.objectContaining({
-            status: PaymentStatus.COMPLETED,
-            // notes field has been removed from the implementation
-          }),
-        })
-      );
-
-      // Result should indicate payment completed
-      expect(result.paymentStatus).toBe(PaymentStatus.COMPLETED);
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.updateMany).not.toHaveBeenCalled();
     });
 
     it('should update only payment status when registration is already confirmed', async () => {
@@ -1444,22 +1392,10 @@ describe('PaymentsService', () => {
         payment_status: 'paid',
       };
 
-      // Mock updated results
-      const updatedPayment = {
-        ...mockPayment,
-        status: PaymentStatus.COMPLETED,
-      };
-
-      const updatedRegistration = {
-        ...mockRegistration,
-        status: 'CONFIRMED', // No change needed
-      };
-
       // Setup mocks
       mockPrismaService.payment.findFirst.mockResolvedValue(partialCompletePayment);
+      mockPrismaService.payment.findUnique.mockResolvedValue(partialCompletePayment);
       mockStripeService.getCheckoutSession.mockResolvedValue(mockStripeSession);
-      mockPrismaService.$transaction.mockResolvedValue([updatedPayment, updatedRegistration]);
-
       // Execute
       const result = await service.verifyStripeSession(sessionId);
 
@@ -1484,6 +1420,168 @@ describe('PaymentsService', () => {
         registrationStatus: 'CONFIRMED',
         paymentId: mockPayment.id,
       });
+    });
+
+    it.each([
+      [PaymentStatus.FAILED, RegistrationStatus.CANCELLED],
+      [PaymentStatus.PARTIALLY_REFUNDED, RegistrationStatus.PENDING],
+      [PaymentStatus.REFUNDED, RegistrationStatus.WAITLISTED],
+    ])(
+      'should preserve terminal payment %s and current registration %s on paid-session replay',
+      async (paymentStatus, registrationStatus) => {
+        const terminalPayment = {
+          ...mockPayment,
+          status: paymentStatus,
+          registration: {
+            ...mockRegistration,
+            status: registrationStatus,
+            paymentDeferred: false,
+          },
+        };
+        mockPrismaService.payment.findFirst.mockResolvedValue(terminalPayment);
+        mockPrismaService.payment.findUnique.mockResolvedValue(terminalPayment);
+        mockStripeService.getCheckoutSession.mockResolvedValue({
+          id: sessionId,
+          status: 'complete',
+          payment_status: 'paid',
+        });
+
+        const actualResult = await service.verifyStripeSession(sessionId);
+
+        expect(actualResult.paymentStatus).toBe(paymentStatus);
+        expect(actualResult.registrationStatus).toBe(registrationStatus);
+        expect(mockPrismaService.payment.updateMany).not.toHaveBeenCalled();
+        expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+        expect(mockNotificationsService.sendRegistrationConfirmationEmail).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should preserve a current non-deferred registration on completed-session replay', async () => {
+      const completedPayment = {
+        ...mockPayment,
+        status: PaymentStatus.COMPLETED,
+        registration: {
+          ...mockRegistration,
+          status: RegistrationStatus.PENDING,
+          paymentDeferred: false,
+        },
+      };
+      mockPrismaService.payment.findFirst.mockResolvedValue(completedPayment);
+      mockPrismaService.payment.findUnique.mockResolvedValue(completedPayment);
+      mockStripeService.getCheckoutSession.mockResolvedValue({
+        id: sessionId,
+        status: 'complete',
+        payment_status: 'paid',
+      });
+
+      const actualResult = await service.verifyStripeSession(sessionId);
+
+      expect(actualResult.paymentStatus).toBe(PaymentStatus.COMPLETED);
+      expect(actualResult.registrationStatus).toBe(RegistrationStatus.PENDING);
+      expect(mockPrismaService.payment.updateMany).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      RegistrationStatus.CANCELLED,
+      RegistrationStatus.APPLICATION_SUBMITTED,
+      RegistrationStatus.APPLICATION_APPROVED,
+      RegistrationStatus.APPLICATION_DECLINED,
+    ])(
+      'should complete a genuinely pending payment without changing protected registration %s',
+      async protectedStatus => {
+        const paymentWithProtectedRegistration = {
+          ...mockPayment,
+          registration: {
+            ...mockRegistration,
+            status: protectedStatus,
+            paymentDeferred: true,
+          },
+        };
+        mockPrismaService.payment.findFirst.mockResolvedValue(paymentWithProtectedRegistration);
+        mockPrismaService.payment.findUnique.mockResolvedValue(paymentWithProtectedRegistration);
+        mockStripeService.getCheckoutSession.mockResolvedValue({
+          id: sessionId,
+          status: 'complete',
+          payment_status: 'paid',
+        });
+
+        const actualResult = await service.verifyStripeSession(sessionId);
+
+        expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
+          where: { id: mockPayment.id, status: PaymentStatus.PENDING },
+          data: { status: PaymentStatus.COMPLETED },
+        });
+        expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+        expect(actualResult.paymentStatus).toBe(PaymentStatus.COMPLETED);
+        expect(actualResult.registrationStatus).toBe(protectedStatus);
+      }
+    );
+
+    it('should preserve a concurrent refund-derived payment transition during paid verification', async () => {
+      const concurrentPayment = {
+        ...mockPayment,
+        status: PaymentStatus.PARTIALLY_REFUNDED,
+        registration: {
+          ...mockRegistration,
+          paymentDeferred: false,
+        },
+      };
+      mockPrismaService.payment.findFirst.mockResolvedValue({
+        ...mockPayment,
+        registration: { ...mockRegistration, paymentDeferred: false },
+      });
+      mockPrismaService.payment.updateMany.mockResolvedValue({ count: 0 });
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce({
+          ...mockPayment,
+          registration: { ...mockRegistration, paymentDeferred: true },
+        })
+        .mockResolvedValueOnce(concurrentPayment);
+      mockStripeService.getCheckoutSession.mockResolvedValue({
+        id: sessionId,
+        status: 'complete',
+        payment_status: 'paid',
+      });
+
+      const actualResult = await service.verifyStripeSession(sessionId);
+
+      expect(actualResult.paymentStatus).toBe(PaymentStatus.PARTIALLY_REFUNDED);
+      expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('should preserve a concurrent protected registration transition during paid verification', async () => {
+      const concurrentPayment = {
+        ...mockPayment,
+        registration: {
+          ...mockRegistration,
+          status: RegistrationStatus.CANCELLED,
+          paymentDeferred: true,
+        },
+      };
+      mockPrismaService.payment.findFirst.mockResolvedValue({
+        ...mockPayment,
+        registration: { ...mockRegistration, paymentDeferred: true },
+      });
+      mockPrismaService.registration.updateMany.mockResolvedValue({ count: 0 });
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce({
+          ...mockPayment,
+          registration: { ...mockRegistration, paymentDeferred: true },
+        })
+        .mockResolvedValueOnce(concurrentPayment);
+      mockStripeService.getCheckoutSession.mockResolvedValue({
+        id: sessionId,
+        status: 'complete',
+        payment_status: 'paid',
+      });
+
+      const actualResult = await service.verifyStripeSession(sessionId);
+
+      expect(actualResult.paymentStatus).toBe(PaymentStatus.PENDING);
+      expect(actualResult.registrationStatus).toBe(RegistrationStatus.CANCELLED);
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
     });
   });
 
@@ -2848,7 +2946,7 @@ describe('PaymentsService', () => {
       // payment row still PENDING (it was created when the user clicked
       // Pay Now from the dashboard, then this verification runs after
       // checkout success).
-      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+      const deferredPayment = {
         id: 'payment-id',
         status: PaymentStatus.PENDING,
         providerRefId: 'cs_deferred_session',
@@ -2859,7 +2957,9 @@ describe('PaymentsService', () => {
           status: 'CONFIRMED',
           paymentDeferred: true,
         },
-      });
+      };
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce(deferredPayment);
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(deferredPayment);
       mockStripeService.getCheckoutSession.mockResolvedValueOnce({
         id: 'cs_deferred_session',
         status: 'complete',
@@ -2870,16 +2970,20 @@ describe('PaymentsService', () => {
 
       // The transaction body issues two prisma update calls; assert the
       // registration update sets both status and clears paymentDeferred.
-      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
+      expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: 'registration-id' },
+          where: {
+            id: 'registration-id',
+            paymentDeferred: true,
+            status: 'CONFIRMED',
+          },
           data: { status: 'CONFIRMED', paymentDeferred: false },
         })
       );
     });
 
     it('skips the post-payment confirmation email when paying off a deferred registration (already emailed at creation)', async () => {
-      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+      const deferredPayment = {
         id: 'payment-id',
         status: PaymentStatus.PENDING,
         providerRefId: 'cs_deferred_pay',
@@ -2890,23 +2994,23 @@ describe('PaymentsService', () => {
           status: 'CONFIRMED',
           paymentDeferred: true,
         },
-      });
+      };
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce(deferredPayment);
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(deferredPayment);
       mockStripeService.getCheckoutSession.mockResolvedValueOnce({
         id: 'cs_deferred_pay',
         status: 'complete',
         payment_status: 'paid',
       });
-      mockPrismaService.payment.findUnique.mockResolvedValue({
-        id: 'payment-id',
-        status: PaymentStatus.COMPLETED,
-        registration: { id: 'registration-id' },
-      });
-
       await service.verifyStripeSession('cs_deferred_pay');
 
-      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
+      expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: 'registration-id' },
+          where: {
+            id: 'registration-id',
+            paymentDeferred: true,
+            status: 'CONFIRMED',
+          },
           data: { status: 'CONFIRMED', paymentDeferred: false },
         })
       );
@@ -2918,7 +3022,7 @@ describe('PaymentsService', () => {
       // registration update failed and is being retried. Without the
       // widened condition, this case would skip the update and leave
       // paymentDeferred=true forever.
-      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+      const deferredPayment = {
         id: 'payment-id',
         status: PaymentStatus.COMPLETED,
         providerRefId: 'cs_deferred_retry',
@@ -2929,7 +3033,9 @@ describe('PaymentsService', () => {
           status: 'CONFIRMED',
           paymentDeferred: true,
         },
-      });
+      };
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce(deferredPayment);
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(deferredPayment);
       mockStripeService.getCheckoutSession.mockResolvedValueOnce({
         id: 'cs_deferred_retry',
         status: 'complete',
@@ -2938,16 +3044,20 @@ describe('PaymentsService', () => {
 
       await service.verifyStripeSession('cs_deferred_retry');
 
-      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
+      expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: 'registration-id' },
+          where: {
+            id: 'registration-id',
+            paymentDeferred: true,
+            status: 'CONFIRMED',
+          },
           data: { status: 'CONFIRMED', paymentDeferred: false },
         })
       );
     });
 
     it('skips the update only when payment is COMPLETED AND registration is CONFIRMED AND paymentDeferred is false', async () => {
-      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+      const completedPayment = {
         id: 'payment-id',
         status: PaymentStatus.COMPLETED,
         providerRefId: 'cs_already_done',
@@ -2958,7 +3068,9 @@ describe('PaymentsService', () => {
           status: 'CONFIRMED',
           paymentDeferred: false,
         },
-      });
+      };
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce(completedPayment);
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(completedPayment);
       mockStripeService.getCheckoutSession.mockResolvedValueOnce({
         id: 'cs_already_done',
         status: 'complete',
@@ -2967,8 +3079,8 @@ describe('PaymentsService', () => {
 
       await service.verifyStripeSession('cs_already_done');
 
-      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
-      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.updateMany).not.toHaveBeenCalled();
     });
 
     it('does NOT promote a WAITLISTED deferred registration to CONFIRMED on payment — capacity wins', async () => {
@@ -2976,7 +3088,7 @@ describe('PaymentsService', () => {
       // payment must record + clear paymentDeferred, but the status
       // must stay WAITLISTED (admin / capacity-opens-up is the only path
       // to CONFIRMED for waitlisted registrations).
-      mockPrismaService.payment.findFirst.mockResolvedValueOnce({
+      const waitlistedPayment = {
         id: 'payment-id',
         status: PaymentStatus.PENDING,
         providerRefId: 'cs_waitlisted_pay',
@@ -2987,7 +3099,9 @@ describe('PaymentsService', () => {
           status: 'WAITLISTED',
           paymentDeferred: true,
         },
-      });
+      };
+      mockPrismaService.payment.findFirst.mockResolvedValueOnce(waitlistedPayment);
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(waitlistedPayment);
       mockStripeService.getCheckoutSession.mockResolvedValueOnce({
         id: 'cs_waitlisted_pay',
         status: 'complete',
@@ -2996,9 +3110,13 @@ describe('PaymentsService', () => {
 
       await service.verifyStripeSession('cs_waitlisted_pay');
 
-      expect(mockPrismaService.registration.update).toHaveBeenCalledWith(
+      expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: 'registration-id' },
+          where: {
+            id: 'registration-id',
+            paymentDeferred: true,
+            status: 'WAITLISTED',
+          },
           data: { status: 'WAITLISTED', paymentDeferred: false },
         })
       );
@@ -4105,6 +4223,7 @@ describe('PaymentsService', () => {
       mockPrismaService.paymentRefund.updateMany.mockResolvedValue({ count: 1 });
       mockPrismaService.payment.findUnique.mockResolvedValue(stripePayment);
       mockPrismaService.payment.update.mockResolvedValue(stripePayment);
+      mockPrismaService.payment.updateMany.mockResolvedValue({ count: 1 });
       mockPrismaService.registration.findUnique.mockResolvedValue({
         status: RegistrationStatus.CONFIRMED,
       });
@@ -4231,8 +4350,8 @@ describe('PaymentsService', () => {
           failureMessage: null,
         },
       });
-      expect(mockPrismaService.payment.update).toHaveBeenCalledWith({
-        where: { id: paymentId },
+      expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
+        where: { id: paymentId, status: PaymentStatus.COMPLETED },
         data: { status: PaymentStatus.PARTIALLY_REFUNDED },
       });
       expect(mockPrismaService.registration.findUnique).toHaveBeenCalledWith({
@@ -4257,6 +4376,61 @@ describe('PaymentsService', () => {
       });
       expect(actualResult.outcome).toBe('SUCCEEDED');
       expect(actualResult.refund).not.toHaveProperty('providerRefundId');
+    });
+
+    it.each([PaymentStatus.FAILED, PaymentStatus.REFUNDED])(
+      'should leave a confirmed processor refund recoverable when payment became %s',
+      async protectedStatus => {
+        mockPrismaService.paymentRefund.findUnique
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(pendingRefund);
+        mockPrismaService.payment.findUnique
+          .mockResolvedValueOnce(stripePayment)
+          .mockResolvedValueOnce({
+            ...stripePayment,
+            status: protectedStatus,
+            refunds: [publicPendingRefund],
+          });
+        mockStripeService.createAdminRefund.mockResolvedValue({
+          outcome: 'SUCCEEDED',
+          providerRefundId: 're_provider',
+        });
+
+        const actualResult = await service.createRefund(paymentId, stripeRequest, 'admin-id');
+
+        expect(actualResult.outcome).toBe('PENDING_UNKNOWN');
+        expect(mockStripeService.createAdminRefund).toHaveBeenCalledTimes(1);
+        expect(mockPrismaService.paymentRefund.updateMany).not.toHaveBeenCalled();
+        expect(mockPrismaService.payment.updateMany).not.toHaveBeenCalled();
+        expect(mockPrismaService.adminAudit.create).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    it('should roll back local finalization when the eligible payment status guard loses a race', async () => {
+      mockPrismaService.paymentRefund.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(pendingRefund);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(stripePayment)
+        .mockResolvedValueOnce({
+          ...stripePayment,
+          refunds: [publicPendingRefund],
+        });
+      mockPrismaService.payment.updateMany.mockResolvedValue({ count: 0 });
+      mockStripeService.createAdminRefund.mockResolvedValue({
+        outcome: 'SUCCEEDED',
+        providerRefundId: 're_provider',
+      });
+
+      const actualResult = await service.createRefund(paymentId, stripeRequest, 'admin-id');
+
+      expect(actualResult.outcome).toBe('PENDING_UNKNOWN');
+      expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
+        where: { id: paymentId, status: PaymentStatus.COMPLETED },
+        data: { status: PaymentStatus.PARTIALLY_REFUNDED },
+      });
+      expect(mockStripeService.createAdminRefund).toHaveBeenCalledTimes(1);
+      expect(mockPrismaService.adminAudit.create).toHaveBeenCalledTimes(1);
     });
 
     it.each([
@@ -4528,6 +4702,34 @@ describe('PaymentsService', () => {
       expect(mockStripeService.findAdminRefund).toHaveBeenCalledWith('pi_original', refundId);
       expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
       expect(actualResult.outcome).toBe('SUCCEEDED');
+    });
+
+    it('should not resubmit a found Stripe refund when local payment finalization conflicts', async () => {
+      const paymentWithPending = buildStripePayment(
+        PaymentStatus.COMPLETED,
+        PaymentRefundStatus.PENDING
+      );
+      mockPrismaService.paymentRefund.findUnique
+        .mockResolvedValueOnce(pendingRefund)
+        .mockResolvedValueOnce(pendingRefund);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(paymentWithPending)
+        .mockResolvedValueOnce(paymentWithPending);
+      mockPrismaService.payment.updateMany.mockResolvedValue({ count: 0 });
+      mockStripeService.findAdminRefund.mockResolvedValue({
+        outcome: 'FOUND',
+        providerRefundId: 're_found',
+      });
+
+      const actualResult = await service.retryStripeRefund(
+        paymentId,
+        refundId,
+        'retry-admin'
+      );
+
+      expect(actualResult.outcome).toBe('PENDING_UNKNOWN');
+      expect(mockStripeService.findAdminRefund).toHaveBeenCalledTimes(1);
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
     });
 
     it('should resubmit the exact stored request with the same key only after inspection misses', async () => {

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -17,6 +17,8 @@ import {
   UserRole,
 } from '@prisma/client';
 import { NotFoundException, BadRequestException, ConflictException } from '@nestjs/common';
+import { CreateRefundDto } from '../dto';
+import { GlobalValidationPipe } from '../../common/pipes/validation.pipe';
 
 // Mock implementations
 const mockPrismaService = {
@@ -3023,6 +3025,16 @@ describe('PaymentsService', () => {
       };
     }
 
+    async function sanitizeRefundRequest(
+      request: Record<string, unknown>
+    ): Promise<CreateRefundDto> {
+      const validationPipe = new GlobalValidationPipe();
+      return validationPipe.transform(request, {
+        type: 'body',
+        metatype: CreateRefundDto,
+      }) as Promise<CreateRefundDto>;
+    }
+
     beforeEach(() => {
       mockPrismaService.$transaction.mockImplementation(
         async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) =>
@@ -3243,6 +3255,46 @@ describe('PaymentsService', () => {
       expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
     });
 
+    it('should reject explicit cents above the PostgreSQL INTEGER range before the transaction', async () => {
+      await expect(
+        service.createManualRefund(
+          paymentId,
+          { ...inputRequest, amountCents: 2_147_483_648 },
+          'admin-id'
+        )
+      ).rejects.toThrow('supported range');
+
+      expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject a full refund for an oversized historical payment before writes', async () => {
+      mockPrismaService.payment.findUnique.mockReset().mockResolvedValue({
+        ...basePayment,
+        amount: 21_474_836.48,
+      });
+
+      await expect(
+        service.createManualRefund(
+          paymentId,
+          {
+            fullRefund: true,
+            executionMode: RefundExecutionMode.MANUAL,
+            idempotencyKey,
+          },
+          'admin-id'
+        )
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+    });
+
     it('should reject manual refunds for a stored payment with sub-cent precision', async () => {
       mockPrismaService.payment.findUnique
         .mockReset()
@@ -3250,13 +3302,65 @@ describe('PaymentsService', () => {
 
       await expect(
         service.createManualRefund(paymentId, inputRequest, 'admin-id')
-      ).rejects.toThrow('Dollar amount must not have sub-cent precision');
+      ).rejects.toThrow(BadRequestException);
 
       expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
       expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
       expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
       expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
     });
+
+    it('should persist canonical text at the exact post-sanitization limits', async () => {
+      const sanitizedRequest = await sanitizeRefundRequest({
+        ...inputRequest,
+        reason: '&'.repeat(100),
+        externalReference: '&'.repeat(51),
+      });
+
+      await service.createManualRefund(paymentId, sanitizedRequest, 'admin-id');
+
+      expect(sanitizedRequest.reason).toHaveLength(500);
+      expect(sanitizedRequest.externalReference).toHaveLength(255);
+      expect(mockPrismaService.paymentRefund.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            reason: sanitizedRequest.reason,
+            externalReference: sanitizedRequest.externalReference,
+          }),
+        })
+      );
+      expect(mockPrismaService.adminAudit.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          newValues: expect.objectContaining({
+            reason: sanitizedRequest.reason,
+            externalReference: sanitizedRequest.externalReference,
+          }),
+        }),
+      });
+    });
+
+    it.each([
+      ['reason', '&'.repeat(101), 500],
+      ['externalReference', '&'.repeat(52), 255],
+    ] as const)(
+      'should reject %s that exceeds its persistence limit after sanitization',
+      async (field, rawValue, expectedLimit) => {
+        const sanitizedRequest = await sanitizeRefundRequest({
+          ...inputRequest,
+          [field]: rawValue,
+        });
+
+        await expect(
+          service.createManualRefund(paymentId, sanitizedRequest, 'admin-id')
+        ).rejects.toThrow(`${field} must not exceed ${expectedLimit} characters`);
+
+        expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
+        expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+        expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+        expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+        expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+      }
+    );
 
     it('should reject manual refunds for an invalid stored currency before writes', async () => {
       mockPrismaService.payment.findUnique
@@ -3407,6 +3511,95 @@ describe('PaymentsService', () => {
       expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
       expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
       expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+    });
+
+    it('should replay a full-refund request after another reservation fails', async () => {
+      const fullRefund = {
+        ...createdRefund,
+        amountCents: 8000,
+      };
+      const changedLedgerPayment = {
+        ...basePayment,
+        status: PaymentStatus.PARTIALLY_REFUNDED,
+        refunds: [
+          {
+            ...publicCreatedRefund,
+            amountCents: 8000,
+          },
+          {
+            ...publicCreatedRefund,
+            id: 'failed-reservation',
+            amountCents: 2000,
+            status: PaymentRefundStatus.FAILED,
+          },
+        ],
+      };
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(fullRefund);
+      mockPrismaService.payment.findUnique.mockReset().mockResolvedValue(changedLedgerPayment);
+      mockPrismaService.adminAudit.findFirst.mockResolvedValue({
+        newValues: { requestedFullRefund: true },
+      });
+
+      const actualResult = await service.createManualRefund(
+        paymentId,
+        {
+          fullRefund: true,
+          executionMode: RefundExecutionMode.MANUAL,
+          reason: inputRequest.reason,
+          externalReference: inputRequest.externalReference,
+          idempotencyKey,
+        },
+        'admin-id'
+      );
+
+      expect(actualResult.refund.amountCents).toBe(8000);
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+    });
+
+    it('should resolve a full-refund P2002 winner after another reservation fails', async () => {
+      const fullRefund = {
+        ...createdRefund,
+        amountCents: 8000,
+      };
+      const changedLedgerPayment = {
+        ...basePayment,
+        status: PaymentStatus.PARTIALLY_REFUNDED,
+        refunds: [
+          {
+            ...publicCreatedRefund,
+            amountCents: 8000,
+          },
+          {
+            ...publicCreatedRefund,
+            id: 'failed-reservation',
+            amountCents: 2000,
+            status: PaymentRefundStatus.FAILED,
+          },
+        ],
+      };
+      mockPrismaService.$transaction.mockRejectedValue({ code: 'P2002' });
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(fullRefund);
+      mockPrismaService.payment.findUnique.mockReset().mockResolvedValue(changedLedgerPayment);
+      mockPrismaService.adminAudit.findFirst.mockResolvedValue({
+        newValues: { requestedFullRefund: true },
+      });
+
+      const actualResult = await service.createManualRefund(
+        paymentId,
+        {
+          fullRefund: true,
+          executionMode: RefundExecutionMode.MANUAL,
+          reason: inputRequest.reason,
+          externalReference: inputRequest.externalReference,
+          idempotencyKey,
+        },
+        'admin-id'
+      );
+
+      expect(actualResult.refund.amountCents).toBe(8000);
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
     });
 
     it('should reject idempotency key reuse with different amount or full-refund semantics', async () => {

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -4237,6 +4237,7 @@ describe('PaymentsService', () => {
           executionMode: RefundExecutionMode.STRIPE,
           requestedFullRefund: false,
           providerRefId: 'pi_original',
+          registrationId: 'registration-id',
         },
       });
       mockStripeService.createAdminRefund.mockResolvedValue({
@@ -4415,7 +4416,11 @@ describe('PaymentsService', () => {
         },
       });
       expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
-        where: { id: paymentId, status: PaymentStatus.COMPLETED },
+        where: {
+          id: paymentId,
+          registrationId: 'registration-id',
+          status: PaymentStatus.COMPLETED,
+        },
         data: { status: PaymentStatus.PARTIALLY_REFUNDED },
       });
       expect(mockPrismaService.registration.findUnique).toHaveBeenCalledWith({
@@ -4435,11 +4440,251 @@ describe('PaymentsService', () => {
             phase: 'RESULT',
             outcome: PaymentRefundStatus.SUCCEEDED,
             providerRefundId: 're_provider',
+            attemptRegistrationId: 'registration-id',
+            currentRegistrationId: 'registration-id',
+            registrationTargetOutcome: 'MATCHED',
           }),
         }),
       });
       expect(actualResult.outcome).toBe('SUCCEEDED');
       expect(actualResult.refund).not.toHaveProperty('providerRefundId');
+    });
+
+    it('should finalize the refund without applying registration A status after relinking to B', async () => {
+      const requestedStatus = RegistrationStatus.WAITLISTED;
+      const pendingWithStatus = {
+        ...pendingRefund,
+        resultingRegistrationStatus: requestedStatus,
+      };
+      const succeededRefund = {
+        ...pendingWithStatus,
+        status: PaymentRefundStatus.SUCCEEDED,
+        providerRefundId: 're_provider',
+      };
+      const relinkedPayment = {
+        ...stripePayment,
+        registrationId: 'registration-b',
+        registration: {
+          ...stripePayment.registration,
+          id: 'registration-b',
+        },
+        refunds: [{ ...publicPendingRefund, resultingRegistrationStatus: requestedStatus }],
+      };
+      mockPrismaService.paymentRefund.create.mockResolvedValue(pendingWithStatus);
+      mockPrismaService.paymentRefund.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(pendingWithStatus)
+        .mockResolvedValueOnce(succeededRefund);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(stripePayment)
+        .mockResolvedValueOnce(relinkedPayment)
+        .mockResolvedValueOnce({
+          ...relinkedPayment,
+          status: PaymentStatus.PARTIALLY_REFUNDED,
+          refunds: [
+            {
+              ...publicPendingRefund,
+              status: PaymentRefundStatus.SUCCEEDED,
+              resultingRegistrationStatus: requestedStatus,
+            },
+          ],
+        });
+      mockStripeService.createAdminRefund.mockResolvedValue({
+        outcome: 'SUCCEEDED',
+        providerRefundId: 're_provider',
+      });
+
+      const actualResult = await service.createRefund(
+        paymentId,
+        {
+          ...stripeRequest,
+          resultingRegistrationStatus: requestedStatus,
+        },
+        'admin-id'
+      );
+
+      expect(actualResult.outcome).toBe('SUCCEEDED');
+      expect(mockPrismaService.registration.findUnique).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.create).toHaveBeenLastCalledWith({
+        data: expect.objectContaining({
+          newValues: expect.objectContaining({
+            attemptRegistrationId: 'registration-id',
+            currentRegistrationId: 'registration-b',
+            registrationTargetOutcome: 'RELINKED',
+            registrationStatusApplied: false,
+            registrationStatusSkipReason: 'PAYMENT_RELINKED',
+          }),
+        }),
+      });
+    });
+
+    it.each([
+      ['missing audit', null],
+      [
+        'missing registration target',
+        {
+          newValues: {
+            phase: 'ATTEMPT',
+            paymentId,
+            refundId,
+            executionMode: RefundExecutionMode.STRIPE,
+          },
+        },
+      ],
+      [
+        'non-string registration target',
+        {
+          newValues: {
+            phase: 'ATTEMPT',
+            paymentId,
+            refundId,
+            executionMode: RefundExecutionMode.STRIPE,
+            registrationId: 42,
+          },
+        },
+      ],
+      [
+        'blank registration target',
+        {
+          newValues: {
+            phase: 'ATTEMPT',
+            paymentId,
+            refundId,
+            executionMode: RefundExecutionMode.STRIPE,
+            registrationId: ' ',
+          },
+        },
+      ],
+      [
+        'mismatched attempt identity',
+        {
+          newValues: {
+            phase: 'ATTEMPT',
+            paymentId: 'different-payment',
+            refundId,
+            executionMode: RefundExecutionMode.STRIPE,
+            registrationId: 'registration-id',
+          },
+        },
+      ],
+    ])(
+      'should finalize successfully and skip registration for an unavailable %s',
+      async (_caseName, inputAudit) => {
+        const requestedStatus = RegistrationStatus.WAITLISTED;
+        const pendingWithStatus = {
+          ...pendingRefund,
+          resultingRegistrationStatus: requestedStatus,
+        };
+        const succeededRefund = {
+          ...pendingWithStatus,
+          status: PaymentRefundStatus.SUCCEEDED,
+          providerRefundId: 're_provider',
+        };
+        mockPrismaService.paymentRefund.create.mockResolvedValue(pendingWithStatus);
+        mockPrismaService.paymentRefund.findUnique
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(pendingWithStatus)
+          .mockResolvedValueOnce(succeededRefund);
+        mockPrismaService.payment.findUnique
+          .mockResolvedValueOnce(stripePayment)
+          .mockResolvedValueOnce({
+            ...stripePayment,
+            refunds: [{ ...publicPendingRefund, resultingRegistrationStatus: requestedStatus }],
+          })
+          .mockResolvedValueOnce({
+            ...buildStripePayment(
+              PaymentStatus.PARTIALLY_REFUNDED,
+              PaymentRefundStatus.SUCCEEDED
+            ),
+            registration: stripePayment.registration,
+          });
+        mockPrismaService.adminAudit.findFirst.mockResolvedValue(inputAudit);
+        mockStripeService.createAdminRefund.mockResolvedValue({
+          outcome: 'SUCCEEDED',
+          providerRefundId: 're_provider',
+        });
+
+        const actualResult = await service.createRefund(
+          paymentId,
+          {
+            ...stripeRequest,
+            resultingRegistrationStatus: requestedStatus,
+          },
+          'admin-id'
+        );
+
+        expect(actualResult.outcome).toBe('SUCCEEDED');
+        expect(mockPrismaService.registration.findUnique).not.toHaveBeenCalled();
+        expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+        expect(mockPrismaService.adminAudit.create).toHaveBeenLastCalledWith({
+          data: expect.objectContaining({
+            newValues: expect.objectContaining({
+              attemptRegistrationId: null,
+              currentRegistrationId: 'registration-id',
+              registrationTargetOutcome: 'UNAVAILABLE',
+              registrationStatusApplied: false,
+              registrationStatusSkipReason: 'ATTEMPT_REGISTRATION_UNAVAILABLE',
+            }),
+          }),
+        });
+      }
+    );
+
+    it('should audit a valid null registration snapshot without mutating registration state', async () => {
+      const paymentWithoutRegistration = {
+        ...stripePayment,
+        registrationId: null,
+        registration: null,
+      };
+      const succeededRefund = {
+        ...pendingRefund,
+        status: PaymentRefundStatus.SUCCEEDED,
+        providerRefundId: 're_provider',
+      };
+      mockPrismaService.paymentRefund.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(pendingRefund)
+        .mockResolvedValueOnce(succeededRefund);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(paymentWithoutRegistration)
+        .mockResolvedValueOnce({
+          ...paymentWithoutRegistration,
+          refunds: [publicPendingRefund],
+        })
+        .mockResolvedValueOnce({
+          ...paymentWithoutRegistration,
+          status: PaymentStatus.PARTIALLY_REFUNDED,
+          refunds: [{ ...publicPendingRefund, status: PaymentRefundStatus.SUCCEEDED }],
+        });
+      mockPrismaService.adminAudit.findFirst.mockResolvedValue({
+        newValues: {
+          phase: 'ATTEMPT',
+          paymentId,
+          refundId,
+          executionMode: RefundExecutionMode.STRIPE,
+          registrationId: null,
+        },
+      });
+      mockStripeService.createAdminRefund.mockResolvedValue({
+        outcome: 'SUCCEEDED',
+        providerRefundId: 're_provider',
+      });
+
+      const actualResult = await service.createRefund(paymentId, stripeRequest, 'admin-id');
+
+      expect(actualResult.outcome).toBe('SUCCEEDED');
+      expect(mockPrismaService.registration.findUnique).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.create).toHaveBeenLastCalledWith({
+        data: expect.objectContaining({
+          newValues: expect.objectContaining({
+            attemptRegistrationId: null,
+            currentRegistrationId: null,
+            registrationTargetOutcome: 'MATCHED',
+          }),
+        }),
+      });
     });
 
     it.each([PaymentStatus.FAILED, PaymentStatus.REFUNDED])(
@@ -4796,6 +5041,47 @@ describe('PaymentsService', () => {
       expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
     });
 
+    it('should keep a found refund pending when the registration link guard loses a race', async () => {
+      const requestedStatus = RegistrationStatus.WAITLISTED;
+      const pendingWithStatus = {
+        ...pendingRefund,
+        resultingRegistrationStatus: requestedStatus,
+      };
+      const paymentWithPending = {
+        ...buildStripePayment(PaymentStatus.COMPLETED, PaymentRefundStatus.PENDING),
+        refunds: [{ ...publicPendingRefund, resultingRegistrationStatus: requestedStatus }],
+      };
+      mockPrismaService.paymentRefund.findUnique
+        .mockResolvedValueOnce(pendingWithStatus)
+        .mockResolvedValueOnce(pendingWithStatus);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(paymentWithPending)
+        .mockResolvedValueOnce(paymentWithPending);
+      mockPrismaService.payment.updateMany.mockResolvedValue({ count: 0 });
+      mockStripeService.findAdminRefund.mockResolvedValue({
+        outcome: 'FOUND',
+        providerRefundId: 're_found',
+      });
+
+      const actualResult = await service.retryStripeRefund(
+        paymentId,
+        refundId,
+        'retry-admin'
+      );
+
+      expect(actualResult.outcome).toBe('PENDING_UNKNOWN');
+      expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: paymentId,
+          status: PaymentStatus.COMPLETED,
+          registrationId: 'registration-id',
+        },
+        data: { status: PaymentStatus.PARTIALLY_REFUNDED },
+      });
+      expect(mockStripeService.findAdminRefund).toHaveBeenCalledTimes(1);
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
+    });
+
     it('should resubmit the exact stored request with the same key only after inspection misses', async () => {
       const paymentWithPending = buildStripePayment(
         PaymentStatus.COMPLETED,
@@ -5003,5 +5289,26 @@ describe('PaymentsService', () => {
         expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
       }
     );
+
+    it.each([
+      PaymentRefundStatus.PENDING,
+      PaymentRefundStatus.SUCCEEDED,
+      PaymentRefundStatus.FAILED,
+    ])('should reject MANUAL retry status %s before payment or network work', async inputStatus => {
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue({
+        ...pendingRefund,
+        status: inputStatus,
+        executionMode: RefundExecutionMode.MANUAL,
+      });
+
+      await expect(
+        service.retryStripeRefund(paymentId, refundId, 'retry-admin')
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockPrismaService.payment.findUnique).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.findFirst).not.toHaveBeenCalled();
+      expect(mockStripeService.findAdminRefund).not.toHaveBeenCalled();
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -460,7 +460,32 @@ describe('PaymentsService', () => {
             email: 'legacy@example.com',
           },
           registration: null,
-          refunds: [],
+          refunds: [
+            {
+              id: 'succeeded-refund',
+              amountCents: 600,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.MANUAL,
+              status: PaymentRefundStatus.SUCCEEDED,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              id: 'pending-refund',
+              amountCents: 100,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.STRIPE,
+              status: PaymentRefundStatus.PENDING,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
         };
         mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
         mockPrismaService.payment.count.mockResolvedValue(1);
@@ -472,8 +497,8 @@ describe('PaymentsService', () => {
             {
               ...mockPayment,
               paymentAmountCents: null,
-              successfulRefundCents: 0,
-              pendingRefundCents: 0,
+              successfulRefundCents: 600,
+              pendingRefundCents: 100,
               availableRefundCents: 0,
               refundUnavailableReason:
                 'Refund unavailable because the stored payment amount has unsupported precision.',
@@ -483,10 +508,192 @@ describe('PaymentsService', () => {
         });
       });
 
+      it('should report a zero-dollar comp payment as exactly zero cents', async () => {
+        const mockPayment = {
+          id: 'zero-dollar-payment',
+          amount: 0,
+          currency: 'USD',
+          status: PaymentStatus.COMPLETED,
+          provider: PaymentProvider.MANUAL,
+          externalMethod: null,
+          externalReference: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 'user-id',
+          registrationId: null,
+          user: {
+            id: 'user-id',
+            firstName: 'Comp',
+            lastName: 'Registration',
+            email: 'comp@example.com',
+          },
+          registration: null,
+          refunds: [],
+        };
+        mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
+        mockPrismaService.payment.count.mockResolvedValue(1);
+
+        const actualResult = await service.findAllForAdmin();
+
+        expect(actualResult.payments[0]).toEqual(
+          expect.objectContaining({
+            paymentAmountCents: 0,
+            successfulRefundCents: 0,
+            pendingRefundCents: 0,
+            availableRefundCents: 0,
+            refundUnavailableReason: null,
+          })
+        );
+      });
+
+      it('should report the maximum supported historical payment amount in cents', async () => {
+        const mockPayment = {
+          id: 'maximum-payment',
+          amount: 21_474_836.47,
+          currency: 'USD',
+          status: PaymentStatus.COMPLETED,
+          provider: PaymentProvider.STRIPE,
+          externalMethod: null,
+          externalReference: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 'user-id',
+          registrationId: null,
+          user: {
+            id: 'user-id',
+            firstName: 'Maximum',
+            lastName: 'Payment',
+            email: 'maximum@example.com',
+          },
+          registration: null,
+          refunds: [],
+        };
+        mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
+        mockPrismaService.payment.count.mockResolvedValue(1);
+
+        const actualResult = await service.findAllForAdmin();
+
+        expect(actualResult.payments[0]).toEqual(
+          expect.objectContaining({
+            paymentAmountCents: 2_147_483_647,
+            successfulRefundCents: 0,
+            pendingRefundCents: 0,
+            availableRefundCents: 2_147_483_647,
+            refundUnavailableReason: null,
+          })
+        );
+      });
+
+      it('should keep an out-of-range payment visible with durable refund totals', async () => {
+        const mockPayment = {
+          id: 'out-of-range-payment',
+          amount: 21_474_836.48,
+          currency: 'USD',
+          status: PaymentStatus.PARTIALLY_REFUNDED,
+          provider: PaymentProvider.STRIPE,
+          externalMethod: null,
+          externalReference: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 'user-id',
+          registrationId: null,
+          user: {
+            id: 'user-id',
+            firstName: 'Out Of Range',
+            lastName: 'Payment',
+            email: 'out-of-range@example.com',
+          },
+          registration: null,
+          refunds: [
+            {
+              id: 'succeeded-refund',
+              amountCents: 600,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.MANUAL,
+              status: PaymentRefundStatus.SUCCEEDED,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              id: 'pending-refund',
+              amountCents: 100,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.STRIPE,
+              status: PaymentRefundStatus.PENDING,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+        };
+        mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
+        mockPrismaService.payment.count.mockResolvedValue(1);
+
+        const actualResult = await service.findAllForAdmin();
+
+        expect(actualResult.payments[0]).toEqual(
+          expect.objectContaining({
+            paymentAmountCents: null,
+            successfulRefundCents: 600,
+            pendingRefundCents: 100,
+            availableRefundCents: 0,
+            refundUnavailableReason:
+              'Refund unavailable because the stored payment amount is invalid or exceeds the supported refund range.',
+          })
+        );
+      });
+
+      it.each([-1, Number.NaN, Number.POSITIVE_INFINITY])(
+        'should keep invalid stored payment amount %s visible but unavailable',
+        async amount => {
+          const mockPayment = {
+            id: 'invalid-amount-payment',
+            amount,
+            currency: 'USD',
+            status: PaymentStatus.COMPLETED,
+            provider: PaymentProvider.PAYPAL,
+            externalMethod: null,
+            externalReference: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            userId: 'user-id',
+            registrationId: null,
+            user: {
+              id: 'user-id',
+              firstName: 'Invalid',
+              lastName: 'Payment',
+              email: 'invalid@example.com',
+            },
+            registration: null,
+            refunds: [],
+          };
+          mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
+          mockPrismaService.payment.count.mockResolvedValue(1);
+
+          const actualResult = await service.findAllForAdmin();
+
+          expect(actualResult.payments[0]).toEqual(
+            expect.objectContaining({
+              paymentAmountCents: null,
+              successfulRefundCents: 0,
+              pendingRefundCents: 0,
+              availableRefundCents: 0,
+              refundUnavailableReason:
+                'Refund unavailable because the stored payment amount is invalid or exceeds the supported refund range.',
+            })
+          );
+        }
+      );
+
       it('should keep a malformed stored currency visible but unavailable for refunds', async () => {
         const mockPayment = {
           id: 'legacy-currency-payment',
-          amount: 10,
+          amount: 0,
           currency: 'usd',
           status: PaymentStatus.COMPLETED,
           provider: PaymentProvider.PAYPAL,
@@ -514,7 +721,7 @@ describe('PaymentsService', () => {
           payments: [
             {
               ...mockPayment,
-              paymentAmountCents: 1000,
+              paymentAmountCents: 0,
               successfulRefundCents: 0,
               pendingRefundCents: 0,
               availableRefundCents: 0,

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -1146,7 +1146,11 @@ describe('PaymentsService', () => {
       });
       expect(mockStripeService.getCheckoutSession).toHaveBeenCalledWith(sessionId);
       expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
-        where: { id: mockPayment.id, status: PaymentStatus.PENDING },
+        where: {
+          id: mockPayment.id,
+          registrationId: null,
+          status: PaymentStatus.PENDING,
+        },
         data: { status: PaymentStatus.COMPLETED },
       });
 
@@ -1191,10 +1195,11 @@ describe('PaymentsService', () => {
       });
       expect(mockStripeService.getCheckoutSession).toHaveBeenCalledWith(sessionId);
 
-      // Should not update already completed payment
-      expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
-      // Transaction already tested: expect(mockPrismaService.$transaction).toHaveBeenCalled();
-      // Transaction already tested
+      expect(mockPrismaService.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      });
+      expect(mockPrismaService.payment.updateMany).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
 
       expect(result).toEqual({
         sessionId,
@@ -1422,6 +1427,110 @@ describe('PaymentsService', () => {
       });
     });
 
+    it('should reconcile the registration linked when the serializable transaction begins', async () => {
+      const initiallyLinkedPayment = {
+        ...mockPayment,
+        registration: mockRegistration,
+      };
+      const transactionRegistration = {
+        ...mockRegistration,
+        id: 'registration-b',
+      };
+      const transactionPayment = {
+        ...mockPayment,
+        registrationId: transactionRegistration.id,
+        registration: transactionRegistration,
+      };
+      let transactionStarted = false;
+      mockPrismaService.payment.findFirst.mockResolvedValue(initiallyLinkedPayment);
+      mockPrismaService.payment.findUnique.mockImplementation(async () => {
+        expect(transactionStarted).toBe(true);
+        return transactionPayment;
+      });
+      mockPrismaService.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) => {
+          transactionStarted = true;
+          return callback(mockPrismaService);
+        }
+      );
+      mockStripeService.getCheckoutSession.mockResolvedValue({
+        id: sessionId,
+        status: 'complete',
+        payment_status: 'paid',
+      });
+
+      const actualResult = await service.verifyStripeSession(sessionId);
+
+      expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: mockPayment.id,
+          registrationId: transactionRegistration.id,
+          status: PaymentStatus.PENDING,
+        },
+        data: { status: PaymentStatus.COMPLETED },
+      });
+      expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: transactionRegistration.id,
+          paymentDeferred: false,
+          status: RegistrationStatus.PENDING,
+        },
+        data: {
+          status: RegistrationStatus.CONFIRMED,
+          paymentDeferred: false,
+        },
+      });
+      expect(actualResult.registrationId).toBe(transactionRegistration.id);
+      expect(actualResult.registrationStatus).toBe(RegistrationStatus.CONFIRMED);
+    });
+
+    it('should reload the durable association when the registration identity guard loses a race', async () => {
+      const initiallyLinkedPayment = {
+        ...mockPayment,
+        registration: mockRegistration,
+      };
+      const relinkedRegistration = {
+        ...mockRegistration,
+        id: 'registration-b',
+        status: RegistrationStatus.WAITLISTED,
+      };
+      const relinkedPayment = {
+        ...mockPayment,
+        registrationId: relinkedRegistration.id,
+        registration: relinkedRegistration,
+      };
+      mockPrismaService.payment.findFirst.mockResolvedValue(initiallyLinkedPayment);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(initiallyLinkedPayment)
+        .mockResolvedValueOnce(relinkedPayment);
+      mockPrismaService.payment.updateMany.mockResolvedValue({ count: 0 });
+      mockStripeService.getCheckoutSession.mockResolvedValue({
+        id: sessionId,
+        status: 'complete',
+        payment_status: 'paid',
+      });
+
+      const actualResult = await service.verifyStripeSession(sessionId);
+
+      expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: mockPayment.id,
+          registrationId: mockRegistration.id,
+          status: PaymentStatus.PENDING,
+        },
+        data: { status: PaymentStatus.COMPLETED },
+      });
+      expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+      expect(actualResult).toEqual({
+        sessionId,
+        paymentStatus: PaymentStatus.PENDING,
+        registrationId: relinkedRegistration.id,
+        registrationStatus: RegistrationStatus.WAITLISTED,
+        paymentId: mockPayment.id,
+      });
+      expect(mockNotificationsService.sendRegistrationConfirmationEmail).not.toHaveBeenCalled();
+    });
+
     it.each([
       [PaymentStatus.FAILED, RegistrationStatus.CANCELLED],
       [PaymentStatus.PARTIALLY_REFUNDED, RegistrationStatus.PENDING],
@@ -1509,7 +1618,11 @@ describe('PaymentsService', () => {
         const actualResult = await service.verifyStripeSession(sessionId);
 
         expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
-          where: { id: mockPayment.id, status: PaymentStatus.PENDING },
+          where: {
+            id: mockPayment.id,
+            registrationId: mockRegistration.id,
+            status: PaymentStatus.PENDING,
+          },
           data: { status: PaymentStatus.COMPLETED },
         });
         expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
@@ -3044,6 +3157,14 @@ describe('PaymentsService', () => {
 
       await service.verifyStripeSession('cs_deferred_retry');
 
+      expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'payment-id',
+          registrationId: 'registration-id',
+          status: PaymentStatus.COMPLETED,
+        },
+        data: { status: PaymentStatus.COMPLETED },
+      });
       expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: {
@@ -3110,6 +3231,14 @@ describe('PaymentsService', () => {
 
       await service.verifyStripeSession('cs_waitlisted_pay');
 
+      expect(mockPrismaService.payment.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'payment-id',
+          registrationId: 'registration-id',
+          status: PaymentStatus.PENDING,
+        },
+        data: { status: PaymentStatus.COMPLETED },
+      });
       expect(mockPrismaService.registration.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: {
@@ -4213,6 +4342,16 @@ describe('PaymentsService', () => {
       };
     }
 
+    async function sanitizeStripeRefundRequest(
+      request: Record<string, unknown>
+    ): Promise<CreateRefundDto> {
+      const validationPipe = new GlobalValidationPipe();
+      return validationPipe.transform(request, {
+        type: 'body',
+        metatype: CreateRefundDto,
+      }) as Promise<CreateRefundDto>;
+    }
+
     beforeEach(() => {
       mockPrismaService.$transaction.mockImplementation(
         async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) =>
@@ -4345,6 +4484,51 @@ describe('PaymentsService', () => {
         });
       }
     );
+
+    it('should persist a Stripe refund reason at the exact post-sanitization limit', async () => {
+      const sanitizedRequest = await sanitizeStripeRefundRequest({
+        ...stripeRequest,
+        reason: '&'.repeat(100),
+      });
+
+      await service.createRefund(paymentId, sanitizedRequest, 'admin-id');
+
+      expect(sanitizedRequest.reason).toHaveLength(500);
+      expect(mockPrismaService.paymentRefund.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ reason: sanitizedRequest.reason }),
+        select: expect.any(Object),
+      });
+      expect(mockPrismaService.adminAudit.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          reason: sanitizedRequest.reason,
+          newValues: expect.objectContaining({ reason: sanitizedRequest.reason }),
+        }),
+      });
+      expect(mockStripeService.createAdminRefund).toHaveBeenCalledWith({
+        providerRefId: 'pi_original',
+        amountCents: 2500,
+        idempotencyKey,
+        localRefundId: refundId,
+      });
+    });
+
+    it('should reject a 501-character sanitized Stripe reason before reservation', async () => {
+      const sanitizedRequest = await sanitizeStripeRefundRequest({
+        ...stripeRequest,
+        reason: `${'&'.repeat(100)}x`,
+      });
+
+      expect(sanitizedRequest.reason).toHaveLength(501);
+      await expect(
+        service.createRefund(paymentId, sanitizedRequest, 'admin-id')
+      ).rejects.toThrow('reason must not exceed 500 characters after sanitization');
+
+      expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      expect(mockPrismaService.adminAudit.create).not.toHaveBeenCalled();
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
+      expect(mockStripeService.findAdminRefund).not.toHaveBeenCalled();
+    });
 
     it('should snapshot and submit the trimmed original Stripe target', async () => {
       mockPrismaService.payment.findUnique.mockResolvedValue({

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -31,6 +31,7 @@ const mockPrismaService = {
   paymentRefund: {
     findUnique: jest.fn(),
     create: jest.fn(),
+    updateMany: jest.fn(),
   },
   user: {
     findUnique: jest.fn(),
@@ -85,6 +86,8 @@ const mockStripeService = {
   createPaymentIntent: jest.fn(),
   createCheckoutSession: jest.fn(),
   createRefund: jest.fn(),
+  createAdminRefund: jest.fn(),
+  findAdminRefund: jest.fn(),
   getPaymentIntent: jest.fn(),
   getCheckoutSession: jest.fn(),
   constructEventFromWebhook: jest.fn(),
@@ -130,6 +133,7 @@ const expectedAdminPaymentSelect = {
   currency: true,
   status: true,
   provider: true,
+  providerRefId: true,
   externalMethod: true,
   externalReference: true,
   createdAt: true,
@@ -426,6 +430,7 @@ describe('PaymentsService', () => {
               pendingRefundCents: 1000,
               availableRefundCents: 9000,
               refundUnavailableReason: null,
+              stripeRefundEligible: false,
             },
           ],
           total: 1,
@@ -475,6 +480,7 @@ describe('PaymentsService', () => {
               availableRefundCents: 0,
               refundUnavailableReason:
                 'Refund unavailable because the stored payment amount has unsupported precision.',
+              stripeRefundEligible: false,
             },
           ],
           total: 1,
@@ -518,6 +524,7 @@ describe('PaymentsService', () => {
               availableRefundCents: 0,
               refundUnavailableReason:
                 'Refund unavailable because the stored payment currency is invalid.',
+              stripeRefundEligible: false,
             },
           ],
           total: 1,
@@ -3479,6 +3486,481 @@ describe('PaymentsService', () => {
           service.createManualRefund(paymentId, inputRequest, 'admin-id')
         ).rejects.toThrow(`Cannot refund payment with status ${inputStatus}`);
         expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe('Stripe refund command', () => {
+    const paymentId = '5f8d0d55-e0a3-4cf0-a620-2412acd4361c';
+    const refundId = '6a9e1e88-e8c0-43f1-9fe4-a2cad9703120';
+    const idempotencyKey = '43ea4b84-1f0d-413d-bc1c-9c91b435d66d';
+    const stripeRequest = {
+      amountCents: 2500,
+      executionMode: RefundExecutionMode.STRIPE,
+      reason: 'duplicate charge',
+      idempotencyKey,
+    };
+    const pendingRefund = {
+      id: refundId,
+      paymentId,
+      amountCents: 2500,
+      currency: 'USD',
+      executionMode: RefundExecutionMode.STRIPE,
+      status: PaymentRefundStatus.PENDING,
+      reason: 'duplicate charge',
+      externalReference: null,
+      providerRefundId: null,
+      idempotencyKey,
+      processedByUserId: 'admin-id',
+      resultingRegistrationStatus: null,
+      failureMessage: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const publicPendingRefund = {
+      id: refundId,
+      amountCents: 2500,
+      currency: 'USD',
+      executionMode: RefundExecutionMode.STRIPE,
+      status: PaymentRefundStatus.PENDING,
+      reason: 'duplicate charge',
+      externalReference: null,
+      resultingRegistrationStatus: null,
+      createdAt: pendingRefund.createdAt,
+      updatedAt: pendingRefund.updatedAt,
+    };
+    const stripePayment = {
+      id: paymentId,
+      amount: 100,
+      currency: 'USD',
+      status: PaymentStatus.COMPLETED,
+      provider: PaymentProvider.STRIPE,
+      providerRefId: 'pi_original',
+      externalMethod: null,
+      externalReference: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      userId: 'user-id',
+      registrationId: 'registration-id',
+      user: {
+        id: 'user-id',
+        firstName: 'Test',
+        lastName: 'User',
+        email: 'test@example.com',
+      },
+      registration: {
+        id: 'registration-id',
+        year: 2026,
+        status: RegistrationStatus.CONFIRMED,
+      },
+      refunds: [],
+    };
+
+    function buildStripePayment(
+      status: PaymentStatus,
+      refundStatus: PaymentRefundStatus
+    ) {
+      return {
+        ...stripePayment,
+        status,
+        refunds: [{ ...publicPendingRefund, status: refundStatus }],
+      };
+    }
+
+    beforeEach(() => {
+      mockPrismaService.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) =>
+          callback(mockPrismaService)
+      );
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(null);
+      mockPrismaService.paymentRefund.create.mockResolvedValue(pendingRefund);
+      mockPrismaService.paymentRefund.updateMany.mockResolvedValue({ count: 1 });
+      mockPrismaService.payment.findUnique.mockResolvedValue(stripePayment);
+      mockPrismaService.payment.update.mockResolvedValue(stripePayment);
+      mockPrismaService.adminAudit.create.mockResolvedValue({ id: 'audit-id' });
+      mockPrismaService.adminAudit.findFirst.mockResolvedValue({
+        newValues: { requestedFullRefund: false },
+      });
+      mockStripeService.createAdminRefund.mockResolvedValue({
+        outcome: 'PENDING_UNKNOWN',
+      });
+      mockStripeService.findAdminRefund.mockResolvedValue({
+        outcome: 'PENDING_UNKNOWN',
+      });
+    });
+
+    it('should reserve and audit before submitting outside the serializable transaction', async () => {
+      let transactionCompleted = false;
+      mockPrismaService.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) => {
+          const result = await callback(mockPrismaService);
+          transactionCompleted = true;
+          return result;
+        }
+      );
+      mockStripeService.createAdminRefund.mockImplementation(async () => {
+        expect(transactionCompleted).toBe(true);
+        return { outcome: 'PENDING_UNKNOWN' };
+      });
+
+      const actualResult = await service.createRefund(paymentId, stripeRequest, 'admin-id');
+
+      expect(mockPrismaService.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      });
+      expect(mockPrismaService.paymentRefund.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          paymentId,
+          amountCents: 2500,
+          currency: 'USD',
+          executionMode: RefundExecutionMode.STRIPE,
+          status: PaymentRefundStatus.PENDING,
+          idempotencyKey,
+        }),
+        select: expect.objectContaining({
+          providerRefundId: true,
+          failureMessage: true,
+        }),
+      });
+      expect(mockPrismaService.adminAudit.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          newValues: expect.objectContaining({
+            phase: 'ATTEMPT',
+            outcome: PaymentRefundStatus.PENDING,
+            refundId,
+          }),
+        }),
+      });
+      expect(mockStripeService.createAdminRefund).toHaveBeenCalledWith({
+        providerRefId: 'pi_original',
+        amountCents: 2500,
+        reason: 'duplicate charge',
+        idempotencyKey,
+        localRefundId: refundId,
+      });
+      expect(actualResult).toEqual(
+        expect.objectContaining({
+          outcome: 'PENDING_UNKNOWN',
+          pendingRefundCents: 2500,
+          availableRefundCents: 7500,
+        })
+      );
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('should finalize the same row and apply registration status only after Stripe succeeds', async () => {
+      const requestedStatus = RegistrationStatus.WAITLISTED;
+      const request = {
+        ...stripeRequest,
+        resultingRegistrationStatus: requestedStatus,
+      };
+      const pendingWithStatus = {
+        ...pendingRefund,
+        resultingRegistrationStatus: requestedStatus,
+      };
+      const succeededRefund = {
+        ...pendingWithStatus,
+        status: PaymentRefundStatus.SUCCEEDED,
+        providerRefundId: 're_provider',
+      };
+      mockPrismaService.paymentRefund.create.mockResolvedValue(pendingWithStatus);
+      mockPrismaService.paymentRefund.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(pendingWithStatus)
+        .mockResolvedValueOnce(succeededRefund);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(stripePayment)
+        .mockResolvedValueOnce({
+          ...stripePayment,
+          refunds: [{ ...publicPendingRefund, resultingRegistrationStatus: requestedStatus }],
+        })
+        .mockResolvedValueOnce({
+          ...buildStripePayment(
+            PaymentStatus.PARTIALLY_REFUNDED,
+            PaymentRefundStatus.SUCCEEDED
+          ),
+          registration: { ...stripePayment.registration, status: requestedStatus },
+        });
+      mockStripeService.createAdminRefund.mockResolvedValue({
+        outcome: 'SUCCEEDED',
+        providerRefundId: 're_provider',
+      });
+
+      const actualResult = await service.createRefund(paymentId, request, 'admin-id');
+
+      expect(mockPrismaService.paymentRefund.updateMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          id: refundId,
+          status: PaymentRefundStatus.PENDING,
+        }),
+        data: {
+          status: PaymentRefundStatus.SUCCEEDED,
+          providerRefundId: 're_provider',
+          failureMessage: null,
+        },
+      });
+      expect(mockPrismaService.payment.update).toHaveBeenCalledWith({
+        where: { id: paymentId },
+        data: { status: PaymentStatus.PARTIALLY_REFUNDED },
+      });
+      expect(mockPrismaService.registration.update).toHaveBeenCalledWith({
+        where: { id: 'registration-id' },
+        data: { status: requestedStatus },
+      });
+      expect(mockPrismaService.adminAudit.create).toHaveBeenLastCalledWith({
+        data: expect.objectContaining({
+          newValues: expect.objectContaining({
+            phase: 'RESULT',
+            outcome: PaymentRefundStatus.SUCCEEDED,
+            providerRefundId: 're_provider',
+          }),
+        }),
+      });
+      expect(actualResult.outcome).toBe('SUCCEEDED');
+      expect(actualResult.refund).not.toHaveProperty('providerRefundId');
+    });
+
+    it('should fail a definite rejection, release the reservation, and preserve payment state', async () => {
+      const failedRefund = {
+        ...pendingRefund,
+        status: PaymentRefundStatus.FAILED,
+        failureMessage: 'Stripe rejected the refund request',
+      };
+      mockPrismaService.paymentRefund.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(pendingRefund)
+        .mockResolvedValueOnce(failedRefund);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(stripePayment)
+        .mockResolvedValueOnce(buildStripePayment(PaymentStatus.COMPLETED, PaymentRefundStatus.PENDING))
+        .mockResolvedValueOnce(buildStripePayment(PaymentStatus.COMPLETED, PaymentRefundStatus.FAILED));
+      mockStripeService.createAdminRefund.mockResolvedValue({
+        outcome: 'FAILED',
+        failureMessage: 'Stripe rejected the refund request',
+      });
+
+      const actualResult = await service.createRefund(paymentId, stripeRequest, 'admin-id');
+
+      expect(mockPrismaService.paymentRefund.updateMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({ id: refundId }),
+        data: {
+          status: PaymentRefundStatus.FAILED,
+          failureMessage: 'Stripe rejected the refund request',
+        },
+      });
+      expect(mockPrismaService.payment.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.registration.update).not.toHaveBeenCalled();
+      expect(actualResult).toEqual(
+        expect.objectContaining({
+          outcome: 'FAILED',
+          pendingRefundCents: 0,
+          availableRefundCents: 10000,
+        })
+      );
+      expect(actualResult.refund).not.toHaveProperty('failureMessage');
+    });
+
+    it('should return an idempotent pending replay without another Stripe submission', async () => {
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(pendingRefund);
+      mockPrismaService.payment.findUnique.mockResolvedValue(
+        buildStripePayment(PaymentStatus.COMPLETED, PaymentRefundStatus.PENDING)
+      );
+
+      const actualResult = await service.createRefund(paymentId, stripeRequest, 'admin-id');
+
+      expect(actualResult.outcome).toBe('PENDING_UNKNOWN');
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
+    });
+
+    it('should return a terminal full-refund replay without depending on the current balance', async () => {
+      const failedFullRefund = {
+        ...pendingRefund,
+        amountCents: 10000,
+        status: PaymentRefundStatus.FAILED,
+      };
+      const otherSuccessfulRefund = {
+        ...publicPendingRefund,
+        id: 'other-refund',
+        amountCents: 1000,
+        status: PaymentRefundStatus.SUCCEEDED,
+      };
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(failedFullRefund);
+      mockPrismaService.payment.findUnique.mockResolvedValue({
+        ...stripePayment,
+        status: PaymentStatus.PARTIALLY_REFUNDED,
+        refunds: [
+          {
+            ...publicPendingRefund,
+            amountCents: 10000,
+            status: PaymentRefundStatus.FAILED,
+          },
+          otherSuccessfulRefund,
+        ],
+      });
+      mockPrismaService.adminAudit.findFirst.mockResolvedValue({
+        newValues: { requestedFullRefund: true },
+      });
+
+      const actualResult = await service.createRefund(
+        paymentId,
+        {
+          fullRefund: true,
+          executionMode: RefundExecutionMode.STRIPE,
+          reason: 'duplicate charge',
+          idempotencyKey,
+        },
+        'admin-id'
+      );
+
+      expect(actualResult.outcome).toBe('FAILED');
+      expect(mockPrismaService.adminAudit.findFirst).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          newValues: {
+            path: ['phase'],
+            equals: 'ATTEMPT',
+          },
+        }),
+        select: { newValues: true },
+      });
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [{ ...stripePayment, provider: PaymentProvider.PAYPAL }, 'original STRIPE payment'],
+      [{ ...stripePayment, providerRefId: ' ' }, 'usable provider reference'],
+      [{ ...stripePayment, currency: 'usd' }, 'stored payment currency'],
+      [{ ...stripePayment, amount: 10.001 }, 'sub-cent precision'],
+    ])('should reject ineligible Stripe payment data', async (inputPayment, expectedMessage) => {
+      mockPrismaService.payment.findUnique.mockResolvedValue(inputPayment);
+
+      await expect(
+        service.createRefund(paymentId, stripeRequest, 'admin-id')
+      ).rejects.toThrow(expectedMessage);
+      expect(mockPrismaService.paymentRefund.create).not.toHaveBeenCalled();
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
+    });
+
+    it('should inspect metadata first and finalize a matching pending retry', async () => {
+      const paymentWithPending = buildStripePayment(
+        PaymentStatus.COMPLETED,
+        PaymentRefundStatus.PENDING
+      );
+      const succeededRefund = {
+        ...pendingRefund,
+        status: PaymentRefundStatus.SUCCEEDED,
+        providerRefundId: 're_found',
+      };
+      mockPrismaService.paymentRefund.findUnique
+        .mockResolvedValueOnce(pendingRefund)
+        .mockResolvedValueOnce(pendingRefund)
+        .mockResolvedValueOnce(succeededRefund);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(paymentWithPending)
+        .mockResolvedValueOnce(paymentWithPending)
+        .mockResolvedValueOnce(
+          buildStripePayment(
+            PaymentStatus.PARTIALLY_REFUNDED,
+            PaymentRefundStatus.SUCCEEDED
+          )
+        );
+      mockStripeService.findAdminRefund.mockResolvedValue({
+        outcome: 'FOUND',
+        providerRefundId: 're_found',
+      });
+
+      const actualResult = await service.retryStripeRefund(
+        paymentId,
+        refundId,
+        'retry-admin'
+      );
+
+      expect(mockStripeService.findAdminRefund).toHaveBeenCalledWith('pi_original', refundId);
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
+      expect(actualResult.outcome).toBe('SUCCEEDED');
+    });
+
+    it('should resubmit the exact stored request with the same key only after inspection misses', async () => {
+      const paymentWithPending = buildStripePayment(
+        PaymentStatus.COMPLETED,
+        PaymentRefundStatus.PENDING
+      );
+      mockPrismaService.paymentRefund.findUnique.mockResolvedValue(pendingRefund);
+      mockPrismaService.payment.findUnique.mockResolvedValue(paymentWithPending);
+      mockStripeService.findAdminRefund.mockResolvedValue({ outcome: 'NOT_FOUND' });
+      mockStripeService.createAdminRefund.mockResolvedValue({
+        outcome: 'PENDING_UNKNOWN',
+      });
+
+      const actualResult = await service.retryStripeRefund(
+        paymentId,
+        refundId,
+        'retry-admin'
+      );
+
+      expect(mockStripeService.createAdminRefund).toHaveBeenCalledWith({
+        providerRefId: 'pi_original',
+        amountCents: 2500,
+        reason: 'duplicate charge',
+        idempotencyKey,
+        localRefundId: refundId,
+      });
+      expect(actualResult.outcome).toBe('PENDING_UNKNOWN');
+    });
+
+    it('should fail the reservation when inspection finds a terminal Stripe failure', async () => {
+      const paymentWithPending = buildStripePayment(
+        PaymentStatus.COMPLETED,
+        PaymentRefundStatus.PENDING
+      );
+      const failedRefund = {
+        ...pendingRefund,
+        status: PaymentRefundStatus.FAILED,
+        failureMessage: 'Stripe rejected the refund request with status failed',
+      };
+      mockPrismaService.paymentRefund.findUnique
+        .mockResolvedValueOnce(pendingRefund)
+        .mockResolvedValueOnce(pendingRefund)
+        .mockResolvedValueOnce(failedRefund);
+      mockPrismaService.payment.findUnique
+        .mockResolvedValueOnce(paymentWithPending)
+        .mockResolvedValueOnce(paymentWithPending)
+        .mockResolvedValueOnce(
+          buildStripePayment(PaymentStatus.COMPLETED, PaymentRefundStatus.FAILED)
+        );
+      mockStripeService.findAdminRefund.mockResolvedValue({
+        outcome: 'FAILED',
+        failureMessage: 'Stripe rejected the refund request with status failed',
+      });
+
+      const actualResult = await service.retryStripeRefund(
+        paymentId,
+        refundId,
+        'retry-admin'
+      );
+
+      expect(actualResult.outcome).toBe('FAILED');
+      expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
+    });
+
+    it.each([PaymentRefundStatus.SUCCEEDED, PaymentRefundStatus.FAILED])(
+      'should return terminal retry status %s unchanged',
+      async terminalStatus => {
+        const terminalRefund = { ...pendingRefund, status: terminalStatus };
+        mockPrismaService.paymentRefund.findUnique.mockResolvedValue(terminalRefund);
+        mockPrismaService.payment.findUnique.mockResolvedValue(
+          buildStripePayment(PaymentStatus.PARTIALLY_REFUNDED, terminalStatus)
+        );
+
+        const actualResult = await service.retryStripeRefund(
+          paymentId,
+          refundId,
+          'retry-admin'
+        );
+
+        expect(actualResult.outcome).toBe(terminalStatus);
+        expect(mockStripeService.findAdminRefund).not.toHaveBeenCalled();
+        expect(mockStripeService.createAdminRefund).not.toHaveBeenCalled();
       }
     );
   });

--- a/apps/api/src/payments/services/payments.service.spec.ts
+++ b/apps/api/src/payments/services/payments.service.spec.ts
@@ -526,6 +526,133 @@ describe('PaymentsService', () => {
         });
       });
 
+      it('should report durable refund totals for a refunded payment with ledger rows', async () => {
+        const mockPayment = {
+          id: 'ledger-backed-refunded-payment',
+          amount: 125,
+          currency: 'USD',
+          status: PaymentStatus.REFUNDED,
+          provider: PaymentProvider.STRIPE,
+          externalMethod: null,
+          externalReference: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 'user-id',
+          registrationId: null,
+          user: {
+            id: 'user-id',
+            firstName: 'Test',
+            lastName: 'User',
+            email: 'test@example.com',
+          },
+          registration: null,
+          refunds: [
+            {
+              id: 'succeeded-refund',
+              amountCents: 10000,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.MANUAL,
+              status: PaymentRefundStatus.SUCCEEDED,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              id: 'pending-refund',
+              amountCents: 2500,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.STRIPE,
+              status: PaymentRefundStatus.PENDING,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+        };
+        mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
+        mockPrismaService.payment.count.mockResolvedValue(1);
+
+        const actualResult = await service.findAllForAdmin();
+
+        expect(actualResult.payments[0]).toEqual(
+          expect.objectContaining({
+            paymentAmountCents: 12500,
+            successfulRefundCents: 10000,
+            pendingRefundCents: 2500,
+            availableRefundCents: 0,
+            refundUnavailableReason: null,
+          })
+        );
+      });
+
+      it('should preserve durable refund totals for a refunded payment with invalid currency', async () => {
+        const mockPayment = {
+          id: 'invalid-currency-ledger-backed-refunded-payment',
+          amount: 125,
+          currency: 'usd',
+          status: PaymentStatus.REFUNDED,
+          provider: PaymentProvider.STRIPE,
+          externalMethod: null,
+          externalReference: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 'user-id',
+          registrationId: null,
+          user: {
+            id: 'user-id',
+            firstName: 'Test',
+            lastName: 'User',
+            email: 'test@example.com',
+          },
+          registration: null,
+          refunds: [
+            {
+              id: 'succeeded-refund',
+              amountCents: 10000,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.MANUAL,
+              status: PaymentRefundStatus.SUCCEEDED,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              id: 'pending-refund',
+              amountCents: 2500,
+              currency: 'USD',
+              executionMode: RefundExecutionMode.STRIPE,
+              status: PaymentRefundStatus.PENDING,
+              reason: null,
+              externalReference: null,
+              resultingRegistrationStatus: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+        };
+        mockPrismaService.payment.findMany.mockResolvedValue([mockPayment]);
+        mockPrismaService.payment.count.mockResolvedValue(1);
+
+        const actualResult = await service.findAllForAdmin();
+
+        expect(actualResult.payments[0]).toEqual(
+          expect.objectContaining({
+            paymentAmountCents: 12500,
+            successfulRefundCents: 10000,
+            pendingRefundCents: 2500,
+            availableRefundCents: 0,
+            refundUnavailableReason:
+              'Refund unavailable because the stored payment currency is invalid.',
+          })
+        );
+      });
+
       it('should report legacy ledgerless refunded payments as fully refunded', async () => {
         const mockPayment = {
           id: 'legacy-refunded-payment',
@@ -559,6 +686,7 @@ describe('PaymentsService', () => {
             successfulRefundCents: 12500,
             pendingRefundCents: 0,
             availableRefundCents: 0,
+            refundUnavailableReason: null,
             refunds: [],
           })
         );

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -91,6 +91,9 @@ const internalRefundSelect = {
   ...adminRefundSelect,
   paymentId: true,
   idempotencyKey: true,
+  providerRefundId: true,
+  processedByUserId: true,
+  failureMessage: true,
 } satisfies Prisma.PaymentRefundSelect;
 
 const adminPaymentSelect = {
@@ -99,6 +102,7 @@ const adminPaymentSelect = {
   currency: true,
   status: true,
   provider: true,
+  providerRefId: true,
   externalMethod: true,
   externalReference: true,
   createdAt: true,
@@ -161,11 +165,17 @@ interface RefundTotals {
   refundUnavailableReason: string | null;
 }
 
-export type AdminPayment = AdminPaymentRecord & RefundTotals;
+export type AdminPayment = Omit<AdminPaymentRecord, 'providerRefId'> &
+  RefundTotals & {
+    stripeRefundEligible: boolean;
+  };
+
+export type RefundCommandOutcome = 'SUCCEEDED' | 'FAILED' | 'PENDING_UNKNOWN';
 
 export interface ManualRefundResult extends RefundTotals {
   payment: AdminPayment;
   refund: AdminRefund;
+  outcome: RefundCommandOutcome;
 }
 
 interface CanonicalExternalPayment {
@@ -183,6 +193,22 @@ interface CanonicalManualRefund {
   reason: string | null;
   externalReference: string | null;
   resultingRegistrationStatus: RegistrationStatus | null;
+}
+
+interface CanonicalStripeRefund {
+  amountCents?: number;
+  fullRefund: boolean;
+  executionMode: RefundExecutionMode;
+  reason: string | null;
+  externalReference: null;
+  resultingRegistrationStatus: RegistrationStatus | null;
+}
+
+interface StripeRefundReservation {
+  payment: AdminPaymentRecord;
+  refund: InternalRefundRecord;
+  providerRefId: string;
+  shouldSubmit: boolean;
 }
 
 interface LegacyRefundRequest {
@@ -683,6 +709,14 @@ export class PaymentsService {
 
   private toAdminPayment(payment: AdminPaymentRecord | ExternalPaymentRecord): AdminPayment {
     const totals = this.getAdminRefundTotals(payment);
+    const stripeRefundEligible =
+      payment.provider === PaymentProvider.STRIPE &&
+      typeof payment.providerRefId === 'string' &&
+      payment.providerRefId.trim().length > 0 &&
+      (payment.status === PaymentStatus.COMPLETED ||
+        payment.status === PaymentStatus.PARTIALLY_REFUNDED) &&
+      totals.refundUnavailableReason === null &&
+      totals.availableRefundCents > 0;
 
     return {
       id: payment.id,
@@ -700,6 +734,7 @@ export class PaymentsService {
       registration: payment.registration,
       refunds: payment.refunds,
       ...totals,
+      stripeRefundEligible,
     };
   }
 
@@ -833,6 +868,24 @@ export class PaymentsService {
 
   private isUniqueConstraintError(error: unknown): boolean {
     return typeof error === 'object' && error !== null && 'code' in error && error.code === 'P2002';
+  }
+
+  /**
+   * Dispatches the nested admin refund command by execution mode.
+   */
+  async createRefund(
+    paymentId: string,
+    data: CreateRefundDto,
+    adminUserId: string
+  ): Promise<ManualRefundResult> {
+    if (data.executionMode === RefundExecutionMode.MANUAL) {
+      return this.createManualRefund(paymentId, data, adminUserId);
+    }
+    if (data.executionMode === RefundExecutionMode.STRIPE) {
+      return this.createStripeRefund(paymentId, data, adminUserId);
+    }
+
+    throw new BadRequestException('executionMode must be MANUAL or STRIPE');
   }
 
   /**
@@ -1122,13 +1175,8 @@ export class PaymentsService {
     canonicalRequest: CanonicalManualRefund
   ): ManualRefundResult {
     const requestedFullRefund = this.getRequestedFullRefundFromAudit(auditValues);
-    const amountMatches = canonicalRequest.fullRefund
-      ? existingRefund.amountCents ===
-        this.calculateRefundTotals(
-          this.getPaymentAmountCents(payment.amount),
-          payment.refunds.filter(refund => refund.id !== existingRefund.id)
-        ).availableRefundCents
-      : existingRefund.amountCents === canonicalRequest.amountCents;
+    const amountMatches =
+      canonicalRequest.fullRefund || existingRefund.amountCents === canonicalRequest.amountCents;
 
     if (
       requestedFullRefund === null ||
@@ -1188,6 +1236,12 @@ export class PaymentsService {
       pendingRefundCents: adminPayment.pendingRefundCents,
       availableRefundCents: adminPayment.availableRefundCents,
       refundUnavailableReason: adminPayment.refundUnavailableReason,
+      outcome:
+        refund.status === PaymentRefundStatus.SUCCEEDED
+          ? 'SUCCEEDED'
+          : refund.status === PaymentRefundStatus.FAILED
+            ? 'FAILED'
+            : 'PENDING_UNKNOWN',
     };
   }
 
@@ -1235,6 +1289,671 @@ export class PaymentsService {
       replayAudit?.newValues,
       canonicalRequest
     );
+  }
+
+  private async createStripeRefund(
+    paymentId: string,
+    data: CreateRefundDto,
+    adminUserId: string
+  ): Promise<ManualRefundResult> {
+    const canonicalRequest = this.canonicalizeStripeRefund(data);
+    let reservation: StripeRefundReservation;
+
+    try {
+      reservation = await this.reserveStripeRefund(
+        paymentId,
+        data.idempotencyKey,
+        canonicalRequest,
+        adminUserId
+      );
+    } catch (error: unknown) {
+      if (this.isSerializationConflict(error)) {
+        throw new ConflictException(
+          'Refund balance changed concurrently; refresh the payment and retry'
+        );
+      }
+      if (!this.isUniqueConstraintError(error)) {
+        throw error;
+      }
+
+      const replay = await this.findStripeRefundReplay(
+        paymentId,
+        data.idempotencyKey,
+        canonicalRequest
+      );
+      if (!replay) {
+        throw error;
+      }
+      reservation = replay;
+    }
+
+    if (!reservation.shouldSubmit) {
+      return this.buildManualRefundResult(reservation.payment, reservation.refund);
+    }
+
+    return this.submitStripeRefund(reservation, adminUserId);
+  }
+
+  private canonicalizeStripeRefund(data: CreateRefundDto): CanonicalStripeRefund {
+    if (data.executionMode !== RefundExecutionMode.STRIPE) {
+      throw new BadRequestException('Stripe refund requires STRIPE executionMode');
+    }
+    if (data.externalReference !== undefined) {
+      throw new BadRequestException('externalReference is supported only for MANUAL refunds');
+    }
+
+    const hasAmount = data.amountCents !== undefined;
+    const hasFullRefund = data.fullRefund !== undefined;
+    if (
+      hasAmount === hasFullRefund ||
+      (hasAmount && (!Number.isSafeInteger(data.amountCents) || (data.amountCents ?? 0) <= 0)) ||
+      (hasFullRefund && data.fullRefund !== true)
+    ) {
+      throw new BadRequestException(
+        'Provide exactly one of a positive integer amountCents or fullRefund: true'
+      );
+    }
+
+    this.validateResultingRegistrationStatus(data.resultingRegistrationStatus);
+
+    return {
+      amountCents: data.amountCents,
+      fullRefund: data.fullRefund === true,
+      executionMode: RefundExecutionMode.STRIPE,
+      reason: data.reason?.trim() || null,
+      externalReference: null,
+      resultingRegistrationStatus: data.resultingRegistrationStatus ?? null,
+    };
+  }
+
+  private async reserveStripeRefund(
+    paymentId: string,
+    idempotencyKey: string,
+    canonicalRequest: CanonicalStripeRefund,
+    adminUserId: string
+  ): Promise<StripeRefundReservation> {
+    return this.prisma.$transaction(
+      async tx => {
+        const existingRefund = await tx.paymentRefund.findUnique({
+          where: { idempotencyKey },
+          select: internalRefundSelect,
+        });
+        if (existingRefund && existingRefund.paymentId !== paymentId) {
+          throw new ConflictException(
+            'Idempotency key has already been used with different refund data'
+          );
+        }
+
+        const payment = await tx.payment.findUnique({
+          where: { id: paymentId },
+          select: adminPaymentSelect,
+        });
+        if (!payment) {
+          throw new NotFoundException(`Payment with ID ${paymentId} not found`);
+        }
+
+        if (existingRefund) {
+          const replayAudit = await tx.adminAudit.findFirst({
+            where: {
+              transactionId: idempotencyKey,
+              actionType: AdminAuditActionType.PAYMENT_REFUND,
+              targetRecordType: AdminAuditTargetType.PAYMENT,
+              targetRecordId: paymentId,
+              newValues: {
+                path: ['phase'],
+                equals: 'ATTEMPT',
+              },
+            },
+            select: { newValues: true },
+          });
+          this.validateStripeRefundReplay(
+            existingRefund,
+            replayAudit?.newValues,
+            canonicalRequest
+          );
+          return {
+            payment,
+            refund: existingRefund,
+            providerRefId: payment.providerRefId ?? '',
+            shouldSubmit: false,
+          };
+        }
+
+        const providerRefId = this.validateStripeRefundPayment(payment);
+        this.validateManualRefundRegistration(
+          payment.registrationId,
+          payment.registration?.status ?? null,
+          canonicalRequest.resultingRegistrationStatus
+        );
+
+        const paymentCurrency = this.getPaymentCurrency(payment.currency);
+        const paymentAmountCents = this.getPaymentAmountCents(payment.amount);
+        const currentTotals = this.calculateRefundTotals(paymentAmountCents, payment.refunds);
+        if (currentTotals.availableRefundCents <= 0) {
+          throw new BadRequestException('Payment has no refundable balance available');
+        }
+
+        const refundAmountCents = canonicalRequest.fullRefund
+          ? currentTotals.availableRefundCents
+          : canonicalRequest.amountCents;
+        if (
+          refundAmountCents === undefined ||
+          refundAmountCents > currentTotals.availableRefundCents
+        ) {
+          throw new BadRequestException(
+            `Refund amount exceeds available balance of ${currentTotals.availableRefundCents} cents`
+          );
+        }
+
+        const createdRefund = await tx.paymentRefund.create({
+          data: {
+            paymentId,
+            amountCents: refundAmountCents,
+            currency: paymentCurrency,
+            executionMode: RefundExecutionMode.STRIPE,
+            status: PaymentRefundStatus.PENDING,
+            reason: canonicalRequest.reason,
+            externalReference: null,
+            idempotencyKey,
+            processedByUserId: adminUserId,
+            resultingRegistrationStatus: canonicalRequest.resultingRegistrationStatus,
+          },
+          select: internalRefundSelect,
+        });
+
+        await tx.adminAudit.create({
+          data: {
+            adminUserId,
+            actionType: AdminAuditActionType.PAYMENT_REFUND,
+            targetRecordType: AdminAuditTargetType.PAYMENT,
+            targetRecordId: paymentId,
+            transactionId: idempotencyKey,
+            newValues: {
+              phase: 'ATTEMPT',
+              outcome: PaymentRefundStatus.PENDING,
+              paymentId,
+              refundId: createdRefund.id,
+              registrationId: payment.registrationId,
+              amountCents: refundAmountCents,
+              currency: paymentCurrency,
+              executionMode: RefundExecutionMode.STRIPE,
+              reason: canonicalRequest.reason,
+              resultingRegistrationStatus: canonicalRequest.resultingRegistrationStatus,
+              requestedFullRefund: canonicalRequest.fullRefund,
+            },
+            reason: canonicalRequest.reason,
+          },
+        });
+
+        return {
+          payment: {
+            ...payment,
+            refunds: [...payment.refunds, this.toAdminRefund(createdRefund)],
+          },
+          refund: createdRefund,
+          providerRefId,
+          shouldSubmit: true,
+        };
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
+  }
+
+  private validateStripeRefundPayment(payment: AdminPaymentRecord): string {
+    this.validateManualRefundPayment(payment.status);
+    if (payment.provider !== PaymentProvider.STRIPE) {
+      throw new BadRequestException('Stripe refunds require an original STRIPE payment');
+    }
+
+    const providerRefId = payment.providerRefId?.trim();
+    if (!providerRefId) {
+      throw new BadRequestException('Stripe payment has no usable provider reference');
+    }
+    return providerRefId;
+  }
+
+  private validateStripeRefundReplay(
+    existingRefund: InternalRefundRecord,
+    auditValues: Prisma.JsonValue | null | undefined,
+    canonicalRequest: CanonicalStripeRefund
+  ): void {
+    const requestedFullRefund = this.getRequestedFullRefundFromAudit(auditValues);
+    const amountMatches = canonicalRequest.fullRefund
+      ? true
+      : existingRefund.amountCents === canonicalRequest.amountCents;
+
+    if (
+      requestedFullRefund === null ||
+      requestedFullRefund !== canonicalRequest.fullRefund ||
+      !amountMatches ||
+      existingRefund.executionMode !== RefundExecutionMode.STRIPE ||
+      existingRefund.reason !== canonicalRequest.reason ||
+      existingRefund.externalReference !== null ||
+      existingRefund.resultingRegistrationStatus !== canonicalRequest.resultingRegistrationStatus
+    ) {
+      throw new ConflictException(
+        'Idempotency key has already been used with different refund data'
+      );
+    }
+  }
+
+  private async findStripeRefundReplay(
+    paymentId: string,
+    idempotencyKey: string,
+    canonicalRequest: CanonicalStripeRefund
+  ): Promise<StripeRefundReservation | null> {
+    const existingRefund = await this.prisma.paymentRefund.findUnique({
+      where: { idempotencyKey },
+      select: internalRefundSelect,
+    });
+    if (!existingRefund) {
+      return null;
+    }
+    if (existingRefund.paymentId !== paymentId) {
+      throw new ConflictException(
+        'Idempotency key has already been used with different refund data'
+      );
+    }
+
+    const [payment, replayAudit] = await Promise.all([
+      this.prisma.payment.findUnique({
+        where: { id: paymentId },
+        select: adminPaymentSelect,
+      }),
+      this.prisma.adminAudit.findFirst({
+        where: {
+          transactionId: idempotencyKey,
+          actionType: AdminAuditActionType.PAYMENT_REFUND,
+          targetRecordType: AdminAuditTargetType.PAYMENT,
+          targetRecordId: paymentId,
+          newValues: {
+            path: ['phase'],
+            equals: 'ATTEMPT',
+          },
+        },
+        select: { newValues: true },
+      }),
+    ]);
+    if (!payment) {
+      throw new NotFoundException(`Payment with ID ${paymentId} not found`);
+    }
+    this.validateStripeRefundReplay(
+      existingRefund,
+      replayAudit?.newValues,
+      canonicalRequest
+    );
+    return {
+      payment,
+      refund: existingRefund,
+      providerRefId: payment.providerRefId ?? '',
+      shouldSubmit: false,
+    };
+  }
+
+  private async submitStripeRefund(
+    reservation: StripeRefundReservation,
+    adminUserId: string
+  ): Promise<ManualRefundResult> {
+    const stripeResult = await this.stripeService.createAdminRefund({
+      providerRefId: reservation.providerRefId,
+      amountCents: reservation.refund.amountCents,
+      reason: reservation.refund.reason,
+      idempotencyKey: reservation.refund.idempotencyKey,
+      localRefundId: reservation.refund.id,
+    });
+
+    if (stripeResult.outcome === 'PENDING_UNKNOWN') {
+      return this.buildManualRefundResult(reservation.payment, reservation.refund);
+    }
+
+    try {
+      if (stripeResult.outcome === 'SUCCEEDED') {
+        return await this.finalizeStripeRefund(
+          reservation.payment.id,
+          reservation.refund.id,
+          stripeResult.providerRefundId,
+          adminUserId
+        );
+      }
+
+      return await this.failStripeRefund(
+        reservation.payment.id,
+        reservation.refund.id,
+        stripeResult.failureMessage,
+        adminUserId
+      );
+    } catch (error: unknown) {
+      this.logger.error(
+        `Stripe refund ${reservation.refund.id} requires local reconciliation`,
+        error instanceof Error ? error.stack : undefined
+      );
+      return this.buildManualRefundResult(reservation.payment, reservation.refund);
+    }
+  }
+
+  private async finalizeStripeRefund(
+    paymentId: string,
+    refundId: string,
+    providerRefundId: string,
+    adminUserId: string
+  ): Promise<ManualRefundResult> {
+    return this.prisma.$transaction(
+      async tx => {
+        const refund = await tx.paymentRefund.findUnique({
+          where: { id: refundId },
+          select: internalRefundSelect,
+        });
+        if (!refund || refund.paymentId !== paymentId) {
+          throw new NotFoundException(`Refund with ID ${refundId} not found for payment ${paymentId}`);
+        }
+
+        const payment = await tx.payment.findUnique({
+          where: { id: paymentId },
+          select: adminPaymentSelect,
+        });
+        if (!payment) {
+          throw new NotFoundException(`Payment with ID ${paymentId} not found`);
+        }
+        if (refund.status !== PaymentRefundStatus.PENDING) {
+          return this.buildManualRefundResult(payment, refund);
+        }
+        if (refund.executionMode !== RefundExecutionMode.STRIPE) {
+          throw new BadRequestException('Only pending STRIPE refunds can be finalized');
+        }
+
+        const transition = await tx.paymentRefund.updateMany({
+          where: {
+            id: refundId,
+            paymentId,
+            status: PaymentRefundStatus.PENDING,
+            executionMode: RefundExecutionMode.STRIPE,
+          },
+          data: {
+            status: PaymentRefundStatus.SUCCEEDED,
+            providerRefundId,
+            failureMessage: null,
+          },
+        });
+        if (transition.count !== 1) {
+          const concurrentRefund = await tx.paymentRefund.findUnique({
+            where: { id: refundId },
+            select: internalRefundSelect,
+          });
+          if (!concurrentRefund) {
+            throw new NotFoundException(`Refund with ID ${refundId} not found`);
+          }
+          return this.buildManualRefundResult(payment, concurrentRefund);
+        }
+
+        const updatedLedger = payment.refunds.map(existingRefund =>
+          existingRefund.id === refundId
+            ? { ...existingRefund, status: PaymentRefundStatus.SUCCEEDED }
+            : existingRefund
+        );
+        const paymentAmountCents = this.getPaymentAmountCents(payment.amount);
+        const ledgerTotals = this.calculateRefundLedgerTotals(updatedLedger);
+        if (ledgerTotals.successfulRefundCents > paymentAmountCents) {
+          throw new ConflictException('Successful refund ledger exceeds the original payment amount');
+        }
+        const resultingPaymentStatus =
+          ledgerTotals.successfulRefundCents === paymentAmountCents
+            ? PaymentStatus.REFUNDED
+            : PaymentStatus.PARTIALLY_REFUNDED;
+
+        await tx.payment.update({
+          where: { id: paymentId },
+          data: { status: resultingPaymentStatus },
+        });
+        if (payment.registrationId && refund.resultingRegistrationStatus) {
+          await tx.registration.update({
+            where: { id: payment.registrationId },
+            data: { status: refund.resultingRegistrationStatus },
+          });
+        }
+
+        await tx.adminAudit.create({
+          data: {
+            adminUserId,
+            actionType: AdminAuditActionType.PAYMENT_REFUND,
+            targetRecordType: AdminAuditTargetType.PAYMENT,
+            targetRecordId: paymentId,
+            transactionId: refund.idempotencyKey,
+            newValues: {
+              phase: 'RESULT',
+              outcome: PaymentRefundStatus.SUCCEEDED,
+              paymentId,
+              refundId,
+              registrationId: payment.registrationId,
+              amountCents: refund.amountCents,
+              currency: refund.currency,
+              executionMode: RefundExecutionMode.STRIPE,
+              reason: refund.reason,
+              resultingRegistrationStatus: refund.resultingRegistrationStatus,
+              providerRefundId,
+            },
+            reason: refund.reason,
+          },
+        });
+
+        const [updatedPayment, updatedRefund] = await Promise.all([
+          tx.payment.findUnique({
+            where: { id: paymentId },
+            select: adminPaymentSelect,
+          }),
+          tx.paymentRefund.findUnique({
+            where: { id: refundId },
+            select: internalRefundSelect,
+          }),
+        ]);
+        if (!updatedPayment || !updatedRefund) {
+          throw new NotFoundException('Refund result could not be reloaded');
+        }
+
+        return this.buildManualRefundResult(updatedPayment, updatedRefund);
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
+  }
+
+  private async failStripeRefund(
+    paymentId: string,
+    refundId: string,
+    failureMessage: string,
+    adminUserId: string
+  ): Promise<ManualRefundResult> {
+    return this.prisma.$transaction(
+      async tx => {
+        const refund = await tx.paymentRefund.findUnique({
+          where: { id: refundId },
+          select: internalRefundSelect,
+        });
+        if (!refund || refund.paymentId !== paymentId) {
+          throw new NotFoundException(`Refund with ID ${refundId} not found for payment ${paymentId}`);
+        }
+        const payment = await tx.payment.findUnique({
+          where: { id: paymentId },
+          select: adminPaymentSelect,
+        });
+        if (!payment) {
+          throw new NotFoundException(`Payment with ID ${paymentId} not found`);
+        }
+        if (refund.status !== PaymentRefundStatus.PENDING) {
+          return this.buildManualRefundResult(payment, refund);
+        }
+        if (refund.executionMode !== RefundExecutionMode.STRIPE) {
+          throw new BadRequestException('Only pending STRIPE refunds can be failed');
+        }
+
+        const boundedFailureMessage = failureMessage.slice(0, 500);
+        const transition = await tx.paymentRefund.updateMany({
+          where: {
+            id: refundId,
+            paymentId,
+            status: PaymentRefundStatus.PENDING,
+            executionMode: RefundExecutionMode.STRIPE,
+          },
+          data: {
+            status: PaymentRefundStatus.FAILED,
+            failureMessage: boundedFailureMessage,
+          },
+        });
+        if (transition.count !== 1) {
+          const concurrentRefund = await tx.paymentRefund.findUnique({
+            where: { id: refundId },
+            select: internalRefundSelect,
+          });
+          if (!concurrentRefund) {
+            throw new NotFoundException(`Refund with ID ${refundId} not found`);
+          }
+          return this.buildManualRefundResult(payment, concurrentRefund);
+        }
+
+        await tx.adminAudit.create({
+          data: {
+            adminUserId,
+            actionType: AdminAuditActionType.PAYMENT_REFUND,
+            targetRecordType: AdminAuditTargetType.PAYMENT,
+            targetRecordId: paymentId,
+            transactionId: refund.idempotencyKey,
+            newValues: {
+              phase: 'RESULT',
+              outcome: PaymentRefundStatus.FAILED,
+              paymentId,
+              refundId,
+              registrationId: payment.registrationId,
+              amountCents: refund.amountCents,
+              currency: refund.currency,
+              executionMode: RefundExecutionMode.STRIPE,
+              reason: refund.reason,
+              resultingRegistrationStatus: refund.resultingRegistrationStatus,
+            },
+            reason: refund.reason,
+          },
+        });
+
+        const [updatedPayment, updatedRefund] = await Promise.all([
+          tx.payment.findUnique({
+            where: { id: paymentId },
+            select: adminPaymentSelect,
+          }),
+          tx.paymentRefund.findUnique({
+            where: { id: refundId },
+            select: internalRefundSelect,
+          }),
+        ]);
+        if (!updatedPayment || !updatedRefund) {
+          throw new NotFoundException('Refund result could not be reloaded');
+        }
+
+        return this.buildManualRefundResult(updatedPayment, updatedRefund);
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
+  }
+
+  /**
+   * Reconciles one pending Stripe refund without accepting mutable refund data.
+   */
+  async retryStripeRefund(
+    paymentId: string,
+    refundId: string,
+    adminUserId: string
+  ): Promise<ManualRefundResult> {
+    const refund = await this.prisma.paymentRefund.findUnique({
+      where: { id: refundId },
+      select: internalRefundSelect,
+    });
+    if (!refund || refund.paymentId !== paymentId) {
+      throw new NotFoundException(`Refund with ID ${refundId} not found for payment ${paymentId}`);
+    }
+
+    const payment = await this.prisma.payment.findUnique({
+      where: { id: paymentId },
+      select: adminPaymentSelect,
+    });
+    if (!payment) {
+      throw new NotFoundException(`Payment with ID ${paymentId} not found`);
+    }
+    if (refund.status !== PaymentRefundStatus.PENDING) {
+      return this.buildManualRefundResult(payment, refund);
+    }
+    if (refund.executionMode !== RefundExecutionMode.STRIPE) {
+      throw new BadRequestException('Only pending STRIPE refunds can be retried');
+    }
+    const providerRefId = this.validateStripeRetryPayment(payment);
+
+    const inspection = await this.stripeService.findAdminRefund(providerRefId, refundId);
+    if (inspection.outcome === 'PENDING_UNKNOWN') {
+      return this.buildManualRefundResult(payment, refund);
+    }
+    if (inspection.outcome === 'FOUND') {
+      try {
+        return await this.finalizeStripeRefund(
+          paymentId,
+          refundId,
+          inspection.providerRefundId,
+          adminUserId
+        );
+      } catch (error: unknown) {
+        this.logger.error(
+          `Stripe refund ${refundId} requires local reconciliation`,
+          error instanceof Error ? error.stack : undefined
+        );
+        return this.buildManualRefundResult(payment, refund);
+      }
+    }
+    if (inspection.outcome === 'FAILED') {
+      try {
+        return await this.failStripeRefund(
+          paymentId,
+          refundId,
+          inspection.failureMessage,
+          adminUserId
+        );
+      } catch (error: unknown) {
+        this.logger.error(
+          `Stripe refund ${refundId} requires local reconciliation`,
+          error instanceof Error ? error.stack : undefined
+        );
+        return this.buildManualRefundResult(payment, refund);
+      }
+    }
+
+    return this.submitStripeRefund(
+      {
+        payment,
+        refund,
+        providerRefId,
+        shouldSubmit: true,
+      },
+      adminUserId
+    );
+  }
+
+  private validateStripeRetryPayment(payment: AdminPaymentRecord): string {
+    if (payment.provider !== PaymentProvider.STRIPE) {
+      throw new BadRequestException('Stripe retry requires an original STRIPE payment');
+    }
+    const providerRefId = payment.providerRefId?.trim();
+    if (!providerRefId) {
+      throw new BadRequestException('Stripe payment has no usable provider reference');
+    }
+    return providerRefId;
+  }
+
+  private toAdminRefund(refund: InternalRefundRecord): AdminRefund {
+    return {
+      id: refund.id,
+      amountCents: refund.amountCents,
+      currency: refund.currency,
+      executionMode: refund.executionMode,
+      status: refund.status,
+      reason: refund.reason,
+      externalReference: refund.externalReference,
+      resultingRegistrationStatus: refund.resultingRegistrationStatus,
+      createdAt: refund.createdAt,
+      updatedAt: refund.updatedAt,
+    };
   }
 
   private isSerializationConflict(error: unknown): boolean {

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -1704,11 +1704,45 @@ export class PaymentsService {
           where: { id: paymentId },
           data: { status: resultingPaymentStatus },
         });
+
+        let registrationStatusBefore: RegistrationStatus | null = null;
+        let registrationStatusAfter: RegistrationStatus | null = null;
+        let registrationStatusApplied = false;
+        let registrationStatusSkipReason: string | null = null;
         if (payment.registrationId && refund.resultingRegistrationStatus) {
-          await tx.registration.update({
+          const currentRegistration = await tx.registration.findUnique({
             where: { id: payment.registrationId },
-            data: { status: refund.resultingRegistrationStatus },
+            select: { status: true },
           });
+          if (!currentRegistration) {
+            throw new NotFoundException(
+              `Registration with ID ${payment.registrationId} not found`
+            );
+          }
+
+          registrationStatusBefore = currentRegistration.status;
+          if (
+            currentRegistration.status === RegistrationStatus.CANCELLED ||
+            isApplicationStatus(currentRegistration.status)
+          ) {
+            registrationStatusAfter = currentRegistration.status;
+            registrationStatusSkipReason = 'CONCURRENT_PROTECTED_STATE';
+          } else {
+            const registrationTransition = await tx.registration.updateMany({
+              where: {
+                id: payment.registrationId,
+                status: currentRegistration.status,
+              },
+              data: { status: refund.resultingRegistrationStatus },
+            });
+            if (registrationTransition.count !== 1) {
+              throw new ConflictException(
+                'Registration status changed concurrently; retry refund reconciliation'
+              );
+            }
+            registrationStatusAfter = refund.resultingRegistrationStatus;
+            registrationStatusApplied = true;
+          }
         }
 
         await tx.adminAudit.create({
@@ -1729,6 +1763,10 @@ export class PaymentsService {
               executionMode: RefundExecutionMode.STRIPE,
               reason: refund.reason,
               resultingRegistrationStatus: refund.resultingRegistrationStatus,
+              registrationStatusBefore,
+              registrationStatusAfter,
+              registrationStatusApplied,
+              registrationStatusSkipReason,
               providerRefundId,
             },
             reason: refund.reason,

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -1446,7 +1446,7 @@ export class PaymentsService {
       amountCents: data.amountCents,
       fullRefund: data.fullRefund === true,
       executionMode: RefundExecutionMode.STRIPE,
-      reason: data.reason?.trim() || null,
+      reason: this.canonicalizeRefundText(data.reason, REFUND_REASON_MAX_LENGTH, 'reason'),
       externalReference: null,
       resultingRegistrationStatus: data.resultingRegistrationStatus ?? null,
     };
@@ -2434,11 +2434,13 @@ export class PaymentsService {
 
       // Determine the payment status based on Stripe session
       let updatedPaymentStatus = payment.status;
+      let updatedRegistrationId = payment.registration?.id;
       let updatedRegistrationStatus = payment.registration?.status;
 
       if (stripeSession.payment_status === 'paid') {
-        const paidState = await this.reconcilePaidStripeSession(payment);
+        const paidState = await this.reconcilePaidStripeSession(payment.id);
         updatedPaymentStatus = paidState.paymentStatus;
+        updatedRegistrationId = paidState.registrationId;
         updatedRegistrationStatus = paidState.registrationStatus;
       } else if (
         stripeSession.payment_status === 'unpaid' &&
@@ -2462,7 +2464,7 @@ export class PaymentsService {
       return {
         sessionId,
         paymentStatus: updatedPaymentStatus,
-        registrationId: payment.registration?.id,
+        registrationId: updatedRegistrationId,
         registrationStatus: updatedRegistrationStatus,
         paymentId: payment.id,
       };
@@ -2479,58 +2481,80 @@ export class PaymentsService {
     }
   }
 
-  private async reconcilePaidStripeSession(payment: PaymentWithRelations): Promise<{
+  private async reconcilePaidStripeSession(paymentId: string): Promise<{
     paymentStatus: PaymentStatus;
+    registrationId?: string;
     registrationStatus?: RegistrationStatus;
   }> {
-    const currentPayment = await this.loadStripeVerificationPayment(payment.id);
-    if (
-      currentPayment.status === PaymentStatus.FAILED ||
-      currentPayment.status === PaymentStatus.PARTIALLY_REFUNDED ||
-      currentPayment.status === PaymentStatus.REFUNDED
-    ) {
-      return {
-        paymentStatus: currentPayment.status,
-        registrationStatus: currentPayment.registration?.status,
-      };
-    }
-
-    const registration = currentPayment.registration;
-    const registrationIsProtected =
-      registration !== null &&
-      registration !== undefined &&
-      (registration.status === RegistrationStatus.CANCELLED ||
-        isApplicationStatus(registration.status));
-    const targetRegistrationStatus =
-      registration?.status === RegistrationStatus.WAITLISTED
-        ? RegistrationStatus.WAITLISTED
-        : RegistrationStatus.CONFIRMED;
-    const shouldCompletePayment = currentPayment.status === PaymentStatus.PENDING;
-    const shouldUpdateRegistration =
-      registration !== null &&
-      registration !== undefined &&
-      !registrationIsProtected &&
-      ((currentPayment.status === PaymentStatus.PENDING &&
-        (registration.status !== targetRegistrationStatus || registration.paymentDeferred)) ||
-        (currentPayment.status === PaymentStatus.COMPLETED && registration.paymentDeferred));
-
-    if (!shouldCompletePayment && !shouldUpdateRegistration) {
-      return {
-        paymentStatus: currentPayment.status,
-        registrationStatus: registration?.status,
-      };
-    }
-
     try {
-      await this.prisma.$transaction(
+      const paidState = await this.prisma.$transaction(
         async tx => {
-          if (shouldCompletePayment) {
+          const currentPayment = (await tx.payment.findUnique({
+            where: { id: paymentId },
+            include: { registration: true },
+          })) as PaymentWithRelations | null;
+          if (!currentPayment) {
+            throw new NotFoundException(`Payment with ID ${paymentId} not found`);
+          }
+
+          const registration = currentPayment.registration;
+          if (
+            currentPayment.status === PaymentStatus.FAILED ||
+            currentPayment.status === PaymentStatus.PARTIALLY_REFUNDED ||
+            currentPayment.status === PaymentStatus.REFUNDED
+          ) {
+            return {
+              paymentStatus: currentPayment.status,
+              registrationId: registration?.id,
+              registrationStatus: registration?.status,
+              confirmationRegistrationId: undefined,
+            };
+          }
+
+          const registrationIsProtected =
+            registration !== null &&
+            registration !== undefined &&
+            (registration.status === RegistrationStatus.CANCELLED ||
+              isApplicationStatus(registration.status));
+          const targetRegistrationStatus =
+            registration?.status === RegistrationStatus.WAITLISTED
+              ? RegistrationStatus.WAITLISTED
+              : RegistrationStatus.CONFIRMED;
+          const shouldCompletePayment = currentPayment.status === PaymentStatus.PENDING;
+          const shouldUpdateRegistration =
+            registration !== null &&
+            registration !== undefined &&
+            !registrationIsProtected &&
+            ((currentPayment.status === PaymentStatus.PENDING &&
+              (registration.status !== targetRegistrationStatus ||
+                registration.paymentDeferred)) ||
+              (currentPayment.status === PaymentStatus.COMPLETED &&
+                registration.paymentDeferred));
+
+          if (!shouldCompletePayment && !shouldUpdateRegistration) {
+            return {
+              paymentStatus: currentPayment.status,
+              registrationId: registration?.id,
+              registrationStatus: registration?.status,
+              confirmationRegistrationId: undefined,
+            };
+          }
+
+          if (shouldCompletePayment || shouldUpdateRegistration) {
             const paymentTransition = await tx.payment.updateMany({
-              where: { id: currentPayment.id, status: PaymentStatus.PENDING },
-              data: { status: PaymentStatus.COMPLETED },
+              where: {
+                id: currentPayment.id,
+                registrationId: currentPayment.registrationId,
+                status: currentPayment.status,
+              },
+              data: {
+                status: shouldCompletePayment ? PaymentStatus.COMPLETED : currentPayment.status,
+              },
             });
             if (paymentTransition.count !== 1) {
-              throw new ConflictException('Payment status changed during Stripe verification');
+              throw new ConflictException(
+                'Payment status or registration changed during Stripe verification'
+              );
             }
           }
 
@@ -2550,41 +2574,58 @@ export class PaymentsService {
               throw new ConflictException('Registration status changed during Stripe verification');
             }
           }
+
+          return {
+            paymentStatus: shouldCompletePayment
+              ? PaymentStatus.COMPLETED
+              : currentPayment.status,
+            registrationId: registration?.id,
+            registrationStatus:
+              shouldUpdateRegistration && registration
+                ? targetRegistrationStatus
+                : registration?.status,
+            confirmationRegistrationId:
+              shouldUpdateRegistration && registration && !registration.paymentDeferred
+                ? registration.id
+                : undefined,
+          };
         },
         { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
       );
+
+      if (paidState.confirmationRegistrationId) {
+        this.sendRegistrationConfirmationEmailAfterPayment(
+          paidState.confirmationRegistrationId
+        ).catch(emailError => {
+          this.logger.warn(
+            `Failed to send registration confirmation email: ${emailError instanceof Error ? emailError.message : 'Unknown error'}`
+          );
+        });
+      }
+
+      return {
+        paymentStatus: paidState.paymentStatus,
+        registrationId: paidState.registrationId,
+        registrationStatus: paidState.registrationStatus,
+      };
     } catch (error: unknown) {
       if (error instanceof ConflictException || this.isSerializationConflict(error)) {
-        return this.reloadStripeVerificationState(currentPayment.id);
+        return this.reloadStripeVerificationState(paymentId);
       }
       throw error;
     }
-
-    if (shouldUpdateRegistration && registration && !registration.paymentDeferred) {
-      this.sendRegistrationConfirmationEmailAfterPayment(registration.id).catch(emailError => {
-        this.logger.warn(
-          `Failed to send registration confirmation email: ${emailError instanceof Error ? emailError.message : 'Unknown error'}`
-        );
-      });
-    }
-
-    return {
-      paymentStatus: shouldCompletePayment ? PaymentStatus.COMPLETED : currentPayment.status,
-      registrationStatus:
-        shouldUpdateRegistration && registration
-          ? targetRegistrationStatus
-          : registration?.status,
-    };
   }
 
   private async reloadStripeVerificationState(paymentId: string): Promise<{
     paymentStatus: PaymentStatus;
+    registrationId?: string;
     registrationStatus?: RegistrationStatus;
   }> {
     const currentPayment = await this.loadStripeVerificationPayment(paymentId);
 
     return {
       paymentStatus: currentPayment.status,
+      registrationId: currentPayment.registration?.id,
       registrationStatus: currentPayment.registration?.status,
     };
   }

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -1744,6 +1744,14 @@ export class PaymentsService {
         if (refund.executionMode !== RefundExecutionMode.STRIPE) {
           throw new BadRequestException('Only pending STRIPE refunds can be finalized');
         }
+        if (
+          payment.status !== PaymentStatus.COMPLETED &&
+          payment.status !== PaymentStatus.PARTIALLY_REFUNDED
+        ) {
+          throw new ConflictException(
+            `Payment status ${payment.status} cannot be replaced by Stripe refund finalization`
+          );
+        }
 
         const transition = await tx.paymentRefund.updateMany({
           where: {
@@ -1784,10 +1792,15 @@ export class PaymentsService {
             ? PaymentStatus.REFUNDED
             : PaymentStatus.PARTIALLY_REFUNDED;
 
-        await tx.payment.update({
-          where: { id: paymentId },
+        const paymentTransition = await tx.payment.updateMany({
+          where: { id: paymentId, status: payment.status },
           data: { status: resultingPaymentStatus },
         });
+        if (paymentTransition.count !== 1) {
+          throw new ConflictException(
+            'Payment status changed concurrently; retry refund reconciliation'
+          );
+        }
 
         let registrationStatusBefore: RegistrationStatus | null = null;
         let registrationStatusAfter: RegistrationStatus | null = null;
@@ -2309,129 +2322,9 @@ export class PaymentsService {
       let updatedRegistrationStatus = payment.registration?.status;
 
       if (stripeSession.payment_status === 'paid') {
-        // Payment was successful - mark payment and registration as complete
-        updatedPaymentStatus = PaymentStatus.COMPLETED;
-
-        if (payment.registration) {
-          // Capacity beats payment: a WAITLISTED registration must NOT be
-          // promoted to CONFIRMED just because the user paid. The
-          // standard waitlist flow (admin or capacity-opens-up) is the
-          // only path that should transition WAITLISTED → CONFIRMED.
-          // We still record the payment as COMPLETED and clear
-          // `paymentDeferred` so the row reflects the paid state, but
-          // the status stays WAITLISTED.
-          //
-          // This is the only WAITLISTED-deferred interaction that is
-          // actually reachable via this PR's new UI: the dashboard's
-          // "Pay Now" CTA hides itself for WAITLISTED registrations
-          // (DashboardPage.tsx), but a direct API call or a TOCTOU race
-          // that produced a WAITLISTED + paymentDeferred=true row would
-          // expose the bug this guard prevents. Pre-#160, this method
-          // always set the registration to CONFIRMED on paid sessions
-          // — a latent issue that became reachable once dashboard
-          // "Pay Now" was added.
-          const isWaitlisted = payment.registration.status === 'WAITLISTED';
-          updatedRegistrationStatus = isWaitlisted ? 'WAITLISTED' : 'CONFIRMED';
-          const targetStatus = updatedRegistrationStatus;
-
-          // Update path fires when ANY of (a) payment not yet COMPLETED,
-          // (b) registration not at its target status (CONFIRMED unless
-          // WAITLISTED, in which case it stays WAITLISTED), (c) registration
-          // still flagged paymentDeferred=true. The third clause matters
-          // for deferred registrations: a deferred row starts as CONFIRMED
-          // + paymentDeferred=true, so without this clause a retry after
-          // payment would skip the update and leave paymentDeferred true.
-          if (
-            payment.status !== PaymentStatus.COMPLETED ||
-            payment.registration.status !== targetStatus ||
-            payment.registration.paymentDeferred
-          ) {
-            try {
-              this.logger.log(
-                `Updating payment ${payment.id} to COMPLETED and registration ${payment.registration.id} to ${targetStatus} (paymentDeferred cleared)`
-              );
-
-              try {
-                // Use transaction to ensure atomicity between payment and registration updates
-                const transactionResults = await this.prisma.$transaction([
-                  this.prisma.payment.update({
-                    where: { id: payment.id },
-                    data: { status: PaymentStatus.COMPLETED },
-                  }),
-                  this.prisma.registration.update({
-                    where: { id: payment.registration.id },
-                    data: { status: targetStatus, paymentDeferred: false },
-                  }),
-                ]);
-
-                this.logger.log(`Successfully updated payment and registration statuses`);
-                this.logger.debug(
-                  `Transaction results: ${JSON.stringify({
-                    payment: transactionResults[0].id,
-                    registration: transactionResults[1].id,
-                  })}`
-                );
-
-                // Send registration confirmation email with the updated
-                // status — but skip it for a deferred → paid transition,
-                // because the participant already received a confirmation
-                // email at registration creation time (with a "payment
-                // deferred" notice). Sending it again would duplicate.
-                const wasDeferred = payment.registration.paymentDeferred === true;
-                if (!wasDeferred) {
-                  this.sendRegistrationConfirmationEmailAfterPayment(payment.registration.id).catch(
-                    emailError => {
-                      this.logger.warn(
-                        `Failed to send registration confirmation email: ${emailError instanceof Error ? emailError.message : 'Unknown error'}`
-                      );
-                    }
-                  );
-                }
-              } catch (transactionError) {
-                // If the transaction fails, at least try to update the payment status
-                // This ensures we record the successful Stripe payment even if registration update fails
-                this.logger.warn(
-                  `Transaction failed, falling back to payment-only update: ${transactionError instanceof Error ? transactionError.message : 'Unknown error'}`
-                );
-
-                if (payment.status !== PaymentStatus.COMPLETED) {
-                  await this.prisma.payment.update({
-                    where: { id: payment.id },
-                    data: {
-                      status: PaymentStatus.COMPLETED,
-                    },
-                  });
-                  this.logger.log(
-                    `Updated payment ${payment.id} to COMPLETED (registration update failed: ${transactionError instanceof Error ? transactionError.message : 'Unknown error'})`
-                  );
-                }
-              }
-            } catch (error) {
-              const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-              this.logger.error(
-                `Failed to update statuses: ${errorMessage}`,
-                error instanceof Error ? error.stack : undefined
-              );
-              throw new BadRequestException(
-                `Failed to update payment or registration status: ${errorMessage}`
-              );
-            }
-          } else {
-            this.logger.log(
-              `Both payment and registration already have correct statuses, no update needed`
-            );
-          }
-        } else {
-          // No registration linked, just update the payment if needed
-          if (payment.status !== PaymentStatus.COMPLETED) {
-            await this.update(payment.id, {
-              status: PaymentStatus.COMPLETED,
-            });
-            this.logger.log(`Updated payment ${payment.id} to COMPLETED (no registration)`);
-          } else {
-            this.logger.log(`Payment ${payment.id} already marked as COMPLETED (no registration)`);
-          }
-        }
+        const paidState = await this.reconcilePaidStripeSession(payment);
+        updatedPaymentStatus = paidState.paymentStatus;
+        updatedRegistrationStatus = paidState.registrationStatus;
       } else if (
         stripeSession.payment_status === 'unpaid' &&
         payment.status === PaymentStatus.PENDING
@@ -2469,6 +2362,128 @@ export class PaymentsService {
       );
       throw new BadRequestException('Failed to verify Stripe session');
     }
+  }
+
+  private async reconcilePaidStripeSession(payment: PaymentWithRelations): Promise<{
+    paymentStatus: PaymentStatus;
+    registrationStatus?: RegistrationStatus;
+  }> {
+    const currentPayment = await this.loadStripeVerificationPayment(payment.id);
+    if (
+      currentPayment.status === PaymentStatus.FAILED ||
+      currentPayment.status === PaymentStatus.PARTIALLY_REFUNDED ||
+      currentPayment.status === PaymentStatus.REFUNDED
+    ) {
+      return {
+        paymentStatus: currentPayment.status,
+        registrationStatus: currentPayment.registration?.status,
+      };
+    }
+
+    const registration = currentPayment.registration;
+    const registrationIsProtected =
+      registration !== null &&
+      registration !== undefined &&
+      (registration.status === RegistrationStatus.CANCELLED ||
+        isApplicationStatus(registration.status));
+    const targetRegistrationStatus =
+      registration?.status === RegistrationStatus.WAITLISTED
+        ? RegistrationStatus.WAITLISTED
+        : RegistrationStatus.CONFIRMED;
+    const shouldCompletePayment = currentPayment.status === PaymentStatus.PENDING;
+    const shouldUpdateRegistration =
+      registration !== null &&
+      registration !== undefined &&
+      !registrationIsProtected &&
+      ((currentPayment.status === PaymentStatus.PENDING &&
+        (registration.status !== targetRegistrationStatus || registration.paymentDeferred)) ||
+        (currentPayment.status === PaymentStatus.COMPLETED && registration.paymentDeferred));
+
+    if (!shouldCompletePayment && !shouldUpdateRegistration) {
+      return {
+        paymentStatus: currentPayment.status,
+        registrationStatus: registration?.status,
+      };
+    }
+
+    try {
+      await this.prisma.$transaction(
+        async tx => {
+          if (shouldCompletePayment) {
+            const paymentTransition = await tx.payment.updateMany({
+              where: { id: currentPayment.id, status: PaymentStatus.PENDING },
+              data: { status: PaymentStatus.COMPLETED },
+            });
+            if (paymentTransition.count !== 1) {
+              throw new ConflictException('Payment status changed during Stripe verification');
+            }
+          }
+
+          if (shouldUpdateRegistration && registration) {
+            const registrationTransition = await tx.registration.updateMany({
+              where: {
+                id: registration.id,
+                status: registration.status,
+                paymentDeferred: registration.paymentDeferred,
+              },
+              data: {
+                status: targetRegistrationStatus,
+                paymentDeferred: false,
+              },
+            });
+            if (registrationTransition.count !== 1) {
+              throw new ConflictException('Registration status changed during Stripe verification');
+            }
+          }
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+      );
+    } catch (error: unknown) {
+      if (error instanceof ConflictException || this.isSerializationConflict(error)) {
+        return this.reloadStripeVerificationState(currentPayment.id);
+      }
+      throw error;
+    }
+
+    if (shouldUpdateRegistration && registration && !registration.paymentDeferred) {
+      this.sendRegistrationConfirmationEmailAfterPayment(registration.id).catch(emailError => {
+        this.logger.warn(
+          `Failed to send registration confirmation email: ${emailError instanceof Error ? emailError.message : 'Unknown error'}`
+        );
+      });
+    }
+
+    return {
+      paymentStatus: shouldCompletePayment ? PaymentStatus.COMPLETED : currentPayment.status,
+      registrationStatus:
+        shouldUpdateRegistration && registration
+          ? targetRegistrationStatus
+          : registration?.status,
+    };
+  }
+
+  private async reloadStripeVerificationState(paymentId: string): Promise<{
+    paymentStatus: PaymentStatus;
+    registrationStatus?: RegistrationStatus;
+  }> {
+    const currentPayment = await this.loadStripeVerificationPayment(paymentId);
+
+    return {
+      paymentStatus: currentPayment.status,
+      registrationStatus: currentPayment.registration?.status,
+    };
+  }
+
+  private async loadStripeVerificationPayment(paymentId: string): Promise<PaymentWithRelations> {
+    const currentPayment = (await this.prisma.payment.findUnique({
+      where: { id: paymentId },
+      include: { registration: true },
+    })) as PaymentWithRelations | null;
+    if (!currentPayment) {
+      throw new NotFoundException(`Payment with ID ${paymentId} not found`);
+    }
+
+    return currentPayment;
   }
 
   /**

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -196,6 +196,8 @@ const DEFAULT_ADMIN_PAYMENT_PAGE_SIZE = 25;
 const MAX_ADMIN_PAYMENT_PAGE_SIZE = 100;
 const UNSUPPORTED_PAYMENT_PRECISION_REASON =
   'Refund unavailable because the stored payment amount has unsupported precision.';
+const UNSUPPORTED_PAYMENT_CURRENCY_REASON =
+  'Refund unavailable because the stored payment currency is invalid.';
 
 // Interface for refund result
 export interface RefundResult {
@@ -704,25 +706,67 @@ export class PaymentsService {
   private getAdminRefundTotals(
     payment: AdminPaymentRecord | ExternalPaymentRecord
   ): RefundTotals {
+    let paymentAmountCents: number;
     try {
-      return this.calculateRefundTotals(
-        dollarsToCents(payment.amount),
-        payment.refunds,
-        payment.status === PaymentStatus.REFUNDED
-      );
+      paymentAmountCents = dollarsToCents(payment.amount);
     } catch (error: unknown) {
       if (!(error instanceof RangeError)) {
         throw error;
       }
 
-      const ledgerTotals = this.calculateRefundLedgerTotals(payment.refunds);
-      return {
-        paymentAmountCents: null,
-        ...ledgerTotals,
-        availableRefundCents: 0,
-        refundUnavailableReason: UNSUPPORTED_PAYMENT_PRECISION_REASON,
-      };
+      return this.buildUnavailableRefundTotals(
+        null,
+        payment.refunds,
+        UNSUPPORTED_PAYMENT_PRECISION_REASON,
+        false
+      );
     }
+
+    try {
+      this.validateStoredPaymentCurrency(payment.currency);
+    } catch (error: unknown) {
+      if (!(error instanceof RangeError)) {
+        throw error;
+      }
+
+      return this.buildUnavailableRefundTotals(
+        paymentAmountCents,
+        payment.refunds,
+        UNSUPPORTED_PAYMENT_CURRENCY_REASON,
+        payment.status === PaymentStatus.REFUNDED
+      );
+    }
+
+    return this.calculateRefundTotals(
+      paymentAmountCents,
+      payment.refunds,
+      payment.status === PaymentStatus.REFUNDED
+    );
+  }
+
+  private buildUnavailableRefundTotals(
+    paymentAmountCents: number | null,
+    refunds: ReadonlyArray<{
+      amountCents: number;
+      status: PaymentRefundStatus;
+    }>,
+    refundUnavailableReason: string,
+    forceFullyRefunded: boolean
+  ): RefundTotals {
+    const ledgerTotals =
+      forceFullyRefunded && paymentAmountCents !== null
+        ? {
+            successfulRefundCents: paymentAmountCents,
+            pendingRefundCents: 0,
+          }
+        : this.calculateRefundLedgerTotals(refunds);
+
+    return {
+      paymentAmountCents,
+      ...ledgerTotals,
+      availableRefundCents: 0,
+      refundUnavailableReason,
+    };
   }
 
   private calculateRefundTotals(
@@ -850,6 +894,7 @@ export class PaymentsService {
             canonicalRequest.resultingRegistrationStatus
           );
 
+          const paymentCurrency = this.getPaymentCurrency(payment.currency);
           const paymentAmountCents = this.getPaymentAmountCents(payment.amount);
           const currentTotals = this.calculateRefundTotals(paymentAmountCents, payment.refunds);
           if (currentTotals.availableRefundCents <= 0) {
@@ -872,7 +917,7 @@ export class PaymentsService {
             data: {
               paymentId,
               amountCents: refundAmountCents,
-              currency: normalizeCurrency(payment.currency),
+              currency: paymentCurrency,
               executionMode: RefundExecutionMode.MANUAL,
               status: PaymentRefundStatus.SUCCEEDED,
               reason: canonicalRequest.reason,
@@ -917,7 +962,7 @@ export class PaymentsService {
                 refundId: createdRefund.id,
                 registrationId: payment.registrationId,
                 amountCents: refundAmountCents,
-                currency: normalizeCurrency(payment.currency),
+                currency: paymentCurrency,
                 executionMode: RefundExecutionMode.MANUAL,
                 reason: canonicalRequest.reason,
                 externalReference: canonicalRequest.externalReference,
@@ -1044,6 +1089,26 @@ export class PaymentsService {
     } catch (error: unknown) {
       if (error instanceof RangeError) {
         throw new BadRequestException(error.message);
+      }
+
+      throw error;
+    }
+  }
+
+  private validateStoredPaymentCurrency(currency: string): void {
+    const normalizedCurrency = normalizeCurrency(currency);
+    if (normalizedCurrency !== currency) {
+      throw new RangeError('Stored payment currency must already be normalized');
+    }
+  }
+
+  private getPaymentCurrency(currency: string): string {
+    try {
+      this.validateStoredPaymentCurrency(currency);
+      return currency;
+    } catch (error: unknown) {
+      if (error instanceof RangeError) {
+        throw new BadRequestException(UNSUPPORTED_PAYMENT_CURRENCY_REASON);
       }
 
       throw error;

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -32,7 +32,7 @@ import {
 import { StripeService } from './stripe.service';
 import { PaypalService } from './paypal.service';
 import { isApplicationStatus } from '../../registrations/constants/registration-status.constants';
-import { dollarsToCents, normalizeCurrency } from '../utils/money.utils';
+import { centsToDollars, dollarsToCents, normalizeCurrency } from '../utils/money.utils';
 import { randomUUID } from 'crypto';
 
 // Create an extended Payment type that includes registration relationship
@@ -198,6 +198,8 @@ const UNSUPPORTED_PAYMENT_PRECISION_REASON =
   'Refund unavailable because the stored payment amount has unsupported precision.';
 const UNSUPPORTED_PAYMENT_CURRENCY_REASON =
   'Refund unavailable because the stored payment currency is invalid.';
+const REFUND_REASON_MAX_LENGTH = 500;
+const REFUND_EXTERNAL_REFERENCE_MAX_LENGTH = 255;
 
 // Interface for refund result
 export interface RefundResult {
@@ -1020,12 +1022,15 @@ export class PaymentsService {
     const hasFullRefund = data.fullRefund !== undefined;
     if (
       hasAmount === hasFullRefund ||
-      (hasAmount && (!Number.isSafeInteger(data.amountCents) || (data.amountCents ?? 0) <= 0)) ||
       (hasFullRefund && data.fullRefund !== true)
     ) {
       throw new BadRequestException(
         'Provide exactly one of a positive integer amountCents or fullRefund: true'
       );
+    }
+
+    if (hasAmount) {
+      this.validateRefundAmountCents(data.amountCents);
     }
 
     this.validateResultingRegistrationStatus(data.resultingRegistrationStatus);
@@ -1034,10 +1039,49 @@ export class PaymentsService {
       amountCents: data.amountCents,
       fullRefund: data.fullRefund === true,
       executionMode: RefundExecutionMode.MANUAL,
-      reason: data.reason?.trim() || null,
-      externalReference: data.externalReference?.trim() || null,
+      reason: this.canonicalizeRefundText(data.reason, REFUND_REASON_MAX_LENGTH, 'reason'),
+      externalReference: this.canonicalizeRefundText(
+        data.externalReference,
+        REFUND_EXTERNAL_REFERENCE_MAX_LENGTH,
+        'externalReference'
+      ),
       resultingRegistrationStatus: data.resultingRegistrationStatus ?? null,
     };
+  }
+
+  private validateRefundAmountCents(amountCents: number | undefined): void {
+    if (amountCents === undefined || amountCents <= 0) {
+      throw new BadRequestException(
+        'amountCents must be a positive integer within the supported range'
+      );
+    }
+
+    try {
+      centsToDollars(amountCents);
+    } catch (error: unknown) {
+      if (error instanceof RangeError) {
+        throw new BadRequestException(
+          'amountCents must be a positive integer within the supported range'
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  private canonicalizeRefundText(
+    value: string | undefined,
+    maxLength: number,
+    fieldName: 'reason' | 'externalReference'
+  ): string | null {
+    const normalizedValue = value?.trim() || null;
+    if (normalizedValue && normalizedValue.length > maxLength) {
+      throw new BadRequestException(
+        `${fieldName} must not exceed ${maxLength} characters after sanitization`
+      );
+    }
+
+    return normalizedValue;
   }
 
   private validateManualRefundPayment(status: PaymentStatus): void {
@@ -1122,13 +1166,8 @@ export class PaymentsService {
     canonicalRequest: CanonicalManualRefund
   ): ManualRefundResult {
     const requestedFullRefund = this.getRequestedFullRefundFromAudit(auditValues);
-    const amountMatches = canonicalRequest.fullRefund
-      ? existingRefund.amountCents ===
-        this.calculateRefundTotals(
-          this.getPaymentAmountCents(payment.amount),
-          payment.refunds.filter(refund => refund.id !== existingRefund.id)
-        ).availableRefundCents
-      : existingRefund.amountCents === canonicalRequest.amountCents;
+    const amountMatches =
+      canonicalRequest.fullRefund || existingRefund.amountCents === canonicalRequest.amountCents;
 
     if (
       requestedFullRefund === null ||

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -32,7 +32,12 @@ import {
 import { StripeService } from './stripe.service';
 import { PaypalService } from './paypal.service';
 import { isApplicationStatus } from '../../registrations/constants/registration-status.constants';
-import { centsToDollars, dollarsToCents, normalizeCurrency } from '../utils/money.utils';
+import {
+  centsToDollars,
+  dollarsToCents,
+  hasSubCentPrecision,
+  normalizeCurrency,
+} from '../utils/money.utils';
 import { randomUUID } from 'crypto';
 
 // Create an extended Payment type that includes registration relationship
@@ -161,6 +166,16 @@ interface RefundTotals {
   refundUnavailableReason: string | null;
 }
 
+type AdminPaymentAmountConversion =
+  | {
+      readonly paymentAmountCents: number;
+      readonly refundUnavailableReason: null;
+    }
+  | {
+      readonly paymentAmountCents: null;
+      readonly refundUnavailableReason: string;
+    };
+
 export type AdminPayment = AdminPaymentRecord & RefundTotals;
 
 export interface ManualRefundResult extends RefundTotals {
@@ -196,6 +211,8 @@ const DEFAULT_ADMIN_PAYMENT_PAGE_SIZE = 25;
 const MAX_ADMIN_PAYMENT_PAGE_SIZE = 100;
 const UNSUPPORTED_PAYMENT_PRECISION_REASON =
   'Refund unavailable because the stored payment amount has unsupported precision.';
+const UNSUPPORTED_PAYMENT_AMOUNT_REASON =
+  'Refund unavailable because the stored payment amount is invalid or exceeds the supported refund range.';
 const UNSUPPORTED_PAYMENT_CURRENCY_REASON =
   'Refund unavailable because the stored payment currency is invalid.';
 const REFUND_REASON_MAX_LENGTH = 500;
@@ -708,21 +725,16 @@ export class PaymentsService {
   private getAdminRefundTotals(
     payment: AdminPaymentRecord | ExternalPaymentRecord
   ): RefundTotals {
-    let paymentAmountCents: number;
-    try {
-      paymentAmountCents = dollarsToCents(payment.amount);
-    } catch (error: unknown) {
-      if (!(error instanceof RangeError)) {
-        throw error;
-      }
-
+    const amountConversion = this.convertAdminPaymentAmount(payment.amount);
+    if (amountConversion.refundUnavailableReason !== null) {
       return this.buildUnavailableRefundTotals(
         null,
         payment.refunds,
-        UNSUPPORTED_PAYMENT_PRECISION_REASON,
+        amountConversion.refundUnavailableReason,
         false
       );
     }
+    const paymentAmountCents = amountConversion.paymentAmountCents;
 
     const isLegacyLedgerlessRefund =
       payment.status === PaymentStatus.REFUNDED && payment.refunds.length === 0;
@@ -743,6 +755,35 @@ export class PaymentsService {
     }
 
     return this.calculateRefundTotals(paymentAmountCents, payment.refunds, isLegacyLedgerlessRefund);
+  }
+
+  private convertAdminPaymentAmount(amount: number): AdminPaymentAmountConversion {
+    if (amount === 0) {
+      return {
+        paymentAmountCents: 0,
+        refundUnavailableReason: null,
+      };
+    }
+
+    try {
+      return {
+        paymentAmountCents: dollarsToCents(amount),
+        refundUnavailableReason: null,
+      };
+    } catch (error: unknown) {
+      if (!(error instanceof RangeError)) {
+        throw error;
+      }
+
+      const refundUnavailableReason =
+        Number.isFinite(amount) && amount > 0 && hasSubCentPrecision(amount)
+          ? UNSUPPORTED_PAYMENT_PRECISION_REASON
+          : UNSUPPORTED_PAYMENT_AMOUNT_REASON;
+      return {
+        paymentAmountCents: null,
+        refundUnavailableReason,
+      };
+    }
   }
 
   private buildUnavailableRefundTotals(

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -1561,6 +1561,7 @@ export class PaymentsService {
               amountCents: refundAmountCents,
               currency: paymentCurrency,
               executionMode: RefundExecutionMode.STRIPE,
+              providerRefId,
               reason: canonicalRequest.reason,
               resultingRegistrationStatus: canonicalRequest.resultingRegistrationStatus,
               requestedFullRefund: canonicalRequest.fullRefund,
@@ -1681,7 +1682,6 @@ export class PaymentsService {
     const stripeResult = await this.stripeService.createAdminRefund({
       providerRefId: reservation.providerRefId,
       amountCents: reservation.refund.amountCents,
-      reason: reservation.refund.reason,
       idempotencyKey: reservation.refund.idempotencyKey,
       localRefundId: reservation.refund.id,
     });
@@ -2002,10 +2002,25 @@ export class PaymentsService {
       throw new NotFoundException(`Refund with ID ${refundId} not found for payment ${paymentId}`);
     }
 
-    const payment = await this.prisma.payment.findUnique({
-      where: { id: paymentId },
-      select: adminPaymentSelect,
-    });
+    const [payment, attemptAudit] = await Promise.all([
+      this.prisma.payment.findUnique({
+        where: { id: paymentId },
+        select: adminPaymentSelect,
+      }),
+      this.prisma.adminAudit.findFirst({
+        where: {
+          transactionId: refund.idempotencyKey,
+          actionType: AdminAuditActionType.PAYMENT_REFUND,
+          targetRecordType: AdminAuditTargetType.PAYMENT,
+          targetRecordId: paymentId,
+          newValues: {
+            path: ['phase'],
+            equals: 'ATTEMPT',
+          },
+        },
+        select: { newValues: true },
+      }),
+    ]);
     if (!payment) {
       throw new NotFoundException(`Payment with ID ${paymentId} not found`);
     }
@@ -2015,7 +2030,11 @@ export class PaymentsService {
     if (refund.executionMode !== RefundExecutionMode.STRIPE) {
       throw new BadRequestException('Only pending STRIPE refunds can be retried');
     }
-    const providerRefId = this.validateStripeRetryPayment(payment);
+    const providerRefId = this.getStripeRefundProviderTarget(
+      attemptAudit?.newValues,
+      paymentId,
+      refundId
+    );
 
     const inspection = await this.stripeService.findAdminRefund(providerRefId, refundId);
     if (inspection.outcome === 'PENDING_UNKNOWN') {
@@ -2065,13 +2084,31 @@ export class PaymentsService {
     );
   }
 
-  private validateStripeRetryPayment(payment: AdminPaymentRecord): string {
-    if (payment.provider !== PaymentProvider.STRIPE) {
-      throw new BadRequestException('Stripe retry requires an original STRIPE payment');
+  private getStripeRefundProviderTarget(
+    auditValues: Prisma.JsonValue | null | undefined,
+    paymentId: string,
+    refundId: string
+  ): string {
+    if (
+      typeof auditValues !== 'object' ||
+      auditValues === null ||
+      Array.isArray(auditValues) ||
+      auditValues.phase !== 'ATTEMPT' ||
+      auditValues.paymentId !== paymentId ||
+      auditValues.refundId !== refundId ||
+      auditValues.executionMode !== RefundExecutionMode.STRIPE ||
+      typeof auditValues.providerRefId !== 'string'
+    ) {
+      throw new ConflictException(
+        'Stripe refund provider target is unavailable; refund remains pending'
+      );
     }
-    const providerRefId = payment.providerRefId?.trim();
+
+    const providerRefId = auditValues.providerRefId.trim();
     if (!providerRefId) {
-      throw new BadRequestException('Stripe payment has no usable provider reference');
+      throw new ConflictException(
+        'Stripe refund provider target is unavailable; refund remains pending'
+      );
     }
     return providerRefId;
   }

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -226,6 +226,8 @@ interface StripeRefundReservation {
   shouldSubmit: boolean;
 }
 
+type StripeRefundRegistrationTargetOutcome = 'MATCHED' | 'RELINKED' | 'UNAVAILABLE';
+
 interface LegacyRefundRequest {
   paymentId: string;
   amount?: number;
@@ -1753,6 +1755,38 @@ export class PaymentsService {
           );
         }
 
+        const attemptAudit = await tx.adminAudit.findFirst({
+          where: {
+            transactionId: refund.idempotencyKey,
+            actionType: AdminAuditActionType.PAYMENT_REFUND,
+            targetRecordType: AdminAuditTargetType.PAYMENT,
+            targetRecordId: paymentId,
+            newValues: {
+              path: ['phase'],
+              equals: 'ATTEMPT',
+            },
+          },
+          select: { newValues: true },
+        });
+        const attemptRegistrationId = this.getStripeRefundAttemptRegistrationId(
+          attemptAudit?.newValues,
+          paymentId,
+          refundId
+        );
+        const currentRegistrationId = payment.registrationId;
+        const registrationTargetOutcome: StripeRefundRegistrationTargetOutcome =
+          attemptRegistrationId === undefined
+            ? 'UNAVAILABLE'
+            : attemptRegistrationId === currentRegistrationId
+              ? 'MATCHED'
+              : 'RELINKED';
+        const guardedRegistrationId =
+          refund.resultingRegistrationStatus &&
+          registrationTargetOutcome === 'MATCHED' &&
+          typeof attemptRegistrationId === 'string'
+            ? attemptRegistrationId
+            : null;
+
         const transition = await tx.paymentRefund.updateMany({
           where: {
             id: refundId,
@@ -1793,7 +1827,11 @@ export class PaymentsService {
             : PaymentStatus.PARTIALLY_REFUNDED;
 
         const paymentTransition = await tx.payment.updateMany({
-          where: { id: paymentId, status: payment.status },
+          where: {
+            id: paymentId,
+            status: payment.status,
+            ...(guardedRegistrationId ? { registrationId: guardedRegistrationId } : {}),
+          },
           data: { status: resultingPaymentStatus },
         });
         if (paymentTransition.count !== 1) {
@@ -1806,14 +1844,26 @@ export class PaymentsService {
         let registrationStatusAfter: RegistrationStatus | null = null;
         let registrationStatusApplied = false;
         let registrationStatusSkipReason: string | null = null;
-        if (payment.registrationId && refund.resultingRegistrationStatus) {
+        if (
+          refund.resultingRegistrationStatus &&
+          registrationTargetOutcome === 'UNAVAILABLE'
+        ) {
+          registrationStatusSkipReason = 'ATTEMPT_REGISTRATION_UNAVAILABLE';
+        } else if (
+          refund.resultingRegistrationStatus &&
+          registrationTargetOutcome === 'RELINKED'
+        ) {
+          registrationStatusSkipReason = 'PAYMENT_RELINKED';
+        } else if (refund.resultingRegistrationStatus && attemptRegistrationId === null) {
+          registrationStatusSkipReason = 'NO_REGISTRATION_TARGET';
+        } else if (refund.resultingRegistrationStatus && attemptRegistrationId) {
           const currentRegistration = await tx.registration.findUnique({
-            where: { id: payment.registrationId },
+            where: { id: attemptRegistrationId },
             select: { status: true },
           });
           if (!currentRegistration) {
             throw new NotFoundException(
-              `Registration with ID ${payment.registrationId} not found`
+              `Registration with ID ${attemptRegistrationId} not found`
             );
           }
 
@@ -1827,7 +1877,7 @@ export class PaymentsService {
           } else {
             const registrationTransition = await tx.registration.updateMany({
               where: {
-                id: payment.registrationId,
+                id: attemptRegistrationId,
                 status: currentRegistration.status,
               },
               data: { status: refund.resultingRegistrationStatus },
@@ -1855,6 +1905,9 @@ export class PaymentsService {
               paymentId,
               refundId,
               registrationId: payment.registrationId,
+              attemptRegistrationId: attemptRegistrationId ?? null,
+              currentRegistrationId,
+              registrationTargetOutcome,
               amountCents: refund.amountCents,
               currency: refund.currency,
               executionMode: RefundExecutionMode.STRIPE,
@@ -2001,35 +2054,33 @@ export class PaymentsService {
     if (!refund || refund.paymentId !== paymentId) {
       throw new NotFoundException(`Refund with ID ${refundId} not found for payment ${paymentId}`);
     }
+    if (refund.executionMode !== RefundExecutionMode.STRIPE) {
+      throw new BadRequestException('Only STRIPE refunds can be retried');
+    }
 
-    const [payment, attemptAudit] = await Promise.all([
-      this.prisma.payment.findUnique({
-        where: { id: paymentId },
-        select: adminPaymentSelect,
-      }),
-      this.prisma.adminAudit.findFirst({
-        where: {
-          transactionId: refund.idempotencyKey,
-          actionType: AdminAuditActionType.PAYMENT_REFUND,
-          targetRecordType: AdminAuditTargetType.PAYMENT,
-          targetRecordId: paymentId,
-          newValues: {
-            path: ['phase'],
-            equals: 'ATTEMPT',
-          },
-        },
-        select: { newValues: true },
-      }),
-    ]);
+    const payment = await this.prisma.payment.findUnique({
+      where: { id: paymentId },
+      select: adminPaymentSelect,
+    });
     if (!payment) {
       throw new NotFoundException(`Payment with ID ${paymentId} not found`);
     }
     if (refund.status !== PaymentRefundStatus.PENDING) {
       return this.buildManualRefundResult(payment, refund);
     }
-    if (refund.executionMode !== RefundExecutionMode.STRIPE) {
-      throw new BadRequestException('Only pending STRIPE refunds can be retried');
-    }
+    const attemptAudit = await this.prisma.adminAudit.findFirst({
+      where: {
+        transactionId: refund.idempotencyKey,
+        actionType: AdminAuditActionType.PAYMENT_REFUND,
+        targetRecordType: AdminAuditTargetType.PAYMENT,
+        targetRecordId: paymentId,
+        newValues: {
+          path: ['phase'],
+          equals: 'ATTEMPT',
+        },
+      },
+      select: { newValues: true },
+    });
     const providerRefId = this.getStripeRefundProviderTarget(
       attemptAudit?.newValues,
       paymentId,
@@ -2082,6 +2133,33 @@ export class PaymentsService {
       },
       adminUserId
     );
+  }
+
+  private getStripeRefundAttemptRegistrationId(
+    auditValues: Prisma.JsonValue | null | undefined,
+    paymentId: string,
+    refundId: string
+  ): string | null | undefined {
+    if (
+      typeof auditValues !== 'object' ||
+      auditValues === null ||
+      Array.isArray(auditValues) ||
+      auditValues.phase !== 'ATTEMPT' ||
+      auditValues.paymentId !== paymentId ||
+      auditValues.refundId !== refundId ||
+      auditValues.executionMode !== RefundExecutionMode.STRIPE ||
+      !('registrationId' in auditValues)
+    ) {
+      return undefined;
+    }
+    if (auditValues.registrationId === null) {
+      return null;
+    }
+    if (typeof auditValues.registrationId !== 'string') {
+      return undefined;
+    }
+
+    return auditValues.registrationId.trim() || undefined;
   }
 
   private getStripeRefundProviderTarget(

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -1,8 +1,34 @@
-import { BadRequestException, ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { NotificationsService } from '../../notifications/services/notifications.service';
-import { CreatePaymentDto, UpdatePaymentDto, CreateRefundDto, CreateExternalPaymentDto, CreateStripePaymentDto, CreatePaypalPaymentDto } from '../dto';
-import { AdminAuditActionType, AdminAuditTargetType, ExternalPaymentMethod, Payment, PaymentProvider, PaymentStatus, Prisma, Registration, RegistrationStatus, UserRole } from '@prisma/client';
+import {
+  CreatePaymentDto,
+  UpdatePaymentDto,
+  CreateRefundDto,
+  CreateExternalPaymentDto,
+  CreateStripePaymentDto,
+  CreatePaypalPaymentDto,
+} from '../dto';
+import {
+  AdminAuditActionType,
+  AdminAuditTargetType,
+  ExternalPaymentMethod,
+  Payment,
+  PaymentProvider,
+  PaymentRefundStatus,
+  PaymentStatus,
+  Prisma,
+  RefundExecutionMode,
+  Registration,
+  RegistrationStatus,
+  UserRole,
+} from '@prisma/client';
 import { StripeService } from './stripe.service';
 import { PaypalService } from './paypal.service';
 import { isApplicationStatus } from '../../registrations/constants/registration-status.constants';
@@ -48,6 +74,25 @@ const sharedPaymentSelect = {
   registration: true,
 } satisfies Prisma.PaymentSelect;
 
+const adminRefundSelect = {
+  id: true,
+  amountCents: true,
+  currency: true,
+  executionMode: true,
+  status: true,
+  reason: true,
+  externalReference: true,
+  resultingRegistrationStatus: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.PaymentRefundSelect;
+
+const internalRefundSelect = {
+  ...adminRefundSelect,
+  paymentId: true,
+  idempotencyKey: true,
+} satisfies Prisma.PaymentRefundSelect;
+
 const adminPaymentSelect = {
   id: true,
   amount: true,
@@ -75,6 +120,10 @@ const adminPaymentSelect = {
       status: true,
     },
   },
+  refunds: {
+    select: adminRefundSelect,
+    orderBy: { createdAt: 'asc' as const },
+  },
 } satisfies Prisma.PaymentSelect;
 
 const externalPaymentSelect = {
@@ -82,16 +131,13 @@ const externalPaymentSelect = {
   idempotencyKey: true,
 } satisfies Prisma.PaymentSelect;
 
-type SharedPayment = Omit<
-  Payment,
-  'externalMethod' | 'externalReference' | 'idempotencyKey'
->;
+type SharedPayment = Omit<Payment, 'externalMethod' | 'externalReference' | 'idempotencyKey'>;
 
 type SharedPaymentWithRelations = SharedPayment & {
   registration?: Registration | null;
 };
 
-export type AdminPayment = Prisma.PaymentGetPayload<{
+type AdminPaymentRecord = Prisma.PaymentGetPayload<{
   select: typeof adminPaymentSelect;
 }>;
 
@@ -99,12 +145,50 @@ type ExternalPaymentRecord = Prisma.PaymentGetPayload<{
   select: typeof externalPaymentSelect;
 }>;
 
+export type AdminRefund = Prisma.PaymentRefundGetPayload<{
+  select: typeof adminRefundSelect;
+}>;
+
+type InternalRefundRecord = Prisma.PaymentRefundGetPayload<{
+  select: typeof internalRefundSelect;
+}>;
+
+interface RefundTotals {
+  paymentAmountCents: number;
+  successfulRefundCents: number;
+  pendingRefundCents: number;
+  availableRefundCents: number;
+}
+
+export type AdminPayment = AdminPaymentRecord & RefundTotals;
+
+export interface ManualRefundResult extends RefundTotals {
+  payment: AdminPayment;
+  refund: AdminRefund;
+}
+
 interface CanonicalExternalPayment {
   registrationId: string;
   amountCents: number;
   currency: string;
   externalMethod: ExternalPaymentMethod;
   externalReference: string | null;
+}
+
+interface CanonicalManualRefund {
+  amountCents?: number;
+  fullRefund: boolean;
+  executionMode: RefundExecutionMode;
+  reason: string | null;
+  externalReference: string | null;
+  resultingRegistrationStatus: RegistrationStatus | null;
+}
+
+interface LegacyRefundRequest {
+  paymentId: string;
+  amount?: number;
+  percentageOfOriginal?: number;
+  reason?: string;
 }
 
 const DEFAULT_ADMIN_PAYMENT_PAGE_SIZE = 25;
@@ -134,7 +218,7 @@ export class PaymentsService {
     private readonly prisma: PrismaService,
     private readonly stripeService: StripeService,
     private readonly paypalService: PaypalService,
-    private readonly notificationsService: NotificationsService,
+    private readonly notificationsService: NotificationsService
   ) {}
 
   /**
@@ -144,36 +228,40 @@ export class PaymentsService {
    */
   async create(createPaymentDto: CreatePaymentDto): Promise<Payment> {
     this.logger.log(`Creating payment record for user ${createPaymentDto.userId}`);
-    
+
     // Verify user exists
     const user = await this.prisma.user.findUnique({
       where: { id: createPaymentDto.userId },
     });
-    
+
     if (!user) {
       throw new NotFoundException(`User with ID ${createPaymentDto.userId} not found`);
     }
-    
+
     // If registration ID provided, verify it exists and belongs to the user
     if (createPaymentDto.registrationId) {
       const registration = await this.prisma.registration.findUnique({
         where: { id: createPaymentDto.registrationId },
       });
-      
+
       if (!registration) {
-        throw new NotFoundException(`Registration with ID ${createPaymentDto.registrationId} not found`);
+        throw new NotFoundException(
+          `Registration with ID ${createPaymentDto.registrationId} not found`
+        );
       }
-      
+
       if (registration.userId !== createPaymentDto.userId) {
         throw new BadRequestException('Registration does not belong to the specified user');
       }
 
       // Prevent payments for registrations still in application phase
       if (isApplicationStatus(registration.status)) {
-        throw new BadRequestException('Cannot process payment for a registration that has not completed the application process');
+        throw new BadRequestException(
+          'Cannot process payment for a registration that has not completed the application process'
+        );
       }
     }
-    
+
     try {
       const paymentData = {
         amount: createPaymentDto.amount,
@@ -183,7 +271,7 @@ export class PaymentsService {
         providerRefId: createPaymentDto.providerRefId,
         user: { connect: { id: createPaymentDto.userId } },
         ...(createPaymentDto.registrationId && {
-          registration: { connect: { id: createPaymentDto.registrationId } }
+          registration: { connect: { id: createPaymentDto.registrationId } },
         }),
       };
 
@@ -192,7 +280,10 @@ export class PaymentsService {
       });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(`Failed to create payment record: ${errorMessage}`, error instanceof Error ? error.stack : undefined);
+      this.logger.error(
+        `Failed to create payment record: ${errorMessage}`,
+        error instanceof Error ? error.stack : undefined
+      );
       throw error;
     }
   }
@@ -205,17 +296,22 @@ export class PaymentsService {
    * @param status - Filter by payment status
    * @returns Paginated list of payments
    */
-  async findAll(skip = 0, take = 10, userId?: string, status?: PaymentStatus): Promise<{ payments: SharedPayment[]; total: number }> {
+  async findAll(
+    skip = 0,
+    take = 10,
+    userId?: string,
+    status?: PaymentStatus
+  ): Promise<{ payments: SharedPayment[]; total: number }> {
     const where: PaymentWhereClause = {};
-    
+
     if (userId) {
       where.userId = userId;
     }
-    
+
     if (status) {
       where.status = status;
     }
-    
+
     const [payments, total] = await Promise.all([
       this.prisma.payment.findMany({
         where,
@@ -226,7 +322,7 @@ export class PaymentsService {
       }),
       this.prisma.payment.count({ where }),
     ]);
-    
+
     return { payments, total };
   }
 
@@ -235,19 +331,15 @@ export class PaymentsService {
    */
   async findAllForAdmin(
     skip = 0,
-    take = DEFAULT_ADMIN_PAYMENT_PAGE_SIZE,
+    take = DEFAULT_ADMIN_PAYMENT_PAGE_SIZE
   ): Promise<{ payments: AdminPayment[]; total: number }> {
     if (!Number.isInteger(skip) || skip < 0) {
       throw new BadRequestException('Skip must be a non-negative integer');
     }
 
-    if (
-      !Number.isInteger(take) ||
-      take < 1 ||
-      take > MAX_ADMIN_PAYMENT_PAGE_SIZE
-    ) {
+    if (!Number.isInteger(take) || take < 1 || take > MAX_ADMIN_PAYMENT_PAGE_SIZE) {
       throw new BadRequestException(
-        `Take must be an integer between 1 and ${MAX_ADMIN_PAYMENT_PAGE_SIZE}`,
+        `Take must be an integer between 1 and ${MAX_ADMIN_PAYMENT_PAGE_SIZE}`
       );
     }
 
@@ -261,7 +353,10 @@ export class PaymentsService {
       this.prisma.payment.count(),
     ]);
 
-    return { payments, total };
+    return {
+      payments: payments.map(payment => this.toAdminPayment(payment)),
+      total,
+    };
   }
 
   /**
@@ -284,11 +379,11 @@ export class PaymentsService {
         registration: true,
       },
     });
-    
+
     if (!payment) {
       throw new NotFoundException(`Payment with ID ${id} not found`);
     }
-    
+
     return payment;
   }
 
@@ -299,21 +394,25 @@ export class PaymentsService {
    * @param userRole - Current user role
    * @returns The payment, if found and user has access
    */
-  async findOneWithOwnershipCheck(id: string, userId: string, userRole: UserRole): Promise<SharedPaymentWithRelations> {
+  async findOneWithOwnershipCheck(
+    id: string,
+    userId: string,
+    userRole: UserRole
+  ): Promise<SharedPaymentWithRelations> {
     const payment = await this.prisma.payment.findUnique({
       where: { id },
       select: sharedPaymentSelect,
     });
-    
+
     if (!payment) {
       throw new NotFoundException(`Payment with ID ${id} not found`);
     }
-    
+
     // Check ownership - only admins/staff can view any payment, others can only view their own
     if (userRole !== UserRole.ADMIN && userRole !== UserRole.STAFF && payment.userId !== userId) {
       throw new NotFoundException(`Payment with ID ${id} not found`); // Don't reveal that payment exists
     }
-    
+
     return payment;
   }
 
@@ -326,7 +425,7 @@ export class PaymentsService {
   async update(id: string, updatePaymentDto: UpdatePaymentDto): Promise<Payment> {
     // Check if payment exists
     await this.findOne(id);
-    
+
     try {
       return await this.prisma.payment.update({
         where: { id },
@@ -334,7 +433,10 @@ export class PaymentsService {
       });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(`Failed to update payment ${id}: ${errorMessage}`, error instanceof Error ? error.stack : undefined);
+      this.logger.error(
+        `Failed to update payment ${id}: ${errorMessage}`,
+        error instanceof Error ? error.stack : undefined
+      );
       throw error;
     }
   }
@@ -348,43 +450,48 @@ export class PaymentsService {
   async linkToRegistration(paymentId: string, registrationId: string): Promise<Payment> {
     // Check if payment exists
     const payment = await this.findOne(paymentId);
-    
+
     // Check if registration exists
     const registration = await this.prisma.registration.findUnique({
       where: { id: registrationId },
       include: { payments: true },
     });
-    
+
     if (!registration) {
       throw new NotFoundException(`Registration with ID ${registrationId} not found`);
     }
-    
+
     // Prevent linking payments to registrations in application phase
     if (isApplicationStatus(registration.status)) {
-      throw new BadRequestException('Cannot link payment to a registration that has not completed the application process');
+      throw new BadRequestException(
+        'Cannot link payment to a registration that has not completed the application process'
+      );
     }
 
     // Check if registration belongs to the same user as the payment
     if (registration.userId !== payment.userId) {
       throw new BadRequestException('Registration does not belong to the same user as the payment');
     }
-    
+
     // Check if payment is already linked to this registration
     if (payment.registrationId === registrationId) {
       throw new BadRequestException(`Payment is already linked to registration ${registrationId}`);
     }
-    
+
     try {
       // Update payment to link it to the registration
       const updatedPayment = await this.prisma.payment.update({
         where: { id: paymentId },
         data: { registrationId },
       });
-      
+
       return updatedPayment;
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(`Failed to link payment to registration: ${errorMessage}`, error instanceof Error ? error.stack : undefined);
+      this.logger.error(
+        `Failed to link payment to registration: ${errorMessage}`,
+        error instanceof Error ? error.stack : undefined
+      );
       throw error;
     }
   }
@@ -406,23 +513,20 @@ export class PaymentsService {
    */
   async recordExternalPayment(
     data: CreateExternalPaymentDto,
-    adminUserId: string,
+    adminUserId: string
   ): Promise<AdminPayment> {
     const canonicalRequest = this.canonicalizeExternalPayment(data);
     const transactionId = randomUUID();
 
     try {
-      return await this.prisma.$transaction(async (tx) => {
+      return await this.prisma.$transaction(async tx => {
         const existingPayment = await tx.payment.findUnique({
           where: { idempotencyKey: data.idempotencyKey },
           select: externalPaymentSelect,
         });
 
         if (existingPayment) {
-          return this.resolveExternalPaymentReplay(
-            existingPayment,
-            canonicalRequest,
-          );
+          return this.resolveExternalPaymentReplay(existingPayment, canonicalRequest);
         }
 
         const registration = await tx.registration.findUnique({
@@ -435,9 +539,7 @@ export class PaymentsService {
         });
 
         if (!registration) {
-          throw new NotFoundException(
-            `Registration with ID ${data.registrationId} not found`,
-          );
+          throw new NotFoundException(`Registration with ID ${data.registrationId} not found`);
         }
 
         this.validateExternalPaymentRegistration(registration.status);
@@ -464,14 +566,11 @@ export class PaymentsService {
           });
 
           if (concurrentPayment) {
-            return this.resolveExternalPaymentReplay(
-              concurrentPayment,
-              canonicalRequest,
-            );
+            return this.resolveExternalPaymentReplay(concurrentPayment, canonicalRequest);
           }
 
           throw new ConflictException(
-            'Registration changed while recording payment; refresh and retry',
+            'Registration changed while recording payment; refresh and retry'
           );
         }
 
@@ -528,16 +627,11 @@ export class PaymentsService {
         throw error;
       }
 
-      return this.resolveExternalPaymentReplay(
-        existingPayment,
-        canonicalRequest,
-      );
+      return this.resolveExternalPaymentReplay(existingPayment, canonicalRequest);
     }
   }
 
-  private canonicalizeExternalPayment(
-    data: CreateExternalPaymentDto,
-  ): CanonicalExternalPayment {
+  private canonicalizeExternalPayment(data: CreateExternalPaymentDto): CanonicalExternalPayment {
     try {
       return {
         registrationId: data.registrationId,
@@ -557,7 +651,7 @@ export class PaymentsService {
 
   private resolveExternalPaymentReplay(
     existingPayment: ExternalPaymentRecord,
-    canonicalRequest: CanonicalExternalPayment,
+    canonicalRequest: CanonicalExternalPayment
   ): AdminPayment {
     const existingCanonicalRequest: CanonicalExternalPayment = {
       registrationId: existingPayment.registrationId ?? '',
@@ -568,24 +662,27 @@ export class PaymentsService {
     };
 
     if (
-      existingCanonicalRequest.registrationId !==
-        canonicalRequest.registrationId ||
+      existingCanonicalRequest.registrationId !== canonicalRequest.registrationId ||
       existingCanonicalRequest.amountCents !== canonicalRequest.amountCents ||
       existingCanonicalRequest.currency !== canonicalRequest.currency ||
-      existingCanonicalRequest.externalMethod !==
-        canonicalRequest.externalMethod ||
-      existingCanonicalRequest.externalReference !==
-        canonicalRequest.externalReference
+      existingCanonicalRequest.externalMethod !== canonicalRequest.externalMethod ||
+      existingCanonicalRequest.externalReference !== canonicalRequest.externalReference
     ) {
       throw new ConflictException(
-        'Idempotency key has already been used with different payment data',
+        'Idempotency key has already been used with different payment data'
       );
     }
 
     return this.toAdminPayment(existingPayment);
   }
 
-  private toAdminPayment(payment: ExternalPaymentRecord): AdminPayment {
+  private toAdminPayment(payment: AdminPaymentRecord | ExternalPaymentRecord): AdminPayment {
+    const totals = this.calculateRefundTotals(
+      dollarsToCents(payment.amount),
+      payment.refunds,
+      payment.status === PaymentStatus.REFUNDED
+    );
+
     return {
       id: payment.id,
       amount: payment.amount,
@@ -600,32 +697,429 @@ export class PaymentsService {
       registrationId: payment.registrationId,
       user: payment.user,
       registration: payment.registration,
+      refunds: payment.refunds,
+      ...totals,
     };
   }
 
-  private validateExternalPaymentRegistration(
-    status: RegistrationStatus,
-  ): void {
+  private calculateRefundTotals(
+    paymentAmountCents: number,
+    refunds: ReadonlyArray<{
+      amountCents: number;
+      status: PaymentRefundStatus;
+    }>,
+    forceFullyRefunded = false
+  ): RefundTotals {
+    if (forceFullyRefunded) {
+      return {
+        paymentAmountCents,
+        successfulRefundCents: paymentAmountCents,
+        pendingRefundCents: 0,
+        availableRefundCents: 0,
+      };
+    }
+
+    const successfulRefundCents = refunds
+      .filter(refund => refund.status === PaymentRefundStatus.SUCCEEDED)
+      .reduce((total, refund) => total + refund.amountCents, 0);
+    const pendingRefundCents = refunds
+      .filter(refund => refund.status === PaymentRefundStatus.PENDING)
+      .reduce((total, refund) => total + refund.amountCents, 0);
+
+    return {
+      paymentAmountCents,
+      successfulRefundCents,
+      pendingRefundCents,
+      availableRefundCents: paymentAmountCents - successfulRefundCents - pendingRefundCents,
+    };
+  }
+
+  private validateExternalPaymentRegistration(status: RegistrationStatus): void {
     if (isApplicationStatus(status)) {
       throw new BadRequestException(
-        'Cannot record payment for a registration in the application phase',
+        'Cannot record payment for a registration in the application phase'
       );
     }
 
     if (status === RegistrationStatus.CANCELLED) {
-      throw new BadRequestException(
-        'Cannot record payment for a cancelled registration',
-      );
+      throw new BadRequestException('Cannot record payment for a cancelled registration');
     }
   }
 
   private isUniqueConstraintError(error: unknown): boolean {
-    return (
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      error.code === 'P2002'
+    return typeof error === 'object' && error !== null && 'code' in error && error.code === 'P2002';
+  }
+
+  /**
+   * Records a manual refund that already completed outside PlayaPlan.
+   */
+  async createManualRefund(
+    paymentId: string,
+    data: CreateRefundDto,
+    adminUserId: string
+  ): Promise<ManualRefundResult> {
+    const canonicalRequest = this.canonicalizeManualRefund(data);
+
+    try {
+      return await this.prisma.$transaction(
+        async tx => {
+          const existingRefund = await tx.paymentRefund.findUnique({
+            where: { idempotencyKey: data.idempotencyKey },
+            select: internalRefundSelect,
+          });
+
+          if (existingRefund && existingRefund.paymentId !== paymentId) {
+            throw new ConflictException(
+              'Idempotency key has already been used with different refund data'
+            );
+          }
+
+          const payment = await tx.payment.findUnique({
+            where: { id: paymentId },
+            select: adminPaymentSelect,
+          });
+
+          if (!payment) {
+            throw new NotFoundException(`Payment with ID ${paymentId} not found`);
+          }
+
+          if (existingRefund) {
+            const replayAudit = await tx.adminAudit.findFirst({
+              where: {
+                transactionId: data.idempotencyKey,
+                actionType: AdminAuditActionType.PAYMENT_REFUND,
+                targetRecordType: AdminAuditTargetType.PAYMENT,
+                targetRecordId: paymentId,
+              },
+              select: { newValues: true },
+            });
+
+            return this.resolveManualRefundReplay(
+              payment,
+              existingRefund,
+              replayAudit?.newValues,
+              canonicalRequest
+            );
+          }
+
+          this.validateManualRefundPayment(payment.status);
+          this.validateManualRefundRegistration(
+            payment.registrationId,
+            canonicalRequest.resultingRegistrationStatus
+          );
+
+          const paymentAmountCents = this.getPaymentAmountCents(payment.amount);
+          const currentTotals = this.calculateRefundTotals(paymentAmountCents, payment.refunds);
+          if (currentTotals.availableRefundCents <= 0) {
+            throw new BadRequestException('Payment has no refundable balance available');
+          }
+
+          const refundAmountCents = canonicalRequest.fullRefund
+            ? currentTotals.availableRefundCents
+            : canonicalRequest.amountCents;
+          if (
+            refundAmountCents === undefined ||
+            refundAmountCents > currentTotals.availableRefundCents
+          ) {
+            throw new BadRequestException(
+              `Refund amount exceeds available balance of ${currentTotals.availableRefundCents} cents`
+            );
+          }
+
+          const createdRefund = await tx.paymentRefund.create({
+            data: {
+              paymentId,
+              amountCents: refundAmountCents,
+              currency: normalizeCurrency(payment.currency),
+              executionMode: RefundExecutionMode.MANUAL,
+              status: PaymentRefundStatus.SUCCEEDED,
+              reason: canonicalRequest.reason,
+              externalReference: canonicalRequest.externalReference,
+              idempotencyKey: data.idempotencyKey,
+              processedByUserId: adminUserId,
+              resultingRegistrationStatus: canonicalRequest.resultingRegistrationStatus,
+            },
+            select: internalRefundSelect,
+          });
+
+          const successfulRefundCents = currentTotals.successfulRefundCents + refundAmountCents;
+          const resultingPaymentStatus =
+            successfulRefundCents === paymentAmountCents
+              ? PaymentStatus.REFUNDED
+              : PaymentStatus.PARTIALLY_REFUNDED;
+
+          await tx.payment.update({
+            where: { id: paymentId },
+            data: { status: resultingPaymentStatus },
+          });
+
+          if (payment.registrationId && canonicalRequest.resultingRegistrationStatus) {
+            await tx.registration.update({
+              where: { id: payment.registrationId },
+              data: {
+                status: canonicalRequest.resultingRegistrationStatus,
+              },
+            });
+          }
+
+          await tx.adminAudit.create({
+            data: {
+              adminUserId,
+              actionType: AdminAuditActionType.PAYMENT_REFUND,
+              targetRecordType: AdminAuditTargetType.PAYMENT,
+              targetRecordId: paymentId,
+              transactionId: data.idempotencyKey,
+              newValues: {
+                outcome: PaymentRefundStatus.SUCCEEDED,
+                paymentId,
+                refundId: createdRefund.id,
+                registrationId: payment.registrationId,
+                amountCents: refundAmountCents,
+                currency: normalizeCurrency(payment.currency),
+                executionMode: RefundExecutionMode.MANUAL,
+                reason: canonicalRequest.reason,
+                externalReference: canonicalRequest.externalReference,
+                resultingRegistrationStatus: canonicalRequest.resultingRegistrationStatus,
+                requestedFullRefund: canonicalRequest.fullRefund,
+              },
+              reason: canonicalRequest.reason,
+            },
+          });
+
+          const updatedPayment = await tx.payment.findUnique({
+            where: { id: paymentId },
+            select: adminPaymentSelect,
+          });
+          if (!updatedPayment) {
+            throw new NotFoundException(`Payment with ID ${paymentId} not found after refund`);
+          }
+
+          return this.buildManualRefundResult(updatedPayment, createdRefund);
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+      );
+    } catch (error: unknown) {
+      if (this.isSerializationConflict(error)) {
+        throw new ConflictException(
+          'Refund balance changed concurrently; refresh the payment and retry'
+        );
+      }
+
+      if (!this.isUniqueConstraintError(error)) {
+        throw error;
+      }
+
+      const replay = await this.findManualRefundReplay(
+        paymentId,
+        data.idempotencyKey,
+        canonicalRequest
+      );
+      if (!replay) {
+        throw error;
+      }
+
+      return replay;
+    }
+  }
+
+  private canonicalizeManualRefund(data: CreateRefundDto): CanonicalManualRefund {
+    if (data.executionMode !== RefundExecutionMode.MANUAL) {
+      throw new BadRequestException(
+        'Only MANUAL executionMode is supported for this refund command'
+      );
+    }
+
+    const hasAmount = data.amountCents !== undefined;
+    const hasFullRefund = data.fullRefund !== undefined;
+    if (
+      hasAmount === hasFullRefund ||
+      (hasAmount && (!Number.isSafeInteger(data.amountCents) || (data.amountCents ?? 0) <= 0)) ||
+      (hasFullRefund && data.fullRefund !== true)
+    ) {
+      throw new BadRequestException(
+        'Provide exactly one of a positive integer amountCents or fullRefund: true'
+      );
+    }
+
+    this.validateResultingRegistrationStatus(data.resultingRegistrationStatus);
+
+    return {
+      amountCents: data.amountCents,
+      fullRefund: data.fullRefund === true,
+      executionMode: RefundExecutionMode.MANUAL,
+      reason: data.reason?.trim() || null,
+      externalReference: data.externalReference?.trim() || null,
+      resultingRegistrationStatus: data.resultingRegistrationStatus ?? null,
+    };
+  }
+
+  private validateManualRefundPayment(status: PaymentStatus): void {
+    if (status !== PaymentStatus.COMPLETED && status !== PaymentStatus.PARTIALLY_REFUNDED) {
+      throw new BadRequestException(`Cannot refund payment with status ${status}`);
+    }
+  }
+
+  private validateManualRefundRegistration(
+    registrationId: string | null,
+    resultingStatus: RegistrationStatus | null
+  ): void {
+    if (resultingStatus && !registrationId) {
+      throw new BadRequestException(
+        'Cannot apply a registration status to a payment without a registration'
+      );
+    }
+  }
+
+  private validateResultingRegistrationStatus(status: RegistrationStatus | undefined): void {
+    if (
+      status === undefined ||
+      status === RegistrationStatus.PENDING ||
+      status === RegistrationStatus.CONFIRMED ||
+      status === RegistrationStatus.WAITLISTED
+    ) {
+      return;
+    }
+
+    throw new BadRequestException(
+      'resultingRegistrationStatus must be PENDING, CONFIRMED, or WAITLISTED; use the cancellation workflow to cancel a registration'
     );
+  }
+
+  private getPaymentAmountCents(amount: number): number {
+    try {
+      return dollarsToCents(amount);
+    } catch (error: unknown) {
+      if (error instanceof RangeError) {
+        throw new BadRequestException(error.message);
+      }
+
+      throw error;
+    }
+  }
+
+  private resolveManualRefundReplay(
+    payment: AdminPaymentRecord,
+    existingRefund: InternalRefundRecord,
+    auditValues: Prisma.JsonValue | null | undefined,
+    canonicalRequest: CanonicalManualRefund
+  ): ManualRefundResult {
+    const requestedFullRefund = this.getRequestedFullRefundFromAudit(auditValues);
+    const amountMatches = canonicalRequest.fullRefund
+      ? existingRefund.amountCents ===
+        this.calculateRefundTotals(
+          this.getPaymentAmountCents(payment.amount),
+          payment.refunds.filter(refund => refund.id !== existingRefund.id)
+        ).availableRefundCents
+      : existingRefund.amountCents === canonicalRequest.amountCents;
+
+    if (
+      requestedFullRefund === null ||
+      requestedFullRefund !== canonicalRequest.fullRefund ||
+      !amountMatches ||
+      existingRefund.executionMode !== canonicalRequest.executionMode ||
+      existingRefund.reason !== canonicalRequest.reason ||
+      existingRefund.externalReference !== canonicalRequest.externalReference ||
+      existingRefund.resultingRegistrationStatus !== canonicalRequest.resultingRegistrationStatus
+    ) {
+      throw new ConflictException(
+        'Idempotency key has already been used with different refund data'
+      );
+    }
+
+    return this.buildManualRefundResult(payment, existingRefund);
+  }
+
+  private getRequestedFullRefundFromAudit(
+    auditValues: Prisma.JsonValue | null | undefined
+  ): boolean | null {
+    if (
+      typeof auditValues !== 'object' ||
+      auditValues === null ||
+      Array.isArray(auditValues) ||
+      !('requestedFullRefund' in auditValues) ||
+      typeof auditValues.requestedFullRefund !== 'boolean'
+    ) {
+      return null;
+    }
+
+    return auditValues.requestedFullRefund;
+  }
+
+  private buildManualRefundResult(
+    payment: AdminPaymentRecord,
+    refund: InternalRefundRecord
+  ): ManualRefundResult {
+    const adminPayment = this.toAdminPayment(payment);
+
+    return {
+      payment: adminPayment,
+      refund: {
+        id: refund.id,
+        amountCents: refund.amountCents,
+        currency: refund.currency,
+        executionMode: refund.executionMode,
+        status: refund.status,
+        reason: refund.reason,
+        externalReference: refund.externalReference,
+        resultingRegistrationStatus: refund.resultingRegistrationStatus,
+        createdAt: refund.createdAt,
+        updatedAt: refund.updatedAt,
+      },
+      paymentAmountCents: adminPayment.paymentAmountCents,
+      successfulRefundCents: adminPayment.successfulRefundCents,
+      pendingRefundCents: adminPayment.pendingRefundCents,
+      availableRefundCents: adminPayment.availableRefundCents,
+    };
+  }
+
+  private async findManualRefundReplay(
+    paymentId: string,
+    idempotencyKey: string,
+    canonicalRequest: CanonicalManualRefund
+  ): Promise<ManualRefundResult | null> {
+    const existingRefund = await this.prisma.paymentRefund.findUnique({
+      where: { idempotencyKey },
+      select: internalRefundSelect,
+    });
+    if (!existingRefund) {
+      return null;
+    }
+
+    if (existingRefund.paymentId !== paymentId) {
+      throw new ConflictException(
+        'Idempotency key has already been used with different refund data'
+      );
+    }
+
+    const [payment, replayAudit] = await Promise.all([
+      this.prisma.payment.findUnique({
+        where: { id: paymentId },
+        select: adminPaymentSelect,
+      }),
+      this.prisma.adminAudit.findFirst({
+        where: {
+          transactionId: idempotencyKey,
+          actionType: AdminAuditActionType.PAYMENT_REFUND,
+          targetRecordType: AdminAuditTargetType.PAYMENT,
+          targetRecordId: paymentId,
+        },
+        select: { newValues: true },
+      }),
+    ]);
+    if (!payment) {
+      throw new NotFoundException(`Payment with ID ${paymentId} not found`);
+    }
+
+    return this.resolveManualRefundReplay(
+      payment,
+      existingRefund,
+      replayAudit?.newValues,
+      canonicalRequest
+    );
+  }
+
+  private isSerializationConflict(error: unknown): boolean {
+    return typeof error === 'object' && error !== null && 'code' in error && error.code === 'P2034';
   }
 
   /**
@@ -633,13 +1127,17 @@ export class PaymentsService {
    * @param data - Stripe payment data
    * @returns Payment intent or checkout session information
    */
-  async initiateStripePayment(data: CreateStripePaymentDto): Promise<{ paymentId: string; clientSecret?: string; url?: string }> {
+  async initiateStripePayment(
+    data: CreateStripePaymentDto
+  ): Promise<{ paymentId: string; clientSecret?: string; url?: string }> {
     try {
-      this.logger.log(`Initiating Stripe payment for user ${data.userId}, registrationId: ${data.registrationId || 'none'}, amount: ${data.amount}`);
-      
+      this.logger.log(
+        `Initiating Stripe payment for user ${data.userId}, registrationId: ${data.registrationId || 'none'}, amount: ${data.amount}`
+      );
+
       // Create checkout session
       const session = await this.stripeService.createCheckoutSession(data);
-      
+
       // Create payment record
       const payment = await this.create({
         amount: data.amount / 100, // Convert from cents
@@ -649,14 +1147,17 @@ export class PaymentsService {
         registrationId: data.registrationId,
         providerRefId: session.id,
       });
-      
+
       return {
         paymentId: payment.id,
         url: session.url || undefined,
       };
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(`Failed to initiate Stripe payment: ${errorMessage}`, error instanceof Error ? error.stack : undefined);
+      this.logger.error(
+        `Failed to initiate Stripe payment: ${errorMessage}`,
+        error instanceof Error ? error.stack : undefined
+      );
       throw error;
     }
   }
@@ -666,18 +1167,20 @@ export class PaymentsService {
    * @param data - PayPal payment data
    * @returns PayPal order information with approval URL
    */
-  async initiatePaypalPayment(data: CreatePaypalPaymentDto): Promise<{ paymentId: string; orderId: string; approvalUrl: string }> {
+  async initiatePaypalPayment(
+    data: CreatePaypalPaymentDto
+  ): Promise<{ paymentId: string; orderId: string; approvalUrl: string }> {
     try {
       // Create PayPal order
       const order = await this.paypalService.createOrder(data);
-      
+
       // Find approval URL
       const approvalUrl = order.links.find((link: PayPalLink) => link.rel === 'approve')?.href;
-      
+
       if (!approvalUrl) {
         throw new BadRequestException('PayPal order missing approval URL');
       }
-      
+
       // Create payment record
       const payment = await this.create({
         amount: data.amount,
@@ -687,7 +1190,7 @@ export class PaymentsService {
         registrationId: data.registrationId,
         providerRefId: order.id,
       });
-      
+
       return {
         paymentId: payment.id,
         orderId: order.id,
@@ -695,7 +1198,10 @@ export class PaymentsService {
       };
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(`Failed to initiate PayPal payment: ${errorMessage}`, error instanceof Error ? error.stack : undefined);
+      this.logger.error(
+        `Failed to initiate PayPal payment: ${errorMessage}`,
+        error instanceof Error ? error.stack : undefined
+      );
       throw error;
     }
   }
@@ -704,12 +1210,14 @@ export class PaymentsService {
    * Process a PayPal webhook event
    * Not yet implemented - would be similar to Stripe webhook handling
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async handlePaypalWebhook(_payload: Record<string, unknown>): Promise<{ received: boolean; type: string }> {
+  async handlePaypalWebhook(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _payload: Record<string, unknown>
+  ): Promise<{ received: boolean; type: string }> {
     // Implementation would be similar to Stripe webhook handling
     // PayPal webhooks have their own format and verification methods
     this.logger.log('PayPal webhook received, but handling not yet implemented');
-    
+
     return { received: true, type: 'paypal.webhook' };
   }
 
@@ -718,65 +1226,65 @@ export class PaymentsService {
    * @param data - Refund data
    * @returns Refund processing result
    */
-  async processRefund(data: CreateRefundDto): Promise<RefundResult> {
+  async processRefund(data: LegacyRefundRequest): Promise<RefundResult> {
     // Check if payment exists
     const payment = await this.findOne(data.paymentId);
-    
+
     // Can only refund completed payments
     if (payment.status !== PaymentStatus.COMPLETED) {
       throw new BadRequestException(`Cannot refund payment with status ${payment.status}`);
     }
-    
+
     try {
       // Calculate refund amount
       let refundAmount = data.amount;
-      
+
       if (!refundAmount && data.percentageOfOriginal) {
         refundAmount = (payment.amount * data.percentageOfOriginal) / 100;
       }
-      
+
       if (!refundAmount) {
         refundAmount = payment.amount; // Full refund
       }
-      
+
       // Process refund with payment provider
       let providerRefund: ProviderRefund;
-      
+
       if (payment.provider === PaymentProvider.STRIPE) {
         if (!payment.providerRefId) {
           throw new BadRequestException('Payment has no provider reference ID');
         }
-        
+
         // Convert from dollars (database) to cents (Stripe expects cents)
         const refundAmountCents = Math.round(refundAmount * 100);
-        
+
         providerRefund = await this.stripeService.createRefund(
           payment.providerRefId,
           refundAmountCents,
-          data.reason,
+          data.reason
         );
       } else if (payment.provider === PaymentProvider.PAYPAL) {
         if (!payment.providerRefId) {
           throw new BadRequestException('Payment has no provider reference ID');
         }
-        
+
         // Use dollar amount as-is since PayPal expects dollar amounts and database stores in dollars
         providerRefund = await this.paypalService.createRefund(
           payment.providerRefId,
           refundAmount,
-          data.reason,
+          data.reason
         );
       } else {
         // Manual refund (just update the database)
         providerRefund = { id: `manual-refund-${Date.now()}` };
       }
-      
+
       // Update payment status
       await this.update(payment.id, {
         status: PaymentStatus.REFUNDED,
         // notes field removed as it's not in the Prisma schema
       });
-      
+
       // If there's a registration, update its status
       if (payment.registration) {
         await this.prisma.registration.update({
@@ -784,7 +1292,7 @@ export class PaymentsService {
           data: { status: 'CANCELLED' },
         });
       }
-      
+
       return {
         paymentId: payment.id,
         refundAmount,
@@ -793,7 +1301,10 @@ export class PaymentsService {
       };
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(`Failed to process refund: ${errorMessage}`, error instanceof Error ? error.stack : undefined);
+      this.logger.error(
+        `Failed to process refund: ${errorMessage}`,
+        error instanceof Error ? error.stack : undefined
+      );
       throw error;
     }
   }
@@ -813,30 +1324,34 @@ export class PaymentsService {
   }> {
     try {
       // Find payment with this session ID
-      const payment = await this.prisma.payment.findFirst({
+      const payment = (await this.prisma.payment.findFirst({
         where: { providerRefId: sessionId },
         include: { registration: true },
-      }) as PaymentWithRelations;
-      
+      })) as PaymentWithRelations;
+
       if (!payment) {
         throw new NotFoundException(`Payment not found for Stripe session ${sessionId}`);
       }
 
-      this.logger.log(`Found payment ${payment.id} for session ${sessionId}, registration: ${payment.registration?.id || 'none'}, registration status: ${payment.registration?.status || 'none'}`);
+      this.logger.log(
+        `Found payment ${payment.id} for session ${sessionId}, registration: ${payment.registration?.id || 'none'}, registration status: ${payment.registration?.status || 'none'}`
+      );
 
       // Get the actual session status from Stripe
       const stripeSession = await this.stripeService.getCheckoutSession(sessionId);
-      
-      this.logger.log(`Stripe session ${sessionId} status: ${stripeSession.status}, payment_status: ${stripeSession.payment_status}`);
-      
+
+      this.logger.log(
+        `Stripe session ${sessionId} status: ${stripeSession.status}, payment_status: ${stripeSession.payment_status}`
+      );
+
       // Determine the payment status based on Stripe session
       let updatedPaymentStatus = payment.status;
       let updatedRegistrationStatus = payment.registration?.status;
-      
+
       if (stripeSession.payment_status === 'paid') {
         // Payment was successful - mark payment and registration as complete
         updatedPaymentStatus = PaymentStatus.COMPLETED;
-        
+
         if (payment.registration) {
           // Capacity beats payment: a WAITLISTED registration must NOT be
           // promoted to CONFIRMED just because the user paid. The
@@ -872,8 +1387,10 @@ export class PaymentsService {
             payment.registration.paymentDeferred
           ) {
             try {
-              this.logger.log(`Updating payment ${payment.id} to COMPLETED and registration ${payment.registration.id} to ${targetStatus} (paymentDeferred cleared)`);
-              
+              this.logger.log(
+                `Updating payment ${payment.id} to COMPLETED and registration ${payment.registration.id} to ${targetStatus} (paymentDeferred cleared)`
+              );
+
               try {
                 // Use transaction to ensure atomicity between payment and registration updates
                 const transactionResults = await this.prisma.$transaction([
@@ -886,12 +1403,14 @@ export class PaymentsService {
                     data: { status: targetStatus, paymentDeferred: false },
                   }),
                 ]);
-                
+
                 this.logger.log(`Successfully updated payment and registration statuses`);
-                this.logger.debug(`Transaction results: ${JSON.stringify({
-                  payment: transactionResults[0].id,
-                  registration: transactionResults[1].id
-                })}`);
+                this.logger.debug(
+                  `Transaction results: ${JSON.stringify({
+                    payment: transactionResults[0].id,
+                    registration: transactionResults[1].id,
+                  })}`
+                );
 
                 // Send registration confirmation email with the updated
                 // status — but skip it for a deferred → paid transition,
@@ -900,33 +1419,47 @@ export class PaymentsService {
                 // deferred" notice). Sending it again would duplicate.
                 const wasDeferred = payment.registration.paymentDeferred === true;
                 if (!wasDeferred) {
-                  this.sendRegistrationConfirmationEmailAfterPayment(payment.registration.id)
-                    .catch(emailError => {
-                      this.logger.warn(`Failed to send registration confirmation email: ${emailError instanceof Error ? emailError.message : 'Unknown error'}`);
-                    });
+                  this.sendRegistrationConfirmationEmailAfterPayment(payment.registration.id).catch(
+                    emailError => {
+                      this.logger.warn(
+                        `Failed to send registration confirmation email: ${emailError instanceof Error ? emailError.message : 'Unknown error'}`
+                      );
+                    }
+                  );
                 }
               } catch (transactionError) {
                 // If the transaction fails, at least try to update the payment status
                 // This ensures we record the successful Stripe payment even if registration update fails
-                this.logger.warn(`Transaction failed, falling back to payment-only update: ${transactionError instanceof Error ? transactionError.message : 'Unknown error'}`);
-                
+                this.logger.warn(
+                  `Transaction failed, falling back to payment-only update: ${transactionError instanceof Error ? transactionError.message : 'Unknown error'}`
+                );
+
                 if (payment.status !== PaymentStatus.COMPLETED) {
                   await this.prisma.payment.update({
                     where: { id: payment.id },
-                    data: { 
-                      status: PaymentStatus.COMPLETED
+                    data: {
+                      status: PaymentStatus.COMPLETED,
                     },
                   });
-                  this.logger.log(`Updated payment ${payment.id} to COMPLETED (registration update failed: ${transactionError instanceof Error ? transactionError.message : 'Unknown error'})`);
+                  this.logger.log(
+                    `Updated payment ${payment.id} to COMPLETED (registration update failed: ${transactionError instanceof Error ? transactionError.message : 'Unknown error'})`
+                  );
                 }
               }
             } catch (error) {
               const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-              this.logger.error(`Failed to update statuses: ${errorMessage}`, error instanceof Error ? error.stack : undefined);
-              throw new BadRequestException(`Failed to update payment or registration status: ${errorMessage}`);
+              this.logger.error(
+                `Failed to update statuses: ${errorMessage}`,
+                error instanceof Error ? error.stack : undefined
+              );
+              throw new BadRequestException(
+                `Failed to update payment or registration status: ${errorMessage}`
+              );
             }
           } else {
-            this.logger.log(`Both payment and registration already have correct statuses, no update needed`);
+            this.logger.log(
+              `Both payment and registration already have correct statuses, no update needed`
+            );
           }
         } else {
           // No registration linked, just update the payment if needed
@@ -939,20 +1472,25 @@ export class PaymentsService {
             this.logger.log(`Payment ${payment.id} already marked as COMPLETED (no registration)`);
           }
         }
-      } else if (stripeSession.payment_status === 'unpaid' && payment.status === PaymentStatus.PENDING) {
+      } else if (
+        stripeSession.payment_status === 'unpaid' &&
+        payment.status === PaymentStatus.PENDING
+      ) {
         // Payment is still pending or failed
         if (stripeSession.status === 'expired') {
-          this.logger.log(`Updating payment ${payment.id} status to FAILED based on expired Stripe session`);
-          
+          this.logger.log(
+            `Updating payment ${payment.id} status to FAILED based on expired Stripe session`
+          );
+
           await this.update(payment.id, {
             status: PaymentStatus.FAILED,
             // notes field removed as it's not in the Prisma schema
           });
-          
+
           updatedPaymentStatus = PaymentStatus.FAILED;
         }
       }
-      
+
       return {
         sessionId,
         paymentStatus: updatedPaymentStatus,
@@ -965,7 +1503,10 @@ export class PaymentsService {
         throw error;
       }
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(`Failed to verify Stripe session: ${errorMessage}`, error instanceof Error ? error.stack : undefined);
+      this.logger.error(
+        `Failed to verify Stripe session: ${errorMessage}`,
+        error instanceof Error ? error.stack : undefined
+      );
       throw new BadRequestException('Failed to verify Stripe session');
     }
   }
@@ -974,7 +1515,9 @@ export class PaymentsService {
    * Send registration confirmation email after payment completion
    * @param registrationId - The registration ID
    */
-  private async sendRegistrationConfirmationEmailAfterPayment(registrationId: string): Promise<void> {
+  private async sendRegistrationConfirmationEmailAfterPayment(
+    registrationId: string
+  ): Promise<void> {
     try {
       // Get the updated registration with all necessary data
       const registration = await this.prisma.registration.findUnique({
@@ -1022,17 +1565,18 @@ export class PaymentsService {
       }));
 
       // Format jobs from registration
-      const jobs = registration.jobs?.map((regJob) => ({
-        name: regJob.job?.name || 'Unknown Job',
-        category: regJob.job?.category?.name || 'Unknown Category',
-        shift: {
-          name: regJob.job?.shift?.name || 'Unknown Shift',
-          startTime: regJob.job?.shift?.startTime || '',
-          endTime: regJob.job?.shift?.endTime || '',
-          dayOfWeek: regJob.job?.shift?.dayOfWeek || '',
-        },
-        location: regJob.job?.location || 'TBD',
-      })) || [];
+      const jobs =
+        registration.jobs?.map(regJob => ({
+          name: regJob.job?.name || 'Unknown Job',
+          category: regJob.job?.category?.name || 'Unknown Category',
+          shift: {
+            name: regJob.job?.shift?.name || 'Unknown Shift',
+            startTime: regJob.job?.shift?.startTime || '',
+            endTime: regJob.job?.shift?.endTime || '',
+            dayOfWeek: regJob.job?.shift?.dayOfWeek || '',
+          },
+          location: regJob.job?.location || 'TBD',
+        })) || [];
 
       const registrationDetails = {
         id: registration.id,
@@ -1045,9 +1589,10 @@ export class PaymentsService {
       };
 
       // Build user name for email personalization
-      const userName = registration.user.firstName && registration.user.lastName 
-        ? `${registration.user.firstName} ${registration.user.lastName}` 
-        : undefined;
+      const userName =
+        registration.user.firstName && registration.user.lastName
+          ? `${registration.user.firstName} ${registration.user.lastName}`
+          : undefined;
 
       await this.notificationsService.sendRegistrationConfirmationEmail(
         registration.user.email,
@@ -1057,10 +1602,15 @@ export class PaymentsService {
         registration.user.playaName || undefined
       );
 
-      this.logger.log(`Registration confirmation email sent to ${registration.user.email} with status ${registration.status}`);
+      this.logger.log(
+        `Registration confirmation email sent to ${registration.user.email} with status ${registration.status}`
+      );
     } catch (error: unknown) {
       const err = error as Error;
-      this.logger.error(`Error sending registration confirmation email after payment: ${err.message}`, err.stack);
+      this.logger.error(
+        `Error sending registration confirmation email after payment: ${err.message}`,
+        err.stack
+      );
       // Don't throw - email failures should not block payment processing
     }
   }

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -154,10 +154,11 @@ type InternalRefundRecord = Prisma.PaymentRefundGetPayload<{
 }>;
 
 interface RefundTotals {
-  paymentAmountCents: number;
+  paymentAmountCents: number | null;
   successfulRefundCents: number;
   pendingRefundCents: number;
   availableRefundCents: number;
+  refundUnavailableReason: string | null;
 }
 
 export type AdminPayment = AdminPaymentRecord & RefundTotals;
@@ -193,6 +194,8 @@ interface LegacyRefundRequest {
 
 const DEFAULT_ADMIN_PAYMENT_PAGE_SIZE = 25;
 const MAX_ADMIN_PAYMENT_PAGE_SIZE = 100;
+const UNSUPPORTED_PAYMENT_PRECISION_REASON =
+  'Refund unavailable because the stored payment amount has unsupported precision.';
 
 // Interface for refund result
 export interface RefundResult {
@@ -677,11 +680,7 @@ export class PaymentsService {
   }
 
   private toAdminPayment(payment: AdminPaymentRecord | ExternalPaymentRecord): AdminPayment {
-    const totals = this.calculateRefundTotals(
-      dollarsToCents(payment.amount),
-      payment.refunds,
-      payment.status === PaymentStatus.REFUNDED
-    );
+    const totals = this.getAdminRefundTotals(payment);
 
     return {
       id: payment.id,
@@ -702,6 +701,30 @@ export class PaymentsService {
     };
   }
 
+  private getAdminRefundTotals(
+    payment: AdminPaymentRecord | ExternalPaymentRecord
+  ): RefundTotals {
+    try {
+      return this.calculateRefundTotals(
+        dollarsToCents(payment.amount),
+        payment.refunds,
+        payment.status === PaymentStatus.REFUNDED
+      );
+    } catch (error: unknown) {
+      if (!(error instanceof RangeError)) {
+        throw error;
+      }
+
+      const ledgerTotals = this.calculateRefundLedgerTotals(payment.refunds);
+      return {
+        paymentAmountCents: null,
+        ...ledgerTotals,
+        availableRefundCents: 0,
+        refundUnavailableReason: UNSUPPORTED_PAYMENT_PRECISION_REASON,
+      };
+    }
+  }
+
   private calculateRefundTotals(
     paymentAmountCents: number,
     refunds: ReadonlyArray<{
@@ -716,9 +739,29 @@ export class PaymentsService {
         successfulRefundCents: paymentAmountCents,
         pendingRefundCents: 0,
         availableRefundCents: 0,
+        refundUnavailableReason: null,
       };
     }
 
+    const ledgerTotals = this.calculateRefundLedgerTotals(refunds);
+
+    return {
+      paymentAmountCents,
+      ...ledgerTotals,
+      availableRefundCents:
+        paymentAmountCents -
+        ledgerTotals.successfulRefundCents -
+        ledgerTotals.pendingRefundCents,
+      refundUnavailableReason: null,
+    };
+  }
+
+  private calculateRefundLedgerTotals(
+    refunds: ReadonlyArray<{
+      amountCents: number;
+      status: PaymentRefundStatus;
+    }>
+  ): Pick<RefundTotals, 'successfulRefundCents' | 'pendingRefundCents'> {
     const successfulRefundCents = refunds
       .filter(refund => refund.status === PaymentRefundStatus.SUCCEEDED)
       .reduce((total, refund) => total + refund.amountCents, 0);
@@ -727,10 +770,8 @@ export class PaymentsService {
       .reduce((total, refund) => total + refund.amountCents, 0);
 
     return {
-      paymentAmountCents,
       successfulRefundCents,
       pendingRefundCents,
-      availableRefundCents: paymentAmountCents - successfulRefundCents - pendingRefundCents,
     };
   }
 
@@ -805,6 +846,7 @@ export class PaymentsService {
           this.validateManualRefundPayment(payment.status);
           this.validateManualRefundRegistration(
             payment.registrationId,
+            payment.registration?.status ?? null,
             canonicalRequest.resultingRegistrationStatus
           );
 
@@ -961,11 +1003,22 @@ export class PaymentsService {
 
   private validateManualRefundRegistration(
     registrationId: string | null,
+    currentStatus: RegistrationStatus | null,
     resultingStatus: RegistrationStatus | null
   ): void {
-    if (resultingStatus && !registrationId) {
+    if (!resultingStatus) {
+      return;
+    }
+
+    if (!registrationId || !currentStatus) {
       throw new BadRequestException(
         'Cannot apply a registration status to a payment without a registration'
+      );
+    }
+
+    if (currentStatus === RegistrationStatus.CANCELLED || isApplicationStatus(currentStatus)) {
+      throw new BadRequestException(
+        `Cannot change a registration from ${currentStatus} during a refund; use the cancellation workflow when cancellation is intended`
       );
     }
   }
@@ -1069,6 +1122,7 @@ export class PaymentsService {
       successfulRefundCents: adminPayment.successfulRefundCents,
       pendingRefundCents: adminPayment.pendingRefundCents,
       availableRefundCents: adminPayment.availableRefundCents,
+      refundUnavailableReason: adminPayment.refundUnavailableReason,
     };
   }
 

--- a/apps/api/src/payments/services/payments.service.ts
+++ b/apps/api/src/payments/services/payments.service.ts
@@ -724,6 +724,9 @@ export class PaymentsService {
       );
     }
 
+    const isLegacyLedgerlessRefund =
+      payment.status === PaymentStatus.REFUNDED && payment.refunds.length === 0;
+
     try {
       this.validateStoredPaymentCurrency(payment.currency);
     } catch (error: unknown) {
@@ -735,15 +738,11 @@ export class PaymentsService {
         paymentAmountCents,
         payment.refunds,
         UNSUPPORTED_PAYMENT_CURRENCY_REASON,
-        payment.status === PaymentStatus.REFUNDED
+        isLegacyLedgerlessRefund
       );
     }
 
-    return this.calculateRefundTotals(
-      paymentAmountCents,
-      payment.refunds,
-      payment.status === PaymentStatus.REFUNDED
-    );
+    return this.calculateRefundTotals(paymentAmountCents, payment.refunds, isLegacyLedgerlessRefund);
   }
 
   private buildUnavailableRefundTotals(

--- a/apps/api/src/payments/services/stripe.service.spec.ts
+++ b/apps/api/src/payments/services/stripe.service.spec.ts
@@ -372,12 +372,11 @@ describe('StripeService', () => {
     const inputRequest = {
       providerRefId: 'pi_123',
       amountCents: 2500,
-      reason: 'duplicate charge',
       idempotencyKey: '43ea4b84-1f0d-413d-bc1c-9c91b435d66d',
       localRefundId: 'refund-local-id',
     };
 
-    it('should submit integer cents with stable idempotency and local metadata', async () => {
+    it('should submit integer cents with stable idempotency and local metadata without a reason', async () => {
       mockStripeInstance.refunds.create.mockResolvedValue({
         id: 're_provider_id',
         status: 'succeeded',
@@ -390,7 +389,6 @@ describe('StripeService', () => {
           payment_intent: 'pi_123',
           amount: 2500,
           metadata: { paymentRefundId: 'refund-local-id' },
-          reason: 'duplicate',
         },
         { idempotencyKey: inputRequest.idempotencyKey }
       );

--- a/apps/api/src/payments/services/stripe.service.spec.ts
+++ b/apps/api/src/payments/services/stripe.service.spec.ts
@@ -421,10 +421,46 @@ describe('StripeService', () => {
       );
     });
 
+    it.each([
+      'cs_test_a1B2c3D4e5F6g7H8i9J0',
+      'cs_live_z9Y8x7W6v5U4t3S2r1Q0',
+    ])(
+      'should redact a Checkout Session ID when the session has no payment intent',
+      async sessionId => {
+        mockStripeInstance.checkout.sessions.retrieve.mockResolvedValue({
+          id: sessionId,
+          payment_intent: null,
+        });
+
+        const actualResult = await service.createAdminRefund({
+          ...inputRequest,
+          providerRefId: sessionId,
+        });
+
+        expect(actualResult).toEqual({
+          outcome: 'FAILED',
+          failureMessage:
+            'Stripe rejected the refund request: Checkout session [redacted] has no associated payment intent',
+        });
+        expect(JSON.stringify(actualResult)).not.toContain(sessionId);
+        expect(loggerSpy.error).toHaveBeenCalledWith(
+          'Stripe rejected the refund request: Checkout session [redacted] has no associated payment intent'
+        );
+        expect(loggerSpy.error.mock.calls.flat().join(' ')).not.toContain(sessionId);
+        expect(mockStripeInstance.refunds.create).not.toHaveBeenCalled();
+      }
+    );
+
     it('should classify and sanitize a definite rejection', async () => {
+      const sensitiveIdentifiers = [
+        'pi_3MwDX2CZ6qsJgOG31M02Umy2',
+        're_3MwDX2CZ6qsJgOG31M02Umy2',
+        'ch_3MwDX2CZ6qsJgOG31M02Umy2',
+        'req_3MwDX2CZ6qsJgOG31M02Umy2',
+      ];
       mockStripeInstance.refunds.create.mockRejectedValue({
         type: 'StripeInvalidRequestError',
-        message: `No such payment_intent: pi_secret ${'x'.repeat(600)}`,
+        message: `No such payment_intent: ${sensitiveIdentifiers.join(' ')}. Keep re_enter ch_name req_id and cs_test mode. ${'x'.repeat(600)}`,
       });
 
       const actualResult = await service.createAdminRefund(inputRequest);
@@ -433,7 +469,15 @@ describe('StripeService', () => {
       if (actualResult.outcome !== 'FAILED') {
         throw new Error('Expected a definite failure');
       }
-      expect(actualResult.failureMessage).not.toContain('pi_secret');
+      for (const sensitiveIdentifier of sensitiveIdentifiers) {
+        expect(actualResult.failureMessage).not.toContain(sensitiveIdentifier);
+        expect(loggerSpy.error.mock.calls.flat().join(' ')).not.toContain(sensitiveIdentifier);
+      }
+      expect(actualResult.failureMessage).toContain(
+        '[redacted] [redacted] [redacted] [redacted]'
+      );
+      expect(actualResult.failureMessage).toContain('Keep re_enter ch_name req_id and cs_test mode.');
+      expect(loggerSpy.error).toHaveBeenCalledWith(actualResult.failureMessage);
       expect(actualResult.failureMessage.length).toBeLessThanOrEqual(500);
     });
 

--- a/apps/api/src/payments/services/stripe.service.spec.ts
+++ b/apps/api/src/payments/services/stripe.service.spec.ts
@@ -482,6 +482,7 @@ describe('StripeService', () => {
 
     it('should find an existing refund by local metadata', async () => {
       mockStripeInstance.refunds.list.mockResolvedValue({
+        has_more: false,
         data: [
           {
             id: 're_other',
@@ -511,16 +512,96 @@ describe('StripeService', () => {
       });
     });
 
-    it('should report not found only after a successful inspection', async () => {
-      mockStripeInstance.refunds.list.mockResolvedValue({ data: [] });
+    it('should find a matching refund on a later page', async () => {
+      mockStripeInstance.refunds.list
+        .mockResolvedValueOnce({
+          has_more: true,
+          data: [
+            {
+              id: 're_first_page',
+              status: 'succeeded',
+              metadata: { paymentRefundId: 'other-refund' },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          has_more: false,
+          data: [
+            {
+              id: 're_later_match',
+              status: 'succeeded',
+              metadata: { paymentRefundId: inputRequest.localRefundId },
+            },
+          ],
+        });
+
+      await expect(
+        service.findAdminRefund(inputRequest.providerRefId, inputRequest.localRefundId)
+      ).resolves.toEqual({
+        outcome: 'FOUND',
+        providerRefundId: 're_later_match',
+      });
+      expect(mockStripeInstance.refunds.list).toHaveBeenNthCalledWith(2, {
+        payment_intent: inputRequest.providerRefId,
+        limit: 100,
+        starting_after: 're_first_page',
+      });
+    });
+
+    it('should report not found only after every page is inspected', async () => {
+      mockStripeInstance.refunds.list
+        .mockResolvedValueOnce({
+          has_more: true,
+          data: [
+            {
+              id: 're_first_page',
+              status: 'succeeded',
+              metadata: { paymentRefundId: 'other-refund' },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          has_more: false,
+          data: [
+            {
+              id: 're_last_page',
+              status: 'succeeded',
+              metadata: { paymentRefundId: 'another-refund' },
+            },
+          ],
+        });
 
       await expect(
         service.findAdminRefund(inputRequest.providerRefId, inputRequest.localRefundId)
       ).resolves.toEqual({ outcome: 'NOT_FOUND' });
+      expect(mockStripeInstance.refunds.list).toHaveBeenCalledTimes(2);
+    });
+
+    it('should preserve pending state when a later page cannot be inspected', async () => {
+      mockStripeInstance.refunds.list
+        .mockResolvedValueOnce({
+          has_more: true,
+          data: [
+            {
+              id: 're_first_page',
+              status: 'succeeded',
+              metadata: { paymentRefundId: 'other-refund' },
+            },
+          ],
+        })
+        .mockRejectedValueOnce({
+          type: 'StripeConnectionError',
+          message: 'Connection reset',
+        });
+
+      await expect(
+        service.findAdminRefund(inputRequest.providerRefId, inputRequest.localRefundId)
+      ).resolves.toEqual({ outcome: 'PENDING_UNKNOWN' });
     });
 
     it('should not finalize a matching non-successful inspected refund', async () => {
       mockStripeInstance.refunds.list.mockResolvedValue({
+        has_more: false,
         data: [
           {
             id: 're_pending',

--- a/apps/api/src/payments/services/stripe.service.spec.ts
+++ b/apps/api/src/payments/services/stripe.service.spec.ts
@@ -18,6 +18,7 @@ const mockStripeInstance = {
   },
   refunds: {
     create: jest.fn(),
+    list: jest.fn(),
   },
 };
 
@@ -226,7 +227,7 @@ describe('StripeService', () => {
         amount,
         reason: 'requested_by_customer',
       });
-      
+
       expect(loggerSpy.log).toHaveBeenCalledWith(
         expect.stringContaining('Creating refund'),
       );
@@ -366,7 +367,186 @@ describe('StripeService', () => {
       );
     });
   });
-  
+
+  describe('admin refunds', () => {
+    const inputRequest = {
+      providerRefId: 'pi_123',
+      amountCents: 2500,
+      reason: 'duplicate charge',
+      idempotencyKey: '43ea4b84-1f0d-413d-bc1c-9c91b435d66d',
+      localRefundId: 'refund-local-id',
+    };
+
+    it('should submit integer cents with stable idempotency and local metadata', async () => {
+      mockStripeInstance.refunds.create.mockResolvedValue({
+        id: 're_provider_id',
+        status: 'succeeded',
+      });
+
+      const actualResult = await service.createAdminRefund(inputRequest);
+
+      expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
+        {
+          payment_intent: 'pi_123',
+          amount: 2500,
+          metadata: { paymentRefundId: 'refund-local-id' },
+          reason: 'duplicate',
+        },
+        { idempotencyKey: inputRequest.idempotencyKey }
+      );
+      expect(actualResult).toEqual({
+        outcome: 'SUCCEEDED',
+        providerRefundId: 're_provider_id',
+      });
+    });
+
+    it('should resolve a checkout session before submitting', async () => {
+      mockStripeInstance.checkout.sessions.retrieve.mockResolvedValue({
+        payment_intent: 'pi_resolved',
+      });
+      mockStripeInstance.refunds.create.mockResolvedValue({
+        id: 're_provider_id',
+        status: 'succeeded',
+      });
+
+      await service.createAdminRefund({
+        ...inputRequest,
+        providerRefId: 'cs_checkout',
+      });
+
+      expect(mockStripeInstance.checkout.sessions.retrieve).toHaveBeenCalledWith('cs_checkout', {
+        expand: ['payment_intent'],
+      });
+      expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
+        expect.objectContaining({ payment_intent: 'pi_resolved' }),
+        { idempotencyKey: inputRequest.idempotencyKey }
+      );
+    });
+
+    it('should classify and sanitize a definite rejection', async () => {
+      mockStripeInstance.refunds.create.mockRejectedValue({
+        type: 'StripeInvalidRequestError',
+        message: `No such payment_intent: pi_secret ${'x'.repeat(600)}`,
+      });
+
+      const actualResult = await service.createAdminRefund(inputRequest);
+
+      expect(actualResult.outcome).toBe('FAILED');
+      if (actualResult.outcome !== 'FAILED') {
+        throw new Error('Expected a definite failure');
+      }
+      expect(actualResult.failureMessage).not.toContain('pi_secret');
+      expect(actualResult.failureMessage.length).toBeLessThanOrEqual(500);
+    });
+
+    it.each(['StripeConnectionError', 'StripeAPIError'])(
+      'should classify %s as pending unknown',
+      async errorType => {
+        mockStripeInstance.refunds.create.mockRejectedValue({
+          type: errorType,
+          message: 'Transport failed',
+        });
+
+        await expect(service.createAdminRefund(inputRequest)).resolves.toEqual({
+          outcome: 'PENDING_UNKNOWN',
+        });
+      }
+    );
+
+    it('should keep a concurrent idempotency conflict pending', async () => {
+      mockStripeInstance.refunds.create.mockRejectedValue({
+        type: 'StripeIdempotencyError',
+        message: 'Another request with this key is executing',
+      });
+
+      await expect(service.createAdminRefund(inputRequest)).resolves.toEqual({
+        outcome: 'PENDING_UNKNOWN',
+      });
+    });
+
+    it.each([
+      ['pending', 'PENDING_UNKNOWN'],
+      ['requires_action', 'PENDING_UNKNOWN'],
+      ['failed', 'FAILED'],
+      ['canceled', 'FAILED'],
+    ] as const)('should classify Stripe refund status %s as %s', async (status, outcome) => {
+      mockStripeInstance.refunds.create.mockResolvedValue({
+        id: 're_provider_id',
+        status,
+      });
+
+      const actualResult = await service.createAdminRefund(inputRequest);
+
+      expect(actualResult.outcome).toBe(outcome);
+    });
+
+    it('should find an existing refund by local metadata', async () => {
+      mockStripeInstance.refunds.list.mockResolvedValue({
+        data: [
+          {
+            id: 're_other',
+            status: 'succeeded',
+            metadata: { paymentRefundId: 'other-refund' },
+          },
+          {
+            id: 're_match',
+            status: 'succeeded',
+            metadata: { paymentRefundId: inputRequest.localRefundId },
+          },
+        ],
+      });
+
+      const actualResult = await service.findAdminRefund(
+        inputRequest.providerRefId,
+        inputRequest.localRefundId
+      );
+
+      expect(mockStripeInstance.refunds.list).toHaveBeenCalledWith({
+        payment_intent: inputRequest.providerRefId,
+        limit: 100,
+      });
+      expect(actualResult).toEqual({
+        outcome: 'FOUND',
+        providerRefundId: 're_match',
+      });
+    });
+
+    it('should report not found only after a successful inspection', async () => {
+      mockStripeInstance.refunds.list.mockResolvedValue({ data: [] });
+
+      await expect(
+        service.findAdminRefund(inputRequest.providerRefId, inputRequest.localRefundId)
+      ).resolves.toEqual({ outcome: 'NOT_FOUND' });
+    });
+
+    it('should not finalize a matching non-successful inspected refund', async () => {
+      mockStripeInstance.refunds.list.mockResolvedValue({
+        data: [
+          {
+            id: 're_pending',
+            status: 'pending',
+            metadata: { paymentRefundId: inputRequest.localRefundId },
+          },
+        ],
+      });
+
+      await expect(
+        service.findAdminRefund(inputRequest.providerRefId, inputRequest.localRefundId)
+      ).resolves.toEqual({ outcome: 'PENDING_UNKNOWN' });
+    });
+
+    it('should preserve pending state when inspection is ambiguous', async () => {
+      mockStripeInstance.refunds.list.mockRejectedValue({
+        type: 'StripeConnectionError',
+        message: 'Connection reset',
+      });
+
+      await expect(
+        service.findAdminRefund(inputRequest.providerRefId, inputRequest.localRefundId)
+      ).resolves.toEqual({ outcome: 'PENDING_UNKNOWN' });
+    });
+  });
+
   describe('getPaymentIntent', () => {
     it('should retrieve a payment intent by ID', async () => {
       const paymentIntentId = 'pi_123';

--- a/apps/api/src/payments/services/stripe.service.spec.ts
+++ b/apps/api/src/payments/services/stripe.service.spec.ts
@@ -453,6 +453,17 @@ describe('StripeService', () => {
       }
     );
 
+    it('should keep a rate-limited refund pending for retry', async () => {
+      mockStripeInstance.refunds.create.mockRejectedValue({
+        type: 'StripeRateLimitError',
+        message: 'Too many requests',
+      });
+
+      await expect(service.createAdminRefund(inputRequest)).resolves.toEqual({
+        outcome: 'PENDING_UNKNOWN',
+      });
+    });
+
     it('should keep a concurrent idempotency conflict pending', async () => {
       mockStripeInstance.refunds.create.mockRejectedValue({
         type: 'StripeIdempotencyError',

--- a/apps/api/src/payments/services/stripe.service.ts
+++ b/apps/api/src/payments/services/stripe.service.ts
@@ -7,7 +7,6 @@ import { CoreConfigService } from '../../core-config/services/core-config.servic
 interface StripeAdminRefundRequest {
   readonly providerRefId: string;
   readonly amountCents: number;
-  readonly reason: string | null;
   readonly idempotencyKey: string;
   readonly localRefundId: string;
 }
@@ -194,7 +193,6 @@ export class StripeService {
     try {
       const stripe = await this.getStripe();
       const paymentIntentId = await this.resolvePaymentIntentId(stripe, request.providerRefId);
-      const reason = this.getRefundReason(request.reason);
       const refund = await stripe.refunds.create(
         {
           payment_intent: paymentIntentId,
@@ -202,7 +200,6 @@ export class StripeService {
           metadata: {
             [LOCAL_REFUND_METADATA_KEY]: request.localRefundId,
           },
-          ...(reason ? { reason } : {}),
         },
         { idempotencyKey: request.idempotencyKey }
       );

--- a/apps/api/src/payments/services/stripe.service.ts
+++ b/apps/api/src/payments/services/stripe.service.ts
@@ -234,15 +234,32 @@ export class StripeService {
     try {
       const stripe = await this.getStripe();
       const paymentIntentId = await this.resolvePaymentIntentId(stripe, providerRefId);
-      const refunds = await stripe.refunds.list({
-        payment_intent: paymentIntentId,
-        limit: 100,
-      });
-      const matchingRefund = refunds.data.find(
-        refund => refund.metadata?.[LOCAL_REFUND_METADATA_KEY] === localRefundId
-      );
+      let startingAfter: string | undefined;
 
-      return matchingRefund ? this.classifyInspectedRefund(matchingRefund) : { outcome: 'NOT_FOUND' };
+      do {
+        const refunds = await stripe.refunds.list({
+          payment_intent: paymentIntentId,
+          limit: 100,
+          ...(startingAfter ? { starting_after: startingAfter } : {}),
+        });
+        const matchingRefund = refunds.data.find(
+          refund => refund.metadata?.[LOCAL_REFUND_METADATA_KEY] === localRefundId
+        );
+        if (matchingRefund) {
+          return this.classifyInspectedRefund(matchingRefund);
+        }
+        if (!refunds.has_more) {
+          return { outcome: 'NOT_FOUND' };
+        }
+
+        startingAfter = refunds.data.at(-1)?.id;
+        if (!startingAfter) {
+          this.logger.warn('Stripe refund inspection returned an incomplete page');
+          return { outcome: 'PENDING_UNKNOWN' };
+        }
+      } while (startingAfter);
+
+      return { outcome: 'PENDING_UNKNOWN' };
     } catch {
       this.logger.warn('Unable to inspect Stripe refunds; refund remains pending');
       return { outcome: 'PENDING_UNKNOWN' };

--- a/apps/api/src/payments/services/stripe.service.ts
+++ b/apps/api/src/payments/services/stripe.service.ts
@@ -4,6 +4,35 @@ import Stripe from 'stripe';
 import { CreateStripePaymentDto } from '../dto';
 import { CoreConfigService } from '../../core-config/services/core-config.service';
 
+interface StripeAdminRefundRequest {
+  readonly providerRefId: string;
+  readonly amountCents: number;
+  readonly reason: string | null;
+  readonly idempotencyKey: string;
+  readonly localRefundId: string;
+}
+
+type StripeAdminRefundResult =
+  | { readonly outcome: 'SUCCEEDED'; readonly providerRefundId: string }
+  | { readonly outcome: 'FAILED'; readonly failureMessage: string }
+  | { readonly outcome: 'PENDING_UNKNOWN' };
+
+type StripeRefundInspectionResult =
+  | { readonly outcome: 'FOUND'; readonly providerRefundId: string }
+  | { readonly outcome: 'FAILED'; readonly failureMessage: string }
+  | { readonly outcome: 'NOT_FOUND' }
+  | { readonly outcome: 'PENDING_UNKNOWN' };
+
+const DEFINITE_STRIPE_ERROR_TYPES = new Set([
+  'StripeCardError',
+  'StripeInvalidRequestError',
+  'StripeAuthenticationError',
+  'StripePermissionError',
+  'StripeRateLimitError',
+]);
+const LOCAL_REFUND_METADATA_KEY = 'paymentRefundId';
+const MAX_FAILURE_MESSAGE_LENGTH = 500;
+
 /**
  * Service for handling Stripe payment processing
  */
@@ -60,6 +89,164 @@ export class StripeService {
       .replace(/pk_test_[a-zA-Z0-9]+/g, 'pk_test_***')
       .replace(/pk_live_[a-zA-Z0-9]+/g, 'pk_live_***')
       .replace(/whsec_[a-zA-Z0-9]+/g, 'whsec_***');
+  }
+
+  private sanitizeRefundFailure(error: unknown): string {
+    const sanitizedMessage = this.sanitizeErrorMessage(error)
+      .replace(/\b(?:pi|cs|re|ch|req)_[a-zA-Z0-9]+\b/g, '[redacted]')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    return `Stripe rejected the refund request: ${sanitizedMessage}`.slice(
+      0,
+      MAX_FAILURE_MESSAGE_LENGTH
+    );
+  }
+
+  private getStripeErrorType(error: unknown): string | null {
+    if (
+      typeof error !== 'object' ||
+      error === null ||
+      !('type' in error) ||
+      typeof error.type !== 'string'
+    ) {
+      return null;
+    }
+
+    return error.type;
+  }
+
+  private isDefiniteRefundRejection(error: unknown): boolean {
+    const errorType = this.getStripeErrorType(error);
+    if (errorType) {
+      return DEFINITE_STRIPE_ERROR_TYPES.has(errorType);
+    }
+
+    return (
+      error instanceof Error &&
+      (error.message === 'Stripe payments are not configured' ||
+        error.message.includes('has no associated payment intent'))
+    );
+  }
+
+  private getRefundReason(reason: string | null | undefined): Stripe.RefundCreateParams.Reason | undefined {
+    if (!reason) {
+      return undefined;
+    }
+
+    const lowerReason = reason.toLowerCase();
+    if (lowerReason.includes('duplicate')) {
+      return 'duplicate';
+    }
+    if (lowerReason.includes('fraud')) {
+      return 'fraudulent';
+    }
+    return 'requested_by_customer';
+  }
+
+  private async resolvePaymentIntentId(stripe: Stripe, providerRefId: string): Promise<string> {
+    if (!providerRefId.startsWith('cs_')) {
+      return providerRefId;
+    }
+
+    const session = await stripe.checkout.sessions.retrieve(providerRefId, {
+      expand: ['payment_intent'],
+    });
+    if (!session.payment_intent) {
+      throw new Error(`Checkout session ${providerRefId} has no associated payment intent`);
+    }
+
+    return typeof session.payment_intent === 'string'
+      ? session.payment_intent
+      : session.payment_intent.id;
+  }
+
+  private classifyRefund(refund: Stripe.Refund): StripeAdminRefundResult {
+    if (refund.status === 'succeeded') {
+      return {
+        outcome: 'SUCCEEDED',
+        providerRefundId: refund.id,
+      };
+    }
+    if (refund.status === 'failed' || refund.status === 'canceled') {
+      return {
+        outcome: 'FAILED',
+        failureMessage: `Stripe rejected the refund request with status ${refund.status}`,
+      };
+    }
+    return { outcome: 'PENDING_UNKNOWN' };
+  }
+
+  private classifyInspectedRefund(refund: Stripe.Refund): StripeRefundInspectionResult {
+    const classifiedRefund = this.classifyRefund(refund);
+    if (classifiedRefund.outcome === 'SUCCEEDED') {
+      return {
+        outcome: 'FOUND',
+        providerRefundId: classifiedRefund.providerRefundId,
+      };
+    }
+    return classifiedRefund;
+  }
+
+  /**
+   * Submit an admin refund with stable idempotency and local metadata.
+   */
+  async createAdminRefund(request: StripeAdminRefundRequest): Promise<StripeAdminRefundResult> {
+    try {
+      const stripe = await this.getStripe();
+      const paymentIntentId = await this.resolvePaymentIntentId(stripe, request.providerRefId);
+      const reason = this.getRefundReason(request.reason);
+      const refund = await stripe.refunds.create(
+        {
+          payment_intent: paymentIntentId,
+          amount: request.amountCents,
+          metadata: {
+            [LOCAL_REFUND_METADATA_KEY]: request.localRefundId,
+          },
+          ...(reason ? { reason } : {}),
+        },
+        { idempotencyKey: request.idempotencyKey }
+      );
+
+      return this.classifyRefund(refund);
+    } catch (error: unknown) {
+      if (this.isDefiniteRefundRejection(error)) {
+        const failureMessage = this.sanitizeRefundFailure(error);
+        this.logger.error(failureMessage);
+        return {
+          outcome: 'FAILED',
+          failureMessage,
+        };
+      }
+
+      this.logger.warn('Stripe refund outcome is pending or unknown after a transport failure');
+      return { outcome: 'PENDING_UNKNOWN' };
+    }
+  }
+
+  /**
+   * Find a Stripe refund previously submitted for a local refund row.
+   */
+  async findAdminRefund(
+    providerRefId: string,
+    localRefundId: string
+  ): Promise<StripeRefundInspectionResult> {
+    try {
+      const stripe = await this.getStripe();
+      const paymentIntentId = await this.resolvePaymentIntentId(stripe, providerRefId);
+      const refunds = await stripe.refunds.list({
+        payment_intent: paymentIntentId,
+        limit: 100,
+      });
+      const matchingRefund = refunds.data.find(
+        refund => refund.metadata?.[LOCAL_REFUND_METADATA_KEY] === localRefundId
+      );
+
+      return matchingRefund ? this.classifyInspectedRefund(matchingRefund) : { outcome: 'NOT_FOUND' };
+    } catch {
+      this.logger.warn('Unable to inspect Stripe refunds; refund remains pending');
+      return { outcome: 'PENDING_UNKNOWN' };
+    }
   }
 
   /**
@@ -189,17 +376,9 @@ export class StripeService {
         refundParams.amount = amount;
       }
       
-      // Map custom reasons to valid Stripe reasons or omit if not applicable
-      if (reason) {
-        const lowerReason = reason.toLowerCase();
-        if (lowerReason.includes('duplicate')) {
-          refundParams.reason = 'duplicate';
-        } else if (lowerReason.includes('fraud')) {
-          refundParams.reason = 'fraudulent';
-        } else {
-          // For registration cancellations and other customer requests, use requested_by_customer
-          refundParams.reason = 'requested_by_customer';
-        }
+      const stripeReason = this.getRefundReason(reason);
+      if (stripeReason) {
+        refundParams.reason = stripeReason;
       }
       
       const refund = await stripe.refunds.create(refundParams);

--- a/apps/api/src/payments/services/stripe.service.ts
+++ b/apps/api/src/payments/services/stripe.service.ts
@@ -28,7 +28,6 @@ const DEFINITE_STRIPE_ERROR_TYPES = new Set([
   'StripeInvalidRequestError',
   'StripeAuthenticationError',
   'StripePermissionError',
-  'StripeRateLimitError',
 ]);
 const LOCAL_REFUND_METADATA_KEY = 'paymentRefundId';
 const MAX_FAILURE_MESSAGE_LENGTH = 500;

--- a/apps/api/src/payments/services/stripe.service.ts
+++ b/apps/api/src/payments/services/stripe.service.ts
@@ -30,6 +30,8 @@ const DEFINITE_STRIPE_ERROR_TYPES = new Set([
 ]);
 const LOCAL_REFUND_METADATA_KEY = 'paymentRefundId';
 const MAX_FAILURE_MESSAGE_LENGTH = 500;
+const STRIPE_REFUND_IDENTIFIER_PATTERN =
+  /\b(?:cs_(?:test|live)_[a-zA-Z0-9]+|(?:pi|re|ch|req)_[a-zA-Z0-9]{8,})\b/g;
 
 /**
  * Service for handling Stripe payment processing
@@ -91,7 +93,7 @@ export class StripeService {
 
   private sanitizeRefundFailure(error: unknown): string {
     const sanitizedMessage = this.sanitizeErrorMessage(error)
-      .replace(/\b(?:pi|cs|re|ch|req)_[a-zA-Z0-9]+\b/g, '[redacted]')
+      .replace(STRIPE_REFUND_IDENTIFIER_PATTERN, '[redacted]')
       .replace(/\s+/g, ' ')
       .trim();
 

--- a/apps/api/src/payments/utils/money.utils.spec.ts
+++ b/apps/api/src/payments/utils/money.utils.spec.ts
@@ -1,6 +1,7 @@
 import {
   centsToDollars,
   dollarsToCents,
+  hasSubCentPrecision,
   normalizeCurrency,
 } from './money.utils';
 
@@ -50,6 +51,22 @@ describe('money utilities', () => {
         'Dollar amount exceeds the supported range',
       );
     });
+  });
+
+  describe('hasSubCentPrecision', () => {
+    it.each([10.001, 1e-3, Number.MIN_VALUE])(
+      'should identify sub-cent precision for %s',
+      inputDollars => {
+        expect(hasSubCentPrecision(inputDollars)).toBe(true);
+      }
+    );
+
+    it.each([0, -0.01, 10.01, 21_474_836.48])(
+      'should not identify sub-cent precision for %s',
+      inputDollars => {
+        expect(hasSubCentPrecision(inputDollars)).toBe(false);
+      }
+    );
   });
 
   describe('centsToDollars', () => {

--- a/apps/api/src/payments/utils/money.utils.ts
+++ b/apps/api/src/payments/utils/money.utils.ts
@@ -13,6 +13,13 @@ function getDecimalPlaces(value: number): number {
 }
 
 /**
+ * Returns whether a dollar amount contains precision smaller than one cent.
+ */
+export function hasSubCentPrecision(amount: number): boolean {
+  return getDecimalPlaces(amount) > 2;
+}
+
+/**
  * Converts a positive dollar amount to PostgreSQL INTEGER cents.
  */
 export function dollarsToCents(amount: number): number {
@@ -20,7 +27,7 @@ export function dollarsToCents(amount: number): number {
     throw new RangeError('Dollar amount must be a positive finite number');
   }
 
-  if (getDecimalPlaces(amount) > 2) {
+  if (hasSubCentPrecision(amount)) {
     throw new RangeError('Dollar amount must not have sub-cent precision');
   }
 

--- a/apps/web/src/lib/api/__tests__/admin-payments.test.ts
+++ b/apps/web/src/lib/api/__tests__/admin-payments.test.ts
@@ -72,6 +72,7 @@ describe('adminPaymentsApi', () => {
       successfulRefundCents: 5050,
       pendingRefundCents: 0,
       availableRefundCents: 4950,
+      refundUnavailableReason: null,
     };
     mockApiPost.mockResolvedValue({ data: mockResult });
 

--- a/apps/web/src/lib/api/__tests__/admin-payments.test.ts
+++ b/apps/web/src/lib/api/__tests__/admin-payments.test.ts
@@ -76,11 +76,37 @@ describe('adminPaymentsApi', () => {
     };
     mockApiPost.mockResolvedValue({ data: mockResult });
 
-    const actualResult = await adminPaymentsApi.createManualRefund('payment-id', inputRequest);
+    const actualResult = await adminPaymentsApi.createRefund('payment-id', inputRequest);
 
     expect(mockApiPost).toHaveBeenCalledWith('/payments/payment-id/refunds', inputRequest);
     expect(mockApiPost.mock.calls[0]?.[1]).not.toHaveProperty('currency');
     expect(mockApiPost.mock.calls[0]?.[1]).not.toHaveProperty('availableRefundCents');
     expect(actualResult).toEqual(mockResult);
+  });
+
+  it('should send Stripe mode without manual or derived fields', async () => {
+    const inputRequest = {
+      fullRefund: true as const,
+      executionMode: 'STRIPE' as const,
+      reason: 'customer request',
+      idempotencyKey: '43ea4b84-1f0d-413d-bc1c-9c91b435d66d',
+    };
+    mockApiPost.mockResolvedValue({ data: { outcome: 'PENDING_UNKNOWN' } });
+
+    await adminPaymentsApi.createRefund('payment-id', inputRequest);
+
+    expect(mockApiPost).toHaveBeenCalledWith('/payments/payment-id/refunds', inputRequest);
+    expect(mockApiPost.mock.calls[0]?.[1]).not.toHaveProperty('externalReference');
+    expect(mockApiPost.mock.calls[0]?.[1]).not.toHaveProperty('currency');
+  });
+
+  it('should retry the exact nested refund route without mutable data', async () => {
+    mockApiPost.mockResolvedValue({ data: { outcome: 'PENDING_UNKNOWN' } });
+
+    await adminPaymentsApi.retryStripeRefund('payment-id', 'refund-id');
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      '/payments/payment-id/refunds/refund-id/retry'
+    );
   });
 });

--- a/apps/web/src/lib/api/__tests__/admin-payments.test.ts
+++ b/apps/web/src/lib/api/__tests__/admin-payments.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { api } from '../../api';
 import {
   ADMIN_PAYMENT_PAGE_SIZE,
@@ -82,5 +82,51 @@ describe('adminPaymentsApi', () => {
     expect(mockApiPost.mock.calls[0]?.[1]).not.toHaveProperty('currency');
     expect(mockApiPost.mock.calls[0]?.[1]).not.toHaveProperty('availableRefundCents');
     expect(actualResult).toEqual(mockResult);
+  });
+
+  it('should require exactly one manual refund amount selection at compile time', () => {
+    const inputCommon = {
+      executionMode: 'MANUAL' as const,
+      idempotencyKey: '43ea4b84-1f0d-413d-bc1c-9c91b435d66d',
+    };
+    const inputPartialRequest = {
+      ...inputCommon,
+      amountCents: 5050,
+    };
+    const inputFullRequest = {
+      ...inputCommon,
+      fullRefund: true as const,
+    };
+    const inputMissingSelection = inputCommon;
+    const inputBothSelections = {
+      ...inputCommon,
+      amountCents: 5050,
+      fullRefund: true as const,
+    };
+    // @ts-expect-error -- A refund amount selection is required.
+    const invalidMissingSelection: CreateManualRefundRequest = inputMissingSelection;
+    // @ts-expect-error -- Partial and full refund selections are mutually exclusive.
+    const invalidBothSelections: CreateManualRefundRequest = inputBothSelections;
+
+    expectTypeOf(inputPartialRequest).toMatchTypeOf<CreateManualRefundRequest>();
+    expectTypeOf(inputFullRequest).toMatchTypeOf<CreateManualRefundRequest>();
+    expectTypeOf(inputMissingSelection).not.toMatchTypeOf<CreateManualRefundRequest>();
+    expectTypeOf(inputBothSelections).not.toMatchTypeOf<CreateManualRefundRequest>();
+    expect(invalidMissingSelection).toBe(inputMissingSelection);
+    expect(invalidBothSelections).toBe(inputBothSelections);
+  });
+
+  it('should send a full selection without amount cents to the manual refund route', async () => {
+    const inputRequest: CreateManualRefundRequest = {
+      fullRefund: true,
+      executionMode: 'MANUAL',
+      idempotencyKey: '43ea4b84-1f0d-413d-bc1c-9c91b435d66d',
+    };
+    mockApiPost.mockResolvedValue({ data: { refund: { id: 'refund-id' } } });
+
+    await adminPaymentsApi.createManualRefund('payment-id', inputRequest);
+
+    expect(mockApiPost).toHaveBeenCalledWith('/payments/payment-id/refunds', inputRequest);
+    expect(mockApiPost.mock.calls[0]?.[1]).not.toHaveProperty('amountCents');
   });
 });

--- a/apps/web/src/lib/api/__tests__/admin-payments.test.ts
+++ b/apps/web/src/lib/api/__tests__/admin-payments.test.ts
@@ -3,6 +3,7 @@ import { api } from '../../api';
 import {
   ADMIN_PAYMENT_PAGE_SIZE,
   adminPaymentsApi,
+  CreateManualRefundRequest,
   CreateExternalPaymentRequest,
 } from '../admin-payments';
 
@@ -28,7 +29,7 @@ describe('adminPaymentsApi', () => {
     const actualPage = await adminPaymentsApi.getPayments();
 
     expect(mockApiGet).toHaveBeenCalledWith(
-      `/payments/admin?skip=0&take=${ADMIN_PAYMENT_PAGE_SIZE}`,
+      `/payments/admin?skip=0&take=${ADMIN_PAYMENT_PAGE_SIZE}`
     );
     expect(actualPage).toEqual(mockPage);
   });
@@ -51,10 +52,34 @@ describe('adminPaymentsApi', () => {
 
     await adminPaymentsApi.recordExternalPayment(inputRequest);
 
-    expect(mockApiPost).toHaveBeenCalledWith(
-      '/payments/external',
-      inputRequest,
-    );
+    expect(mockApiPost).toHaveBeenCalledWith('/payments/external', inputRequest);
     expect(mockApiPost.mock.calls[0]?.[1]).not.toHaveProperty('userId');
+  });
+
+  it('should send integer cents to the payment-attached manual refund route', async () => {
+    const inputRequest: CreateManualRefundRequest = {
+      amountCents: 5050,
+      executionMode: 'MANUAL',
+      reason: 'duplicate charge',
+      externalReference: 'refund-123',
+      resultingRegistrationStatus: 'WAITLISTED',
+      idempotencyKey: '43ea4b84-1f0d-413d-bc1c-9c91b435d66d',
+    };
+    const mockResult = {
+      payment: { id: 'payment-id' },
+      refund: { id: 'refund-id', amountCents: 5050 },
+      paymentAmountCents: 10000,
+      successfulRefundCents: 5050,
+      pendingRefundCents: 0,
+      availableRefundCents: 4950,
+    };
+    mockApiPost.mockResolvedValue({ data: mockResult });
+
+    const actualResult = await adminPaymentsApi.createManualRefund('payment-id', inputRequest);
+
+    expect(mockApiPost).toHaveBeenCalledWith('/payments/payment-id/refunds', inputRequest);
+    expect(mockApiPost.mock.calls[0]?.[1]).not.toHaveProperty('currency');
+    expect(mockApiPost.mock.calls[0]?.[1]).not.toHaveProperty('availableRefundCents');
+    expect(actualResult).toEqual(mockResult);
   });
 });

--- a/apps/web/src/lib/api/admin-payments.ts
+++ b/apps/web/src/lib/api/admin-payments.ts
@@ -13,6 +13,7 @@ export type ExternalPaymentMethod =
 export type RefundExecutionMode = 'MANUAL' | 'STRIPE';
 export type PaymentRefundStatus = 'PENDING' | 'SUCCEEDED' | 'FAILED';
 export type RefundRegistrationStatus = 'PENDING' | 'CONFIRMED' | 'WAITLISTED';
+export type RefundCommandOutcome = 'SUCCEEDED' | 'FAILED' | 'PENDING_UNKNOWN';
 
 export interface AdminPaymentRefund {
   id: string;
@@ -56,6 +57,7 @@ export interface AdminPayment {
   pendingRefundCents: number;
   availableRefundCents: number;
   refundUnavailableReason: string | null;
+  stripeRefundEligible: boolean;
 }
 
 export interface AdminPaymentPage {
@@ -82,7 +84,18 @@ export interface CreateManualRefundRequest {
   idempotencyKey: string;
 }
 
-export interface ManualRefundResult {
+export interface CreateStripeRefundRequest {
+  amountCents?: number;
+  fullRefund?: true;
+  executionMode: 'STRIPE';
+  reason?: string;
+  resultingRegistrationStatus?: RefundRegistrationStatus;
+  idempotencyKey: string;
+}
+
+export type CreateRefundRequest = CreateManualRefundRequest | CreateStripeRefundRequest;
+
+export interface RefundCommandResult {
   payment: AdminPayment;
   refund: AdminPaymentRefund;
   paymentAmountCents: number | null;
@@ -90,6 +103,7 @@ export interface ManualRefundResult {
   pendingRefundCents: number;
   availableRefundCents: number;
   refundUnavailableReason: string | null;
+  outcome: RefundCommandOutcome;
 }
 
 export const adminPaymentsApi = {
@@ -107,11 +121,19 @@ export const adminPaymentsApi = {
     return response.data;
   },
 
-  createManualRefund: async (
+  createRefund: async (
     paymentId: string,
-    request: CreateManualRefundRequest
-  ): Promise<ManualRefundResult> => {
+    request: CreateRefundRequest
+  ): Promise<RefundCommandResult> => {
     const response = await api.post(`/payments/${paymentId}/refunds`, request);
+    return response.data;
+  },
+
+  retryStripeRefund: async (
+    paymentId: string,
+    refundId: string
+  ): Promise<RefundCommandResult> => {
+    const response = await api.post(`/payments/${paymentId}/refunds/${refundId}/retry`);
     return response.data;
   },
 };

--- a/apps/web/src/lib/api/admin-payments.ts
+++ b/apps/web/src/lib/api/admin-payments.ts
@@ -93,15 +93,27 @@ export interface CreateExternalPaymentRequest {
   idempotencyKey: string;
 }
 
-export interface CreateManualRefundRequest {
-  amountCents?: number;
-  fullRefund?: true;
-  executionMode: 'MANUAL';
+export type RefundAmountSelection =
+  | {
+      amountCents: number;
+      fullRefund?: never;
+    }
+  | {
+      amountCents?: never;
+      fullRefund: true;
+    };
+
+interface CreateRefundRequestFields {
   reason?: string;
   externalReference?: string;
   resultingRegistrationStatus?: RefundRegistrationStatus;
   idempotencyKey: string;
 }
+
+export type CreateManualRefundRequest = RefundAmountSelection &
+  CreateRefundRequestFields & {
+    executionMode: 'MANUAL';
+  };
 
 export interface ManualRefundResult {
   payment: AdminPayment;

--- a/apps/web/src/lib/api/admin-payments.ts
+++ b/apps/web/src/lib/api/admin-payments.ts
@@ -51,10 +51,11 @@ export interface AdminPayment {
     status: string;
   } | null;
   refunds: AdminPaymentRefund[];
-  paymentAmountCents: number;
+  paymentAmountCents: number | null;
   successfulRefundCents: number;
   pendingRefundCents: number;
   availableRefundCents: number;
+  refundUnavailableReason: string | null;
 }
 
 export interface AdminPaymentPage {
@@ -84,10 +85,11 @@ export interface CreateManualRefundRequest {
 export interface ManualRefundResult {
   payment: AdminPayment;
   refund: AdminPaymentRefund;
-  paymentAmountCents: number;
+  paymentAmountCents: number | null;
   successfulRefundCents: number;
   pendingRefundCents: number;
   availableRefundCents: number;
+  refundUnavailableReason: string | null;
 }
 
 export const adminPaymentsApi = {

--- a/apps/web/src/lib/api/admin-payments.ts
+++ b/apps/web/src/lib/api/admin-payments.ts
@@ -10,6 +10,23 @@ export type ExternalPaymentMethod =
   | 'BANK_TRANSFER'
   | 'OTHER';
 
+export type RefundExecutionMode = 'MANUAL' | 'STRIPE';
+export type PaymentRefundStatus = 'PENDING' | 'SUCCEEDED' | 'FAILED';
+export type RefundRegistrationStatus = 'PENDING' | 'CONFIRMED' | 'WAITLISTED';
+
+export interface AdminPaymentRefund {
+  id: string;
+  amountCents: number;
+  currency: string;
+  executionMode: RefundExecutionMode;
+  status: PaymentRefundStatus;
+  reason: string | null;
+  externalReference: string | null;
+  resultingRegistrationStatus: RefundRegistrationStatus | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface AdminPayment {
   id: string;
   amount: number;
@@ -33,6 +50,11 @@ export interface AdminPayment {
     year: number;
     status: string;
   } | null;
+  refunds: AdminPaymentRefund[];
+  paymentAmountCents: number;
+  successfulRefundCents: number;
+  pendingRefundCents: number;
+  availableRefundCents: number;
 }
 
 export interface AdminPaymentPage {
@@ -49,11 +71,27 @@ export interface CreateExternalPaymentRequest {
   idempotencyKey: string;
 }
 
+export interface CreateManualRefundRequest {
+  amountCents?: number;
+  fullRefund?: true;
+  executionMode: 'MANUAL';
+  reason?: string;
+  externalReference?: string;
+  resultingRegistrationStatus?: RefundRegistrationStatus;
+  idempotencyKey: string;
+}
+
+export interface ManualRefundResult {
+  payment: AdminPayment;
+  refund: AdminPaymentRefund;
+  paymentAmountCents: number;
+  successfulRefundCents: number;
+  pendingRefundCents: number;
+  availableRefundCents: number;
+}
+
 export const adminPaymentsApi = {
-  getPayments: async (
-    skip = 0,
-    take = ADMIN_PAYMENT_PAGE_SIZE,
-  ): Promise<AdminPaymentPage> => {
+  getPayments: async (skip = 0, take = ADMIN_PAYMENT_PAGE_SIZE): Promise<AdminPaymentPage> => {
     const params = new URLSearchParams({
       skip: skip.toString(),
       take: take.toString(),
@@ -62,10 +100,16 @@ export const adminPaymentsApi = {
     return response.data;
   },
 
-  recordExternalPayment: async (
-    request: CreateExternalPaymentRequest,
-  ): Promise<AdminPayment> => {
+  recordExternalPayment: async (request: CreateExternalPaymentRequest): Promise<AdminPayment> => {
     const response = await api.post('/payments/external', request);
+    return response.data;
+  },
+
+  createManualRefund: async (
+    paymentId: string,
+    request: CreateManualRefundRequest
+  ): Promise<ManualRefundResult> => {
+    const response = await api.post(`/payments/${paymentId}/refunds`, request);
     return response.data;
   },
 };

--- a/apps/web/src/pages/AdminPaymentsPage.tsx
+++ b/apps/web/src/pages/AdminPaymentsPage.tsx
@@ -53,6 +53,19 @@ interface ApiErrorResponse {
   readonly message?: unknown;
 }
 
+type RefundFeedbackSource = 'MANUAL_CREATE' | 'STRIPE_CREATE' | 'STRIPE_RETRY';
+
+interface RefundError {
+  readonly source: RefundFeedbackSource;
+  readonly message: string;
+}
+
+interface RefundNotice {
+  readonly source: RefundFeedbackSource;
+  readonly kind: 'success' | 'warning' | 'failure';
+  readonly message: string;
+}
+
 function createIdempotencyKey(): string {
   return crypto.randomUUID();
 }
@@ -167,11 +180,8 @@ export default function AdminPaymentsPage() {
   const [refundIdempotencyKey, setRefundIdempotencyKey] = useState(createIdempotencyKey);
   const [isSubmittingRefund, setIsSubmittingRefund] = useState(false);
   const [retryingRefundId, setRetryingRefundId] = useState<string | null>(null);
-  const [refundError, setRefundError] = useState<string | null>(null);
-  const [refundNotice, setRefundNotice] = useState<{
-    kind: 'success' | 'warning' | 'failure';
-    message: string;
-  } | null>(null);
+  const [refundError, setRefundError] = useState<RefundError | null>(null);
+  const [refundNotice, setRefundNotice] = useState<RefundNotice | null>(null);
 
   const hasMeaningfulSearch = useMemo(() => {
     const hasName = (registrationFilters.name?.trim().length ?? 0) >= 2;
@@ -287,17 +297,20 @@ export default function AdminPaymentsPage() {
     }
 
     let amountSelection: RefundAmountSelection;
+    const feedbackSource =
+      refundExecutionMode === 'MANUAL' ? 'MANUAL_CREATE' : 'STRIPE_CREATE';
     if (refundAmountMode === 'full') {
       amountSelection = { fullRefund: true };
     } else {
       const amountCents = parseDollarsToCents(refundAmount);
       if (amountCents === null || amountCents > selectedRefundPayment.availableRefundCents) {
-        setRefundError(
-          `Enter a positive amount with at most two decimals, no more than ${formatCents(
+        setRefundError({
+          source: feedbackSource,
+          message: `Enter a positive amount with at most two decimals, no more than ${formatCents(
             selectedRefundPayment.currency,
             selectedRefundPayment.availableRefundCents
-          )}.`
-        );
+          )}.`,
+        });
         return;
       }
       amountSelection = { amountCents };
@@ -328,6 +341,7 @@ export default function AdminPaymentsPage() {
       const formattedAmount = formatCents(result.refund.currency, result.refund.amountCents);
       if (result.outcome === 'SUCCEEDED') {
         setRefundNotice({
+          source: feedbackSource,
           kind: 'success',
           message:
             refundExecutionMode === 'MANUAL'
@@ -336,11 +350,13 @@ export default function AdminPaymentsPage() {
         });
       } else if (result.outcome === 'FAILED') {
         setRefundNotice({
+          source: feedbackSource,
           kind: 'failure',
           message: `Stripe rejected the refund. ${formattedAmount} is no longer reserved.`,
         });
       } else {
         setRefundNotice({
+          source: feedbackSource,
           kind: 'warning',
           message:
             `Stripe outcome is pending or unknown for ${formattedAmount}. ` +
@@ -355,14 +371,15 @@ export default function AdminPaymentsPage() {
       setRefundRegistrationStatus('');
       await loadPayments(paymentSkip);
     } catch (error: unknown) {
-      setRefundError(
-        getErrorMessage(
+      setRefundError({
+        source: feedbackSource,
+        message: getErrorMessage(
           error,
           refundExecutionMode === 'MANUAL'
             ? 'Unable to record the manual refund.'
             : 'Unable to initiate the Stripe refund.'
-        )
-      );
+        ),
+      });
     } finally {
       setIsSubmittingRefund(false);
     }
@@ -370,30 +387,49 @@ export default function AdminPaymentsPage() {
 
   const retryStripeRefund = async (paymentId: string, refundId: string): Promise<void> => {
     setRetryingRefundId(refundId);
+    setSelectedRefundPayment(null);
     setRefundError(null);
     setRefundNotice(null);
     try {
       const result = await adminPaymentsApi.retryStripeRefund(paymentId, refundId);
       if (result.outcome === 'SUCCEEDED') {
-        setRefundNotice({ kind: 'success', message: 'Stripe refund reconciliation succeeded.' });
+        setRefundNotice({
+          source: 'STRIPE_RETRY',
+          kind: 'success',
+          message: 'Stripe refund reconciliation succeeded.',
+        });
       } else if (result.outcome === 'FAILED') {
         setRefundNotice({
+          source: 'STRIPE_RETRY',
           kind: 'failure',
           message: 'Stripe rejected the refund. Its reserved balance has been released.',
         });
       } else {
         setRefundNotice({
+          source: 'STRIPE_RETRY',
           kind: 'warning',
           message: 'Stripe outcome remains pending or unknown; the amount is still reserved.',
         });
       }
       await loadPayments(paymentSkip);
     } catch (error: unknown) {
-      setRefundError(getErrorMessage(error, 'Unable to retry the Stripe refund.'));
+      setRefundError({
+        source: 'STRIPE_RETRY',
+        message: getErrorMessage(error, 'Unable to retry the Stripe refund.'),
+      });
     } finally {
       setRetryingRefundId(null);
     }
   };
+
+  const refundFeedbackSource: RefundFeedbackSource | null =
+    refundNotice?.source ??
+    refundError?.source ??
+    (selectedRefundPayment
+      ? refundExecutionMode === 'MANUAL'
+        ? 'MANUAL_CREATE'
+        : 'STRIPE_CREATE'
+      : null);
 
   return (
     <div className="mx-auto max-w-6xl space-y-8 px-4 py-8">
@@ -804,25 +840,34 @@ export default function AdminPaymentsPage() {
       {(selectedRefundPayment || refundNotice || refundError) && (
         <section className="rounded-lg bg-white p-6 shadow">
           <h2 className="text-xl font-semibold text-gray-900">
-            {refundExecutionMode === 'MANUAL'
+            {refundFeedbackSource === 'MANUAL_CREATE'
               ? 'Record completed manual refund'
-              : 'Initiate Stripe refund'}
+              : refundFeedbackSource === 'STRIPE_CREATE'
+                ? 'Initiate Stripe refund'
+                : 'Reconcile Stripe refund'}
           </h2>
-          {refundExecutionMode === 'MANUAL' ? (
+          {refundFeedbackSource === 'MANUAL_CREATE' ? (
             <p className="mt-2 text-sm text-gray-700">
               Manual mode records a refund that already completed outside PlayaPlan. It does not
               contact Stripe, PayPal, or another processor.
             </p>
-          ) : (
+          ) : refundFeedbackSource === 'STRIPE_CREATE' ? (
             <p className="mt-2 text-sm text-gray-700">
               Stripe mode initiates a processor refund. A pending or unknown outcome remains
               reserved until Retry reconciles it.
             </p>
+          ) : (
+            <p className="mt-2 text-sm text-gray-700">
+              Retry inspects Stripe before deciding whether the stored request needs to be
+              resubmitted.
+            </p>
           )}
-          <p className="mt-2 text-sm font-medium text-amber-800">
-            A full refund does not cancel the registration. Use the existing cancellation workflow
-            when cancellation is intended.
-          </p>
+          {refundFeedbackSource !== 'STRIPE_RETRY' && (
+            <p className="mt-2 text-sm font-medium text-amber-800">
+              A full refund does not cancel the registration. Use the existing cancellation
+              workflow when cancellation is intended.
+            </p>
+          )}
 
           {selectedRefundPayment && (
             <>
@@ -979,7 +1024,7 @@ export default function AdminPaymentsPage() {
 
                 {refundError && (
                   <p className="text-sm text-red-700" role="alert">
-                    {refundError}
+                    {refundError.message}
                   </p>
                 )}
                 <div className="flex gap-3">
@@ -1014,7 +1059,7 @@ export default function AdminPaymentsPage() {
 
           {!selectedRefundPayment && refundError && (
             <p className="mt-4 text-sm text-red-700" role="alert">
-              {refundError}
+              {refundError.message}
             </p>
           )}
 

--- a/apps/web/src/pages/AdminPaymentsPage.tsx
+++ b/apps/web/src/pages/AdminPaymentsPage.tsx
@@ -7,6 +7,7 @@ import {
   AdminPayment,
   adminPaymentsApi,
   ExternalPaymentMethod,
+  RefundAmountSelection,
   RefundRegistrationStatus,
   ExternalPaymentSearchRegistration,
   ExternalPaymentSearchRegistrationStatus,
@@ -277,18 +278,21 @@ export default function AdminPaymentsPage() {
       return;
     }
 
-    const amountCents = refundAmountMode === 'partial' ? parseDollarsToCents(refundAmount) : null;
-    if (
-      refundAmountMode === 'partial' &&
-      (amountCents === null || amountCents > selectedRefundPayment.availableRefundCents)
-    ) {
-      setRefundError(
-        `Enter a positive amount with at most two decimals, no more than ${formatCents(
-          selectedRefundPayment.currency,
-          selectedRefundPayment.availableRefundCents
-        )}.`
-      );
-      return;
+    let amountSelection: RefundAmountSelection;
+    if (refundAmountMode === 'full') {
+      amountSelection = { fullRefund: true };
+    } else {
+      const amountCents = parseDollarsToCents(refundAmount);
+      if (amountCents === null || amountCents > selectedRefundPayment.availableRefundCents) {
+        setRefundError(
+          `Enter a positive amount with at most two decimals, no more than ${formatCents(
+            selectedRefundPayment.currency,
+            selectedRefundPayment.availableRefundCents
+          )}.`
+        );
+        return;
+      }
+      amountSelection = { amountCents };
     }
 
     setIsSubmittingRefund(true);
@@ -296,9 +300,7 @@ export default function AdminPaymentsPage() {
     setRefundSuccess(null);
     try {
       const result = await adminPaymentsApi.createManualRefund(selectedRefundPayment.id, {
-        ...(refundAmountMode === 'full'
-          ? { fullRefund: true as const }
-          : { amountCents: amountCents as number }),
+        ...amountSelection,
         executionMode: 'MANUAL',
         reason: refundReason.trim() || undefined,
         externalReference: refundReference.trim() || undefined,

--- a/apps/web/src/pages/AdminPaymentsPage.tsx
+++ b/apps/web/src/pages/AdminPaymentsPage.tsx
@@ -423,13 +423,11 @@ export default function AdminPaymentsPage() {
   };
 
   const refundFeedbackSource: RefundFeedbackSource | null =
-    refundNotice?.source ??
-    refundError?.source ??
-    (selectedRefundPayment
+    selectedRefundPayment
       ? refundExecutionMode === 'MANUAL'
         ? 'MANUAL_CREATE'
         : 'STRIPE_CREATE'
-      : null);
+      : (refundNotice?.source ?? refundError?.source ?? null);
 
   return (
     <div className="mx-auto max-w-6xl space-y-8 px-4 py-8">

--- a/apps/web/src/pages/AdminPaymentsPage.tsx
+++ b/apps/web/src/pages/AdminPaymentsPage.tsx
@@ -65,8 +65,16 @@ function formatCents(currency: string, amountCents: number): string {
   return `${currency} ${(amountCents / 100).toFixed(2)}`;
 }
 
+function formatPaymentAmount(payment: AdminPayment): string {
+  return payment.paymentAmountCents === null
+    ? `${payment.currency} ${String(payment.amount)}`
+    : formatCents(payment.currency, payment.paymentAmountCents);
+}
+
 function canRefundPayment(payment: AdminPayment): boolean {
   return (
+    payment.paymentAmountCents !== null &&
+    payment.refundUnavailableReason === null &&
     (payment.status === 'COMPLETED' || payment.status === 'PARTIALLY_REFUNDED') &&
     payment.availableRefundCents > 0
   );
@@ -84,8 +92,34 @@ function getRegistrationEffect(registration: Registration): string {
   return `The registration will remain ${registration.status} and payment deferral will be cleared.`;
 }
 
+function getBoundedServerMessage(error: unknown): string | null {
+  if (typeof error !== 'object' || error === null || !('response' in error)) {
+    return null;
+  }
+
+  const response = error.response;
+  if (typeof response !== 'object' || response === null || !('data' in response)) {
+    return null;
+  }
+
+  const data = response.data;
+  if (typeof data !== 'object' || data === null || Array.isArray(data) || !('message' in data)) {
+    return null;
+  }
+
+  const message = data.message;
+  const normalizedMessage =
+    typeof message === 'string'
+      ? message.trim()
+      : Array.isArray(message) && message.every(item => typeof item === 'string')
+        ? message.map(item => item.trim()).filter(Boolean).join('; ')
+        : '';
+
+  return normalizedMessage ? normalizedMessage.slice(0, 500) : null;
+}
+
 function getErrorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error ? error.message : fallback;
+  return getBoundedServerMessage(error) ?? (error instanceof Error ? error.message : fallback);
 }
 
 /**
@@ -576,7 +610,7 @@ export default function AdminPaymentsPage() {
                       {new Date(payment.createdAt).toLocaleDateString()}
                     </td>
                     <td className="px-3 py-3">
-                      {payment.currency} {payment.amount.toFixed(2)}
+                      {formatPaymentAmount(payment)}
                     </td>
                     <td className="px-3 py-3">{payment.status}</td>
                     <td className="px-3 py-3">{payment.provider}</td>
@@ -596,6 +630,11 @@ export default function AdminPaymentsPage() {
                       <div className="font-medium">
                         Available: {formatCents(payment.currency, payment.availableRefundCents)}
                       </div>
+                      {payment.refundUnavailableReason && (
+                        <div className="mt-1 max-w-xs text-red-700">
+                          {payment.refundUnavailableReason}
+                        </div>
+                      )}
                     </td>
                     <td className="px-3 py-3 text-sm">
                       {payment.refunds.length === 0 ? (
@@ -683,10 +722,7 @@ export default function AdminPaymentsPage() {
               <div className="mt-4 grid gap-3 rounded border border-gray-200 p-4 text-sm md:grid-cols-4">
                 <div>
                   <span className="block text-gray-500">Original amount</span>
-                  {formatCents(
-                    selectedRefundPayment.currency,
-                    selectedRefundPayment.paymentAmountCents
-                  )}
+                  {formatPaymentAmount(selectedRefundPayment)}
                 </div>
                 <div>
                   <span className="block text-gray-500">Successful refunds</span>

--- a/apps/web/src/pages/AdminPaymentsPage.tsx
+++ b/apps/web/src/pages/AdminPaymentsPage.tsx
@@ -98,7 +98,13 @@ function getBoundedServerMessage(error: unknown): string | null {
   }
 
   const response = error.response;
-  if (typeof response !== 'object' || response === null || !('data' in response)) {
+  if (
+    typeof response !== 'object' ||
+    response === null ||
+    !('status' in response) ||
+    ![400, 404, 409].includes(typeof response.status === 'number' ? response.status : -1) ||
+    !('data' in response)
+  ) {
     return null;
   }
 
@@ -119,7 +125,7 @@ function getBoundedServerMessage(error: unknown): string | null {
 }
 
 function getErrorMessage(error: unknown, fallback: string): string {
-  return getBoundedServerMessage(error) ?? (error instanceof Error ? error.message : fallback);
+  return getBoundedServerMessage(error) ?? fallback;
 }
 
 /**

--- a/apps/web/src/pages/AdminPaymentsPage.tsx
+++ b/apps/web/src/pages/AdminPaymentsPage.tsx
@@ -11,6 +11,7 @@ import {
   AdminPayment,
   adminPaymentsApi,
   ExternalPaymentMethod,
+  RefundExecutionMode,
   RefundRegistrationStatus,
 } from '../lib/api/admin-payments';
 import { ROUTES } from '../routes';
@@ -156,6 +157,8 @@ export default function AdminPaymentsPage() {
   const [selectedRefundPayment, setSelectedRefundPayment] = useState<AdminPayment | null>(null);
   const [refundAmountMode, setRefundAmountMode] = useState<'partial' | 'full'>('partial');
   const [refundAmount, setRefundAmount] = useState('');
+  const [refundExecutionMode, setRefundExecutionMode] =
+    useState<RefundExecutionMode>('MANUAL');
   const [refundReason, setRefundReason] = useState('');
   const [refundReference, setRefundReference] = useState('');
   const [refundRegistrationStatus, setRefundRegistrationStatus] = useState<
@@ -163,8 +166,12 @@ export default function AdminPaymentsPage() {
   >('');
   const [refundIdempotencyKey, setRefundIdempotencyKey] = useState(createIdempotencyKey);
   const [isSubmittingRefund, setIsSubmittingRefund] = useState(false);
+  const [retryingRefundId, setRetryingRefundId] = useState<string | null>(null);
   const [refundError, setRefundError] = useState<string | null>(null);
-  const [refundSuccess, setRefundSuccess] = useState<string | null>(null);
+  const [refundNotice, setRefundNotice] = useState<{
+    kind: 'success' | 'warning' | 'failure';
+    message: string;
+  } | null>(null);
 
   const hasMeaningfulSearch = useMemo(() => {
     const hasName = (registrationFilters.name?.trim().length ?? 0) >= 2;
@@ -258,15 +265,16 @@ export default function AdminPaymentsPage() {
     setSelectedRefundPayment(payment);
     setRefundAmountMode('partial');
     setRefundAmount('');
+    setRefundExecutionMode('MANUAL');
     setRefundReason('');
     setRefundReference('');
     setRefundRegistrationStatus('');
     setRefundIdempotencyKey(createIdempotencyKey());
     setRefundError(null);
-    setRefundSuccess(null);
+    setRefundNotice(null);
   };
 
-  const recordManualRefund = async (event: FormEvent): Promise<void> => {
+  const submitRefund = async (event: FormEvent): Promise<void> => {
     event.preventDefault();
     if (!selectedRefundPayment) {
       return;
@@ -288,21 +296,42 @@ export default function AdminPaymentsPage() {
 
     setIsSubmittingRefund(true);
     setRefundError(null);
-    setRefundSuccess(null);
+    setRefundNotice(null);
     try {
-      const result = await adminPaymentsApi.createManualRefund(selectedRefundPayment.id, {
+      const result = await adminPaymentsApi.createRefund(selectedRefundPayment.id, {
         ...(refundAmountMode === 'full'
           ? { fullRefund: true as const }
           : { amountCents: amountCents as number }),
-        executionMode: 'MANUAL',
+        executionMode: refundExecutionMode,
         reason: refundReason.trim() || undefined,
-        externalReference: refundReference.trim() || undefined,
+        ...(refundExecutionMode === 'MANUAL'
+          ? { externalReference: refundReference.trim() || undefined }
+          : {}),
         resultingRegistrationStatus: refundRegistrationStatus || undefined,
         idempotencyKey: refundIdempotencyKey,
       });
-      setRefundSuccess(
-        `Manual refund recorded: ${formatCents(result.refund.currency, result.refund.amountCents)}.`
-      );
+      const formattedAmount = formatCents(result.refund.currency, result.refund.amountCents);
+      if (result.outcome === 'SUCCEEDED') {
+        setRefundNotice({
+          kind: 'success',
+          message:
+            refundExecutionMode === 'MANUAL'
+              ? `Manual refund recorded: ${formattedAmount}.`
+              : `Stripe refund succeeded: ${formattedAmount}.`,
+        });
+      } else if (result.outcome === 'FAILED') {
+        setRefundNotice({
+          kind: 'failure',
+          message: `Stripe rejected the refund. ${formattedAmount} is no longer reserved.`,
+        });
+      } else {
+        setRefundNotice({
+          kind: 'warning',
+          message:
+            `Stripe outcome is pending or unknown for ${formattedAmount}. ` +
+            'The amount remains reserved; use Retry from refund history.',
+        });
+      }
       setRefundIdempotencyKey(createIdempotencyKey());
       setSelectedRefundPayment(null);
       setRefundAmount('');
@@ -311,9 +340,43 @@ export default function AdminPaymentsPage() {
       setRefundRegistrationStatus('');
       await loadPayments(paymentSkip);
     } catch (error: unknown) {
-      setRefundError(getErrorMessage(error, 'Unable to record the manual refund.'));
+      setRefundError(
+        getErrorMessage(
+          error,
+          refundExecutionMode === 'MANUAL'
+            ? 'Unable to record the manual refund.'
+            : 'Unable to initiate the Stripe refund.'
+        )
+      );
     } finally {
       setIsSubmittingRefund(false);
+    }
+  };
+
+  const retryStripeRefund = async (paymentId: string, refundId: string): Promise<void> => {
+    setRetryingRefundId(refundId);
+    setRefundError(null);
+    setRefundNotice(null);
+    try {
+      const result = await adminPaymentsApi.retryStripeRefund(paymentId, refundId);
+      if (result.outcome === 'SUCCEEDED') {
+        setRefundNotice({ kind: 'success', message: 'Stripe refund reconciliation succeeded.' });
+      } else if (result.outcome === 'FAILED') {
+        setRefundNotice({
+          kind: 'failure',
+          message: 'Stripe rejected the refund. Its reserved balance has been released.',
+        });
+      } else {
+        setRefundNotice({
+          kind: 'warning',
+          message: 'Stripe outcome remains pending or unknown; the amount is still reserved.',
+        });
+      }
+      await loadPayments(paymentSkip);
+    } catch (error: unknown) {
+      setRefundError(getErrorMessage(error, 'Unable to retry the Stripe refund.'));
+    } finally {
+      setRetryingRefundId(null);
     }
   };
 
@@ -648,12 +711,26 @@ export default function AdminPaymentsPage() {
                       ) : (
                         <ul className="space-y-1">
                           {payment.refunds.map(refund => (
-                            <li key={refund.id}>
+                            <li
+                              className={refund.status === 'FAILED' ? 'text-red-700' : undefined}
+                              key={refund.id}
+                            >
                               {formatCents(refund.currency, refund.amountCents)} {refund.status} /{' '}
                               {refund.executionMode}
                               {refund.externalReference && (
                                 <div className="text-gray-500">{refund.externalReference}</div>
                               )}
+                              {refund.status === 'PENDING' &&
+                                refund.executionMode === 'STRIPE' && (
+                                  <button
+                                    className="ml-2 rounded border border-amber-600 px-2 py-1 text-xs font-medium text-amber-800 disabled:text-gray-400"
+                                    disabled={retryingRefundId !== null}
+                                    onClick={() => void retryStripeRefund(payment.id, refund.id)}
+                                    type="button"
+                                  >
+                                    {retryingRefundId === refund.id ? 'Retrying...' : 'Retry'}
+                                  </button>
+                                )}
                             </li>
                           ))}
                         </ul>
@@ -711,13 +788,24 @@ export default function AdminPaymentsPage() {
         </div>
       </section>
 
-      {(selectedRefundPayment || refundSuccess) && (
+      {(selectedRefundPayment || refundNotice || refundError) && (
         <section className="rounded-lg bg-white p-6 shadow">
-          <h2 className="text-xl font-semibold text-gray-900">Record completed manual refund</h2>
-          <p className="mt-2 text-sm text-gray-700">
-            Manual mode records a refund that already completed outside PlayaPlan. It does not
-            contact Stripe, PayPal, or another processor.
-          </p>
+          <h2 className="text-xl font-semibold text-gray-900">
+            {refundExecutionMode === 'MANUAL'
+              ? 'Record completed manual refund'
+              : 'Initiate Stripe refund'}
+          </h2>
+          {refundExecutionMode === 'MANUAL' ? (
+            <p className="mt-2 text-sm text-gray-700">
+              Manual mode records a refund that already completed outside PlayaPlan. It does not
+              contact Stripe, PayPal, or another processor.
+            </p>
+          ) : (
+            <p className="mt-2 text-sm text-gray-700">
+              Stripe mode initiates a processor refund. A pending or unknown outcome remains
+              reserved until Retry reconciles it.
+            </p>
+          )}
           <p className="mt-2 text-sm font-medium text-amber-800">
             A full refund does not cancel the registration. Use the existing cancellation workflow
             when cancellation is intended.
@@ -753,7 +841,36 @@ export default function AdminPaymentsPage() {
                 </div>
               </div>
 
-              <form className="mt-5 space-y-4" onSubmit={recordManualRefund}>
+              <form className="mt-5 space-y-4" onSubmit={submitRefund}>
+                {selectedRefundPayment.stripeRefundEligible && (
+                  <fieldset>
+                    <legend className="text-sm font-medium text-gray-700">Execution mode</legend>
+                    <div className="mt-2 flex flex-wrap gap-4">
+                      <label className="flex items-center gap-2 text-sm">
+                        <input
+                          checked={refundExecutionMode === 'MANUAL'}
+                          name="refundExecutionMode"
+                          onChange={() => setRefundExecutionMode('MANUAL')}
+                          type="radio"
+                        />
+                        Record completed external refund
+                      </label>
+                      <label className="flex items-center gap-2 text-sm">
+                        <input
+                          aria-label="Initiate Stripe refund"
+                          checked={refundExecutionMode === 'STRIPE'}
+                          name="refundExecutionMode"
+                          onChange={() => {
+                            setRefundExecutionMode('STRIPE');
+                            setRefundReference('');
+                          }}
+                          type="radio"
+                        />
+                        Initiate Stripe processor refund
+                      </label>
+                    </div>
+                  </fieldset>
+                )}
                 <fieldset>
                   <legend className="text-sm font-medium text-gray-700">Refund amount</legend>
                   <div className="mt-2 flex flex-wrap gap-4">
@@ -810,16 +927,18 @@ export default function AdminPaymentsPage() {
                       onChange={event => setRefundReason(event.target.value)}
                     />
                   </label>
-                  <label className="text-sm font-medium text-gray-700">
-                    External reference (optional)
-                    <input
-                      aria-label="Manual refund reference"
-                      className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
-                      maxLength={255}
-                      value={refundReference}
-                      onChange={event => setRefundReference(event.target.value)}
-                    />
-                  </label>
+                  {refundExecutionMode === 'MANUAL' && (
+                    <label className="text-sm font-medium text-gray-700">
+                      External reference (optional)
+                      <input
+                        aria-label="Manual refund reference"
+                        className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                        maxLength={255}
+                        value={refundReference}
+                        onChange={event => setRefundReference(event.target.value)}
+                      />
+                    </label>
+                  )}
                 </div>
 
                 {selectedRefundPayment.registration && (
@@ -856,7 +975,13 @@ export default function AdminPaymentsPage() {
                     disabled={isSubmittingRefund}
                     type="submit"
                   >
-                    {isSubmittingRefund ? 'Recording refund...' : 'Record manual refund'}
+                    {isSubmittingRefund
+                      ? refundExecutionMode === 'MANUAL'
+                        ? 'Recording refund...'
+                        : 'Initiating refund...'
+                      : refundExecutionMode === 'MANUAL'
+                        ? 'Record manual refund'
+                        : 'Initiate Stripe refund'}
                   </button>
                   <button
                     className="rounded border border-gray-300 px-4 py-2"
@@ -874,12 +999,24 @@ export default function AdminPaymentsPage() {
             </>
           )}
 
-          {refundSuccess && (
+          {!selectedRefundPayment && refundError && (
+            <p className="mt-4 text-sm text-red-700" role="alert">
+              {refundError}
+            </p>
+          )}
+
+          {refundNotice && (
             <p
-              className="mt-4 rounded border border-green-300 bg-green-50 p-4 text-green-900"
+              className={`mt-4 rounded border p-4 ${
+                refundNotice.kind === 'success'
+                  ? 'border-green-300 bg-green-50 text-green-900'
+                  : refundNotice.kind === 'failure'
+                    ? 'border-red-300 bg-red-50 text-red-900'
+                    : 'border-amber-300 bg-amber-50 text-amber-900'
+              }`}
               role="status"
             >
-              {refundSuccess}
+              {refundNotice.message}
             </p>
           )}
         </section>

--- a/apps/web/src/pages/AdminPaymentsPage.tsx
+++ b/apps/web/src/pages/AdminPaymentsPage.tsx
@@ -11,6 +11,7 @@ import {
   AdminPayment,
   adminPaymentsApi,
   ExternalPaymentMethod,
+  RefundRegistrationStatus,
 } from '../lib/api/admin-payments';
 import { ROUTES } from '../routes';
 
@@ -39,8 +40,36 @@ const EXTERNAL_PAYMENT_METHODS: readonly ExternalPaymentMethod[] = [
   'OTHER',
 ];
 
+const REFUND_REGISTRATION_STATUSES: readonly RefundRegistrationStatus[] = [
+  'PENDING',
+  'CONFIRMED',
+  'WAITLISTED',
+];
+
 function createIdempotencyKey(): string {
   return crypto.randomUUID();
+}
+
+function parseDollarsToCents(value: string): number | null {
+  const normalizedValue = value.trim();
+  if (!/^(?:0|[1-9]\d*)(?:\.\d{1,2})?$/.test(normalizedValue)) {
+    return null;
+  }
+
+  const [dollars, fraction = ''] = normalizedValue.split('.');
+  const amountCents = Number(dollars) * 100 + Number(fraction.padEnd(2, '0'));
+  return Number.isSafeInteger(amountCents) && amountCents > 0 ? amountCents : null;
+}
+
+function formatCents(currency: string, amountCents: number): string {
+  return `${currency} ${(amountCents / 100).toFixed(2)}`;
+}
+
+function canRefundPayment(payment: AdminPayment): boolean {
+  return (
+    (payment.status === 'COMPLETED' || payment.status === 'PARTIALLY_REFUNDED') &&
+    payment.availableRefundCents > 0
+  );
 }
 
 function isEligibleRegistration(registration: Registration): boolean {
@@ -63,13 +92,9 @@ function getErrorMessage(error: unknown, fallback: string): string {
  * Admin-only workflow for recording completed payments made outside PlayaPlan.
  */
 export default function AdminPaymentsPage() {
-  const [registrationFilters, setRegistrationFilters] =
-    useState<RegistrationFilters>({});
-  const [registrationResults, setRegistrationResults] = useState<
-    Registration[] | null
-  >(null);
-  const [selectedRegistration, setSelectedRegistration] =
-    useState<Registration | null>(null);
+  const [registrationFilters, setRegistrationFilters] = useState<RegistrationFilters>({});
+  const [registrationResults, setRegistrationResults] = useState<Registration[] | null>(null);
+  const [selectedRegistration, setSelectedRegistration] = useState<Registration | null>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
 
@@ -81,41 +106,41 @@ export default function AdminPaymentsPage() {
 
   const [amount, setAmount] = useState('');
   const [currency, setCurrency] = useState('USD');
-  const [externalMethod, setExternalMethod] =
-    useState<ExternalPaymentMethod>('CASH');
+  const [externalMethod, setExternalMethod] = useState<ExternalPaymentMethod>('CASH');
   const [externalReference, setExternalReference] = useState('');
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [idempotencyKey, setIdempotencyKey] = useState(createIdempotencyKey);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const [successfulPayment, setSuccessfulPayment] =
-    useState<AdminPayment | null>(null);
+  const [successfulPayment, setSuccessfulPayment] = useState<AdminPayment | null>(null);
+  const [selectedRefundPayment, setSelectedRefundPayment] = useState<AdminPayment | null>(null);
+  const [refundAmountMode, setRefundAmountMode] = useState<'partial' | 'full'>('partial');
+  const [refundAmount, setRefundAmount] = useState('');
+  const [refundReason, setRefundReason] = useState('');
+  const [refundReference, setRefundReference] = useState('');
+  const [refundRegistrationStatus, setRefundRegistrationStatus] = useState<
+    RefundRegistrationStatus | ''
+  >('');
+  const [refundIdempotencyKey, setRefundIdempotencyKey] = useState(createIdempotencyKey);
+  const [isSubmittingRefund, setIsSubmittingRefund] = useState(false);
+  const [refundError, setRefundError] = useState<string | null>(null);
+  const [refundSuccess, setRefundSuccess] = useState<string | null>(null);
 
   const hasMeaningfulSearch = useMemo(() => {
     const hasName = (registrationFilters.name?.trim().length ?? 0) >= 2;
     const hasEmail = (registrationFilters.email?.trim().length ?? 0) >= 2;
-    return Boolean(
-      hasName ||
-        hasEmail ||
-        registrationFilters.year ||
-        registrationFilters.status,
-    );
+    return Boolean(hasName || hasEmail || registrationFilters.year || registrationFilters.status);
   }, [registrationFilters]);
 
   const loadPayments = useCallback(async (skip: number): Promise<void> => {
     setIsLoadingPayments(true);
     setPaymentListError(null);
     try {
-      const paymentPage = await adminPaymentsApi.getPayments(
-        skip,
-        ADMIN_PAYMENT_PAGE_SIZE,
-      );
+      const paymentPage = await adminPaymentsApi.getPayments(skip, ADMIN_PAYMENT_PAGE_SIZE);
       setPayments(paymentPage.payments);
       setPaymentTotal(paymentPage.total);
     } catch (error: unknown) {
-      setPaymentListError(
-        getErrorMessage(error, 'Unable to load admin payments.'),
-      );
+      setPaymentListError(getErrorMessage(error, 'Unable to load admin payments.'));
     } finally {
       setIsLoadingPayments(false);
     }
@@ -125,18 +150,10 @@ export default function AdminPaymentsPage() {
     void loadPayments(paymentSkip);
   }, [loadPayments, paymentSkip]);
 
-  const updateRegistrationFilter = (
-    key: keyof RegistrationFilters,
-    value: string,
-  ): void => {
-    setRegistrationFilters((currentFilters) => ({
+  const updateRegistrationFilter = (key: keyof RegistrationFilters, value: string): void => {
+    setRegistrationFilters(currentFilters => ({
       ...currentFilters,
-      [key]:
-        value === ''
-          ? undefined
-          : key === 'year'
-            ? Number.parseInt(value, 10)
-            : value,
+      [key]: value === '' ? undefined : key === 'year' ? Number.parseInt(value, 10) : value,
     }));
   };
 
@@ -158,9 +175,7 @@ export default function AdminPaymentsPage() {
       });
       setRegistrationResults(result.registrations);
     } catch (error: unknown) {
-      setSearchError(
-        getErrorMessage(error, 'Unable to search registrations.'),
-      );
+      setSearchError(getErrorMessage(error, 'Unable to search registrations.'));
       setRegistrationResults([]);
     } finally {
       setIsSearching(false);
@@ -193,11 +208,72 @@ export default function AdminPaymentsPage() {
       setPaymentSkip(0);
       await loadPayments(0);
     } catch (error: unknown) {
-      setSubmitError(
-        getErrorMessage(error, 'Unable to record the external payment.'),
-      );
+      setSubmitError(getErrorMessage(error, 'Unable to record the external payment.'));
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const openRefundForm = (payment: AdminPayment): void => {
+    setSelectedRefundPayment(payment);
+    setRefundAmountMode('partial');
+    setRefundAmount('');
+    setRefundReason('');
+    setRefundReference('');
+    setRefundRegistrationStatus('');
+    setRefundIdempotencyKey(createIdempotencyKey());
+    setRefundError(null);
+    setRefundSuccess(null);
+  };
+
+  const recordManualRefund = async (event: FormEvent): Promise<void> => {
+    event.preventDefault();
+    if (!selectedRefundPayment) {
+      return;
+    }
+
+    const amountCents = refundAmountMode === 'partial' ? parseDollarsToCents(refundAmount) : null;
+    if (
+      refundAmountMode === 'partial' &&
+      (amountCents === null || amountCents > selectedRefundPayment.availableRefundCents)
+    ) {
+      setRefundError(
+        `Enter a positive amount with at most two decimals, no more than ${formatCents(
+          selectedRefundPayment.currency,
+          selectedRefundPayment.availableRefundCents
+        )}.`
+      );
+      return;
+    }
+
+    setIsSubmittingRefund(true);
+    setRefundError(null);
+    setRefundSuccess(null);
+    try {
+      const result = await adminPaymentsApi.createManualRefund(selectedRefundPayment.id, {
+        ...(refundAmountMode === 'full'
+          ? { fullRefund: true as const }
+          : { amountCents: amountCents as number }),
+        executionMode: 'MANUAL',
+        reason: refundReason.trim() || undefined,
+        externalReference: refundReference.trim() || undefined,
+        resultingRegistrationStatus: refundRegistrationStatus || undefined,
+        idempotencyKey: refundIdempotencyKey,
+      });
+      setRefundSuccess(
+        `Manual refund recorded: ${formatCents(result.refund.currency, result.refund.amountCents)}.`
+      );
+      setRefundIdempotencyKey(createIdempotencyKey());
+      setSelectedRefundPayment(null);
+      setRefundAmount('');
+      setRefundReason('');
+      setRefundReference('');
+      setRefundRegistrationStatus('');
+      await loadPayments(paymentSkip);
+    } catch (error: unknown) {
+      setRefundError(getErrorMessage(error, 'Unable to record the manual refund.'));
+    } finally {
+      setIsSubmittingRefund(false);
     }
   };
 
@@ -210,19 +286,15 @@ export default function AdminPaymentsPage() {
         >
           &larr; Admin Panel
         </Link>
-        <h1 className="mt-3 text-3xl font-bold text-gray-900">
-          Admin Payments
-        </h1>
+        <h1 className="mt-3 text-3xl font-bold text-gray-900">Admin Payments</h1>
         <p className="mt-2 text-gray-600">
-          Record a payment that has already completed outside PlayaPlan. This
-          form does not charge Stripe, PayPal, or any other processor.
+          Record a payment that has already completed outside PlayaPlan. This form does not charge
+          Stripe, PayPal, or any other processor.
         </p>
       </div>
 
       <section className="rounded-lg bg-white p-6 shadow">
-        <h2 className="text-xl font-semibold text-gray-900">
-          1. Find a registration
-        </h2>
+        <h2 className="text-xl font-semibold text-gray-900">1. Find a registration</h2>
         <form
           className="mt-4 grid gap-4 md:grid-cols-2 lg:grid-cols-5"
           onSubmit={searchRegistrations}
@@ -233,9 +305,7 @@ export default function AdminPaymentsPage() {
               aria-label="Registration name"
               className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
               value={registrationFilters.name ?? ''}
-              onChange={(event) =>
-                updateRegistrationFilter('name', event.target.value)
-              }
+              onChange={event => updateRegistrationFilter('name', event.target.value)}
             />
           </label>
           <label className="text-sm font-medium text-gray-700">
@@ -245,9 +315,7 @@ export default function AdminPaymentsPage() {
               className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
               type="email"
               value={registrationFilters.email ?? ''}
-              onChange={(event) =>
-                updateRegistrationFilter('email', event.target.value)
-              }
+              onChange={event => updateRegistrationFilter('email', event.target.value)}
             />
           </label>
           <label className="text-sm font-medium text-gray-700">
@@ -258,9 +326,7 @@ export default function AdminPaymentsPage() {
               min="2020"
               type="number"
               value={registrationFilters.year ?? ''}
-              onChange={(event) =>
-                updateRegistrationFilter('year', event.target.value)
-              }
+              onChange={event => updateRegistrationFilter('year', event.target.value)}
             />
           </label>
           <label className="text-sm font-medium text-gray-700">
@@ -269,12 +335,10 @@ export default function AdminPaymentsPage() {
               aria-label="Registration status"
               className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
               value={registrationFilters.status ?? ''}
-              onChange={(event) =>
-                updateRegistrationFilter('status', event.target.value)
-              }
+              onChange={event => updateRegistrationFilter('status', event.target.value)}
             >
               <option value="">Any status</option>
-              {REGISTRATION_STATUS_OPTIONS.map((status) => (
+              {REGISTRATION_STATUS_OPTIONS.map(status => (
                 <option key={status} value={status}>
                   {status}
                 </option>
@@ -311,7 +375,7 @@ export default function AdminPaymentsPage() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
-                {registrationResults.map((registration) => {
+                {registrationResults.map(registration => {
                   const eligible = isEligibleRegistration(registration);
                   return (
                     <tr key={registration.id}>
@@ -327,20 +391,15 @@ export default function AdminPaymentsPage() {
                       </td>
                       <td className="px-3 py-3">
                         <div className="font-medium text-gray-900">
-                          {registration.user.firstName}{' '}
-                          {registration.user.lastName}
+                          {registration.user.firstName} {registration.user.lastName}
                         </div>
-                        <div className="text-sm text-gray-500">
-                          {registration.user.email}
-                        </div>
+                        <div className="text-sm text-gray-500">{registration.user.email}</div>
                       </td>
                       <td className="px-3 py-3">{registration.year}</td>
                       <td className="px-3 py-3">
                         {registration.status}
                         {!eligible && (
-                          <span className="ml-2 text-sm text-red-700">
-                            Not eligible
-                          </span>
+                          <span className="ml-2 text-sm text-red-700">Not eligible</span>
                         )}
                       </td>
                     </tr>
@@ -349,9 +408,7 @@ export default function AdminPaymentsPage() {
               </tbody>
             </table>
             {registrationResults.length === 0 && (
-              <p className="py-4 text-sm text-gray-600">
-                No registrations matched.
-              </p>
+              <p className="py-4 text-sm text-gray-600">No registrations matched.</p>
             )}
           </div>
         )}
@@ -364,13 +421,11 @@ export default function AdminPaymentsPage() {
         {selectedRegistration ? (
           <div className="mt-3 rounded border border-blue-200 bg-blue-50 p-4">
             <p className="font-medium text-blue-950">
-              {selectedRegistration.user.firstName}{' '}
-              {selectedRegistration.user.lastName} (
+              {selectedRegistration.user.firstName} {selectedRegistration.user.lastName} (
               {selectedRegistration.user.email})
             </p>
             <p className="text-sm text-blue-900">
-              Registration {selectedRegistration.id} &middot;{' '}
-              {selectedRegistration.year} &middot;{' '}
+              Registration {selectedRegistration.id} &middot; {selectedRegistration.year} &middot;{' '}
               {selectedRegistration.status}
             </p>
             <p className="mt-2 text-sm text-blue-900">
@@ -395,7 +450,7 @@ export default function AdminPaymentsPage() {
                 step="0.01"
                 type="number"
                 value={amount}
-                onChange={(event) => setAmount(event.target.value)}
+                onChange={event => setAmount(event.target.value)}
               />
             </label>
             <label className="text-sm font-medium text-gray-700">
@@ -408,7 +463,7 @@ export default function AdminPaymentsPage() {
                 pattern="[A-Za-z]{3}"
                 required
                 value={currency}
-                onChange={(event) => setCurrency(event.target.value)}
+                onChange={event => setCurrency(event.target.value)}
               />
             </label>
             <label className="text-sm font-medium text-gray-700">
@@ -417,11 +472,9 @@ export default function AdminPaymentsPage() {
                 aria-label="External payment method"
                 className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
                 value={externalMethod}
-                onChange={(event) =>
-                  setExternalMethod(event.target.value as ExternalPaymentMethod)
-                }
+                onChange={event => setExternalMethod(event.target.value as ExternalPaymentMethod)}
               >
-                {EXTERNAL_PAYMENT_METHODS.map((method) => (
+                {EXTERNAL_PAYMENT_METHODS.map(method => (
                   <option key={method} value={method}>
                     {method.replace('_', ' ')}
                   </option>
@@ -435,7 +488,7 @@ export default function AdminPaymentsPage() {
                 className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
                 maxLength={255}
                 value={externalReference}
-                onChange={(event) => setExternalReference(event.target.value)}
+                onChange={event => setExternalReference(event.target.value)}
               />
             </label>
           </div>
@@ -444,12 +497,12 @@ export default function AdminPaymentsPage() {
               aria-label="Confirm external payment"
               checked={isConfirmed}
               className="mt-1"
-              onChange={(event) => setIsConfirmed(event.target.checked)}
+              onChange={event => setIsConfirmed(event.target.checked)}
               type="checkbox"
             />
             <span>
-              I confirm this payment already completed outside PlayaPlan and
-              that the selected registration behavior shown above is correct.
+              I confirm this payment already completed outside PlayaPlan and that the selected
+              registration behavior shown above is correct.
             </span>
           </label>
           {submitError && (
@@ -459,12 +512,7 @@ export default function AdminPaymentsPage() {
           )}
           <button
             className="rounded bg-green-700 px-4 py-2 font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-400"
-            disabled={
-              !selectedRegistration ||
-              !isConfirmed ||
-              Number(amount) <= 0 ||
-              isSubmitting
-            }
+            disabled={!selectedRegistration || !isConfirmed || Number(amount) <= 0 || isSubmitting}
             type="submit"
           >
             {isSubmitting ? 'Recording...' : 'Record external payment'}
@@ -472,17 +520,11 @@ export default function AdminPaymentsPage() {
         </form>
 
         {successfulPayment && (
-          <div
-            className="mt-5 rounded border border-green-300 bg-green-50 p-4"
-            role="status"
-          >
-            <p className="font-semibold text-green-900">
-              External payment recorded
-            </p>
+          <div className="mt-5 rounded border border-green-300 bg-green-50 p-4" role="status">
+            <p className="font-semibold text-green-900">External payment recorded</p>
             <p className="text-sm text-green-800">
               {successfulPayment.id}: {successfulPayment.currency}{' '}
-              {successfulPayment.amount.toFixed(2)} for{' '}
-              {successfulPayment.user.firstName}{' '}
+              {successfulPayment.amount.toFixed(2)} for {successfulPayment.user.firstName}{' '}
               {successfulPayment.user.lastName}
             </p>
           </div>
@@ -510,21 +552,20 @@ export default function AdminPaymentsPage() {
                   <th className="px-3 py-2">Status</th>
                   <th className="px-3 py-2">Provider</th>
                   <th className="px-3 py-2">External details</th>
+                  <th className="px-3 py-2">Refund balance</th>
+                  <th className="px-3 py-2">Refund history</th>
+                  <th className="px-3 py-2">Action</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
-                {payments.map((payment) => (
+                {payments.map(payment => (
                   <tr
-                    className={
-                      payment.id === successfulPayment?.id ? 'bg-green-50' : ''
-                    }
+                    className={payment.id === successfulPayment?.id ? 'bg-green-50' : ''}
                     key={payment.id}
                   >
                     <td className="px-3 py-3">
                       {payment.user.firstName} {payment.user.lastName}
-                      <div className="text-sm text-gray-500">
-                        {payment.user.email}
-                      </div>
+                      <div className="text-sm text-gray-500">{payment.user.email}</div>
                     </td>
                     <td className="px-3 py-3">
                       {payment.registration
@@ -542,9 +583,48 @@ export default function AdminPaymentsPage() {
                     <td className="px-3 py-3">
                       {payment.externalMethod ?? '—'}
                       {payment.externalReference && (
-                        <div className="text-sm text-gray-500">
-                          {payment.externalReference}
-                        </div>
+                        <div className="text-sm text-gray-500">{payment.externalReference}</div>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-sm">
+                      <div>
+                        Successful: {formatCents(payment.currency, payment.successfulRefundCents)}
+                      </div>
+                      <div>
+                        Pending: {formatCents(payment.currency, payment.pendingRefundCents)}
+                      </div>
+                      <div className="font-medium">
+                        Available: {formatCents(payment.currency, payment.availableRefundCents)}
+                      </div>
+                    </td>
+                    <td className="px-3 py-3 text-sm">
+                      {payment.refunds.length === 0 ? (
+                        <span className="text-gray-500">No ledger history</span>
+                      ) : (
+                        <ul className="space-y-1">
+                          {payment.refunds.map(refund => (
+                            <li key={refund.id}>
+                              {formatCents(refund.currency, refund.amountCents)} {refund.status} /{' '}
+                              {refund.executionMode}
+                              {refund.externalReference && (
+                                <div className="text-gray-500">{refund.externalReference}</div>
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </td>
+                    <td className="px-3 py-3">
+                      {canRefundPayment(payment) ? (
+                        <button
+                          className="rounded bg-blue-700 px-3 py-2 text-sm font-medium text-white"
+                          onClick={() => openRefundForm(payment)}
+                          type="button"
+                        >
+                          Refund
+                        </button>
+                      ) : (
+                        <span className="text-sm text-gray-500">Unavailable</span>
                       )}
                     </td>
                   </tr>
@@ -561,9 +641,7 @@ export default function AdminPaymentsPage() {
             className="rounded border border-gray-300 px-3 py-2 text-sm disabled:text-gray-400"
             disabled={paymentSkip === 0 || isLoadingPayments}
             onClick={() =>
-              setPaymentSkip((currentSkip) =>
-                Math.max(0, currentSkip - ADMIN_PAYMENT_PAGE_SIZE),
-              )
+              setPaymentSkip(currentSkip => Math.max(0, currentSkip - ADMIN_PAYMENT_PAGE_SIZE))
             }
             type="button"
           >
@@ -574,26 +652,196 @@ export default function AdminPaymentsPage() {
               ? '0 payments'
               : `${paymentSkip + 1}-${Math.min(
                   paymentSkip + ADMIN_PAYMENT_PAGE_SIZE,
-                  paymentTotal,
+                  paymentTotal
                 )} of ${paymentTotal}`}
           </span>
           <button
             className="rounded border border-gray-300 px-3 py-2 text-sm disabled:text-gray-400"
-            disabled={
-              paymentSkip + ADMIN_PAYMENT_PAGE_SIZE >= paymentTotal ||
-              isLoadingPayments
-            }
-            onClick={() =>
-              setPaymentSkip(
-                (currentSkip) => currentSkip + ADMIN_PAYMENT_PAGE_SIZE,
-              )
-            }
+            disabled={paymentSkip + ADMIN_PAYMENT_PAGE_SIZE >= paymentTotal || isLoadingPayments}
+            onClick={() => setPaymentSkip(currentSkip => currentSkip + ADMIN_PAYMENT_PAGE_SIZE)}
             type="button"
           >
             Next
           </button>
         </div>
       </section>
+
+      {(selectedRefundPayment || refundSuccess) && (
+        <section className="rounded-lg bg-white p-6 shadow">
+          <h2 className="text-xl font-semibold text-gray-900">Record completed manual refund</h2>
+          <p className="mt-2 text-sm text-gray-700">
+            Manual mode records a refund that already completed outside PlayaPlan. It does not
+            contact Stripe, PayPal, or another processor.
+          </p>
+          <p className="mt-2 text-sm font-medium text-amber-800">
+            A full refund does not cancel the registration. Use the existing cancellation workflow
+            when cancellation is intended.
+          </p>
+
+          {selectedRefundPayment && (
+            <>
+              <div className="mt-4 grid gap-3 rounded border border-gray-200 p-4 text-sm md:grid-cols-4">
+                <div>
+                  <span className="block text-gray-500">Original amount</span>
+                  {formatCents(
+                    selectedRefundPayment.currency,
+                    selectedRefundPayment.paymentAmountCents
+                  )}
+                </div>
+                <div>
+                  <span className="block text-gray-500">Successful refunds</span>
+                  {formatCents(
+                    selectedRefundPayment.currency,
+                    selectedRefundPayment.successfulRefundCents
+                  )}
+                </div>
+                <div>
+                  <span className="block text-gray-500">Pending reserved</span>
+                  {formatCents(
+                    selectedRefundPayment.currency,
+                    selectedRefundPayment.pendingRefundCents
+                  )}
+                </div>
+                <div>
+                  <span className="block text-gray-500">Available balance</span>
+                  {formatCents(
+                    selectedRefundPayment.currency,
+                    selectedRefundPayment.availableRefundCents
+                  )}
+                </div>
+              </div>
+
+              <form className="mt-5 space-y-4" onSubmit={recordManualRefund}>
+                <fieldset>
+                  <legend className="text-sm font-medium text-gray-700">Refund amount</legend>
+                  <div className="mt-2 flex flex-wrap gap-4">
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        checked={refundAmountMode === 'partial'}
+                        name="refundAmountMode"
+                        onChange={() => setRefundAmountMode('partial')}
+                        type="radio"
+                      />
+                      Partial
+                    </label>
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        aria-label="Full available refund"
+                        checked={refundAmountMode === 'full'}
+                        name="refundAmountMode"
+                        onChange={() => setRefundAmountMode('full')}
+                        type="radio"
+                      />
+                      Full available (
+                      {formatCents(
+                        selectedRefundPayment.currency,
+                        selectedRefundPayment.availableRefundCents
+                      )}
+                      )
+                    </label>
+                  </div>
+                </fieldset>
+
+                {refundAmountMode === 'partial' && (
+                  <label className="block text-sm font-medium text-gray-700">
+                    Partial refund amount
+                    <input
+                      aria-label="Partial refund amount"
+                      className="mt-1 block w-full max-w-xs rounded border border-gray-300 px-3 py-2"
+                      inputMode="decimal"
+                      placeholder="0.00"
+                      required
+                      value={refundAmount}
+                      onChange={event => setRefundAmount(event.target.value)}
+                    />
+                  </label>
+                )}
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <label className="text-sm font-medium text-gray-700">
+                    Reason (optional)
+                    <textarea
+                      aria-label="Manual refund reason"
+                      className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                      maxLength={500}
+                      value={refundReason}
+                      onChange={event => setRefundReason(event.target.value)}
+                    />
+                  </label>
+                  <label className="text-sm font-medium text-gray-700">
+                    External reference (optional)
+                    <input
+                      aria-label="Manual refund reference"
+                      className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                      maxLength={255}
+                      value={refundReference}
+                      onChange={event => setRefundReference(event.target.value)}
+                    />
+                  </label>
+                </div>
+
+                {selectedRefundPayment.registration && (
+                  <label className="block text-sm font-medium text-gray-700">
+                    Registration status after success (optional)
+                    <select
+                      aria-label="Refund registration status"
+                      className="mt-1 block w-full max-w-xs rounded border border-gray-300 px-3 py-2"
+                      value={refundRegistrationStatus}
+                      onChange={event =>
+                        setRefundRegistrationStatus(
+                          event.target.value as RefundRegistrationStatus | ''
+                        )
+                      }
+                    >
+                      <option value="">Leave unchanged</option>
+                      {REFUND_REGISTRATION_STATUSES.map(status => (
+                        <option key={status} value={status}>
+                          {status}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+
+                {refundError && (
+                  <p className="text-sm text-red-700" role="alert">
+                    {refundError}
+                  </p>
+                )}
+                <div className="flex gap-3">
+                  <button
+                    className="rounded bg-blue-700 px-4 py-2 font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-400"
+                    disabled={isSubmittingRefund}
+                    type="submit"
+                  >
+                    {isSubmittingRefund ? 'Recording refund...' : 'Record manual refund'}
+                  </button>
+                  <button
+                    className="rounded border border-gray-300 px-4 py-2"
+                    disabled={isSubmittingRefund}
+                    onClick={() => {
+                      setSelectedRefundPayment(null);
+                      setRefundError(null);
+                    }}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            </>
+          )}
+
+          {refundSuccess && (
+            <p
+              className="mt-4 rounded border border-green-300 bg-green-50 p-4 text-green-900"
+              role="status"
+            >
+              {refundSuccess}
+            </p>
+          )}
+        </section>
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
@@ -157,7 +157,7 @@ describe('AdminPaymentsPage', () => {
     fireEvent.click(screen.getByLabelText('Confirm external payment'));
     fireEvent.click(screen.getByRole('button', { name: 'Record external payment' }));
 
-    expect(await screen.findByText('Temporary request failure')).toBeInTheDocument();
+    expect(await screen.findByText('Unable to record the external payment.')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Record external payment' }));
 
@@ -347,6 +347,52 @@ describe('AdminPaymentsPage', () => {
       )
     ).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Refund' })).not.toBeInTheDocument();
+  });
+
+  it('should show an invalid stored currency reason without normalizing or offering a refund', async () => {
+    const legacyCurrencyPayment = {
+      ...payment,
+      id: 'legacy-currency-payment',
+      currency: 'usd',
+      refundUnavailableReason:
+        'Refund unavailable because the stored payment currency is invalid.',
+      availableRefundCents: 0,
+    };
+    mockGetPayments.mockResolvedValue({
+      payments: [legacyCurrencyPayment],
+      total: 1,
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('usd 125.50')).toBeInTheDocument();
+    expect(
+      screen.getByText('Refund unavailable because the stored payment currency is invalid.')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Refund' })).not.toBeInTheDocument();
+  });
+
+  it('should hide an internal 500 message behind the safe refund fallback', async () => {
+    const axiosError = Object.assign(new Error('Request failed with status code 500'), {
+      response: {
+        data: {
+          message: 'Internal database connection details',
+        },
+        status: 500,
+      },
+    });
+    mockGetPayments.mockResolvedValue({ payments: [payment], total: 1 });
+    mockCreateManualRefund.mockRejectedValue(axiosError);
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
+    fireEvent.change(screen.getByLabelText('Partial refund amount'), {
+      target: { value: '1.00' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
+
+    expect(await screen.findByText('Unable to record the manual refund.')).toBeInTheDocument();
+    expect(screen.queryByText('Internal database connection details')).not.toBeInTheDocument();
   });
 
   it.each(['1.001', '125.51'])(

--- a/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
@@ -70,6 +70,7 @@ const payment = {
   successfulRefundCents: 0,
   pendingRefundCents: 0,
   availableRefundCents: 12550,
+  refundUnavailableReason: null,
 };
 
 function renderPage(): void {
@@ -203,9 +204,16 @@ describe('AdminPaymentsPage', () => {
     mockGetPayments
       .mockResolvedValueOnce({ payments: [payment], total: 1 })
       .mockResolvedValue({ payments: [refundedPayment], total: 1 });
-    mockCreateManualRefund
-      .mockRejectedValueOnce(new Error('Temporary refund failure'))
-      .mockResolvedValueOnce(refundResult);
+    const axiosError = Object.assign(new Error('Request failed with status code 409'), {
+      response: {
+        data: {
+          message: 'Refund balance changed concurrently; refresh the payment and retry',
+          internalDetails: 'do not expose this payload',
+        },
+        status: 409,
+      },
+    });
+    mockCreateManualRefund.mockRejectedValueOnce(axiosError).mockResolvedValueOnce(refundResult);
     renderPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
@@ -227,7 +235,10 @@ describe('AdminPaymentsPage', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
 
-    expect(await screen.findByText('Temporary refund failure')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Refund balance changed concurrently; refresh the payment and retry')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('do not expose this payload')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
 
     expect(await screen.findByText('Manual refund recorded: USD 50.50.')).toBeInTheDocument();
@@ -290,6 +301,7 @@ describe('AdminPaymentsPage', () => {
       successfulRefundCents: 12550,
       pendingRefundCents: 0,
       availableRefundCents: 0,
+      refundUnavailableReason: null,
     });
     renderPage();
 
@@ -309,6 +321,32 @@ describe('AdminPaymentsPage', () => {
       })
     );
     expect(mockCreateManualRefund.mock.calls[0]?.[1]).not.toHaveProperty('amountCents');
+  });
+
+  it('should show a legacy precision reason without rounding or offering a refund action', async () => {
+    const legacyPrecisionPayment = {
+      ...payment,
+      id: 'legacy-precision-payment',
+      amount: 10.001,
+      paymentAmountCents: null,
+      availableRefundCents: 0,
+      refundUnavailableReason:
+        'Refund unavailable because the stored payment amount has unsupported precision.',
+    };
+    mockGetPayments.mockResolvedValue({
+      payments: [legacyPrecisionPayment],
+      total: 1,
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('USD 10.001')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Refund unavailable because the stored payment amount has unsupported precision.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Refund' })).not.toBeInTheDocument();
   });
 
   it.each(['1.001', '125.51'])(

--- a/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
@@ -593,6 +593,117 @@ describe('AdminPaymentsPage', () => {
     expect(mockGetPayments).toHaveBeenLastCalledWith(0, 25);
   });
 
+  it.each([
+    ['SUCCEEDED', 'SUCCEEDED', 'Stripe refund reconciliation succeeded.'],
+    [
+      'PENDING_UNKNOWN',
+      'PENDING',
+      'Stripe outcome remains pending or unknown; the amount is still reserved.',
+    ],
+    ['FAILED', 'FAILED', 'Stripe rejected the refund. Its reserved balance has been released.'],
+  ] as const)(
+    'should render direct Stripe retry outcome %s without manual recording context',
+    async (outcome, refundStatus, expectedMessage) => {
+      const pendingRefund = {
+        id: 'pending-refund',
+        amountCents: 2500,
+        currency: 'USD',
+        executionMode: 'STRIPE' as const,
+        status: 'PENDING' as const,
+        reason: null,
+        externalReference: null,
+        resultingRegistrationStatus: null,
+        createdAt: '2026-07-14T01:00:00.000Z',
+        updatedAt: '2026-07-14T01:00:00.000Z',
+      };
+      const pendingPayment = {
+        ...payment,
+        provider: 'STRIPE',
+        stripeRefundEligible: true,
+        refunds: [pendingRefund],
+        pendingRefundCents: 2500,
+        availableRefundCents: 10050,
+      };
+      const resultRefund = { ...pendingRefund, status: refundStatus };
+      mockGetPayments.mockResolvedValue({ payments: [pendingPayment], total: 1 });
+      mockRetryStripeRefund.mockResolvedValue({
+        payment: {
+          ...pendingPayment,
+          status: outcome === 'SUCCEEDED' ? 'PARTIALLY_REFUNDED' : pendingPayment.status,
+          refunds: [resultRefund],
+          successfulRefundCents: outcome === 'SUCCEEDED' ? 2500 : 0,
+          pendingRefundCents: outcome === 'PENDING_UNKNOWN' ? 2500 : 0,
+          availableRefundCents: outcome === 'PENDING_UNKNOWN' ? 10050 : 12550,
+        },
+        refund: resultRefund,
+        paymentAmountCents: 12550,
+        successfulRefundCents: outcome === 'SUCCEEDED' ? 2500 : 0,
+        pendingRefundCents: outcome === 'PENDING_UNKNOWN' ? 2500 : 0,
+        availableRefundCents: outcome === 'PENDING_UNKNOWN' ? 10050 : 12550,
+        refundUnavailableReason: null,
+        outcome,
+      });
+      renderPage();
+
+      if (outcome === 'SUCCEEDED') {
+        fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
+        expect(
+          screen.getByRole('heading', { name: 'Record completed manual refund' })
+        ).toBeInTheDocument();
+      }
+      fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+
+      expect(await screen.findByText(expectedMessage)).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Reconcile Stripe refund' })).toBeInTheDocument();
+      expect(
+        screen.getByText(/Retry inspects Stripe before deciding whether the stored request/)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', { name: 'Record completed manual refund' })
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/Manual mode records a refund/)).not.toBeInTheDocument();
+    }
+  );
+
+  it('should render a direct Stripe retry error without manual recording context', async () => {
+    const pendingRefund = {
+      id: 'pending-refund',
+      amountCents: 2500,
+      currency: 'USD',
+      executionMode: 'STRIPE' as const,
+      status: 'PENDING' as const,
+      reason: null,
+      externalReference: null,
+      resultingRegistrationStatus: null,
+      createdAt: '2026-07-14T01:00:00.000Z',
+      updatedAt: '2026-07-14T01:00:00.000Z',
+    };
+    mockGetPayments.mockResolvedValue({
+      payments: [
+        {
+          ...payment,
+          provider: 'STRIPE',
+          stripeRefundEligible: true,
+          refunds: [pendingRefund],
+          pendingRefundCents: 2500,
+          availableRefundCents: 10050,
+        },
+      ],
+      total: 1,
+    });
+    mockRetryStripeRefund.mockRejectedValue(new Error('Retry unavailable'));
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Retry unavailable');
+    expect(screen.getByRole('heading', { name: 'Reconcile Stripe refund' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Record completed manual refund' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Manual mode records a refund/)).not.toBeInTheDocument();
+  });
+
   it('should show a definite Stripe failure and released reservation', async () => {
     const failedRefund = {
       id: 'failed-refund',

--- a/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
@@ -12,25 +12,23 @@ vi.mock('../../lib/api/admin-registrations', () => ({
 }));
 
 vi.mock('../../lib/api/admin-payments', async () => {
-  const actual = await vi.importActual<
-    typeof import('../../lib/api/admin-payments')
-  >('../../lib/api/admin-payments');
+  const actual = await vi.importActual<typeof import('../../lib/api/admin-payments')>(
+    '../../lib/api/admin-payments'
+  );
   return {
     ...actual,
     adminPaymentsApi: {
       getPayments: vi.fn(),
       recordExternalPayment: vi.fn(),
+      createManualRefund: vi.fn(),
     },
   };
 });
 
-const mockGetRegistrations = vi.mocked(
-  adminRegistrationsApi.getRegistrations,
-);
+const mockGetRegistrations = vi.mocked(adminRegistrationsApi.getRegistrations);
 const mockGetPayments = vi.mocked(adminPaymentsApi.getPayments);
-const mockRecordExternalPayment = vi.mocked(
-  adminPaymentsApi.recordExternalPayment,
-);
+const mockRecordExternalPayment = vi.mocked(adminPaymentsApi.recordExternalPayment);
+const mockCreateManualRefund = vi.mocked(adminPaymentsApi.createManualRefund);
 
 const registration = {
   id: '6adf7e80-3035-4d12-a2d4-45c591bb2441',
@@ -67,13 +65,18 @@ const payment = {
     year: registration.year,
     status: 'CONFIRMED',
   },
+  refunds: [],
+  paymentAmountCents: 12550,
+  successfulRefundCents: 0,
+  pendingRefundCents: 0,
+  availableRefundCents: 12550,
 };
 
 function renderPage(): void {
   render(
     <MemoryRouter>
       <AdminPaymentsPage />
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
@@ -81,9 +84,7 @@ async function searchAndSelectRegistration(): Promise<void> {
   fireEvent.change(screen.getByLabelText('Registration name'), {
     target: { value: 'Pat' },
   });
-  fireEvent.click(
-    screen.getByRole('button', { name: 'Search registrations' }),
-  );
+  fireEvent.click(screen.getByRole('button', { name: 'Search registrations' }));
   await screen.findByText('pat@example.com');
   fireEvent.click(screen.getByLabelText('Select Pat Participant'));
 }
@@ -108,16 +109,12 @@ describe('AdminPaymentsPage', () => {
     renderPage();
 
     expect(mockGetRegistrations).not.toHaveBeenCalled();
-    expect(
-      screen.getByRole('button', { name: 'Search registrations' }),
-    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Search registrations' })).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText('Registration name'), {
       target: { value: 'Pat' },
     });
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Search registrations' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Search registrations' }));
 
     await waitFor(() => {
       expect(mockGetRegistrations).toHaveBeenCalledWith({
@@ -133,7 +130,7 @@ describe('AdminPaymentsPage', () => {
 
     expect(screen.getByText(/The registration will become CONFIRMED/)).toBeInTheDocument();
     expect(
-      screen.getByText(/does not charge Stripe, PayPal, or any other processor/),
+      screen.getByText(/does not charge Stripe, PayPal, or any other processor/)
     ).toBeInTheDocument();
   });
 
@@ -157,26 +154,178 @@ describe('AdminPaymentsPage', () => {
       target: { value: 'check-123' },
     });
     fireEvent.click(screen.getByLabelText('Confirm external payment'));
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Record external payment' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Record external payment' }));
 
     expect(await screen.findByText('Temporary request failure')).toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Record external payment' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Record external payment' }));
 
     await screen.findByText('External payment recorded');
     expect(mockRecordExternalPayment).toHaveBeenCalledTimes(2);
     const firstRequest = mockRecordExternalPayment.mock.calls[0]?.[0];
     const secondRequest = mockRecordExternalPayment.mock.calls[1]?.[0];
-    expect(firstRequest?.idempotencyKey).toBe(
-      '43ea4b84-1f0d-413d-bc1c-9c91b435d66d',
-    );
+    expect(firstRequest?.idempotencyKey).toBe('43ea4b84-1f0d-413d-bc1c-9c91b435d66d');
     expect(secondRequest?.idempotencyKey).toBe(firstRequest?.idempotencyKey);
     expect(secondRequest).not.toHaveProperty('userId');
     expect(mockGetPayments).toHaveBeenLastCalledWith(0, 25);
     expect(screen.getByText(/payment-id: USD 125.50/)).toBeInTheDocument();
   });
+
+  it('should convert a two-decimal partial amount once, retain idempotency on failure, and refresh after success', async () => {
+    const refundedPayment = {
+      ...payment,
+      status: 'PARTIALLY_REFUNDED',
+      refunds: [
+        {
+          id: 'refund-id',
+          amountCents: 5050,
+          currency: 'USD',
+          executionMode: 'MANUAL' as const,
+          status: 'SUCCEEDED' as const,
+          reason: 'duplicate charge',
+          externalReference: 'refund-123',
+          resultingRegistrationStatus: 'WAITLISTED' as const,
+          createdAt: '2026-07-14T01:00:00.000Z',
+          updatedAt: '2026-07-14T01:00:00.000Z',
+        },
+      ],
+      successfulRefundCents: 5050,
+      availableRefundCents: 7500,
+    };
+    const refundResult = {
+      payment: refundedPayment,
+      refund: refundedPayment.refunds[0],
+      paymentAmountCents: 12550,
+      successfulRefundCents: 5050,
+      pendingRefundCents: 0,
+      availableRefundCents: 7500,
+    };
+    mockGetPayments
+      .mockResolvedValueOnce({ payments: [payment], total: 1 })
+      .mockResolvedValue({ payments: [refundedPayment], total: 1 });
+    mockCreateManualRefund
+      .mockRejectedValueOnce(new Error('Temporary refund failure'))
+      .mockResolvedValueOnce(refundResult);
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
+    expect(
+      screen.getByText(/does not contact Stripe, PayPal, or another processor/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/A full refund does not cancel the registration/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Partial refund amount'), {
+      target: { value: '50.50' },
+    });
+    fireEvent.change(screen.getByLabelText('Manual refund reason'), {
+      target: { value: 'duplicate charge' },
+    });
+    fireEvent.change(screen.getByLabelText('Manual refund reference'), {
+      target: { value: 'refund-123' },
+    });
+    fireEvent.change(screen.getByLabelText('Refund registration status'), {
+      target: { value: 'WAITLISTED' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
+
+    expect(await screen.findByText('Temporary refund failure')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
+
+    expect(await screen.findByText('Manual refund recorded: USD 50.50.')).toBeInTheDocument();
+    expect(mockCreateManualRefund).toHaveBeenCalledTimes(2);
+    const firstRequest = mockCreateManualRefund.mock.calls[0]?.[1];
+    const secondRequest = mockCreateManualRefund.mock.calls[1]?.[1];
+    expect(firstRequest).toEqual(
+      expect.objectContaining({
+        amountCents: 5050,
+        executionMode: 'MANUAL',
+        reason: 'duplicate charge',
+        externalReference: 'refund-123',
+        resultingRegistrationStatus: 'WAITLISTED',
+      })
+    );
+    expect(firstRequest).not.toHaveProperty('currency');
+    expect(secondRequest?.idempotencyKey).toBe(firstRequest?.idempotencyKey);
+    expect(mockGetPayments).toHaveBeenLastCalledWith(0, 25);
+  });
+
+  it('should use the full available shortcut and hide actions for ledgerless refunded payments', async () => {
+    const legacyRefundedPayment = {
+      ...payment,
+      id: 'legacy-refunded',
+      status: 'REFUNDED',
+      refunds: [],
+      successfulRefundCents: 12550,
+      availableRefundCents: 0,
+    };
+    const fullyRefundedPayment = {
+      ...payment,
+      status: 'REFUNDED',
+      successfulRefundCents: 12550,
+      availableRefundCents: 0,
+    };
+    mockGetPayments
+      .mockResolvedValueOnce({
+        payments: [payment, legacyRefundedPayment],
+        total: 2,
+      })
+      .mockResolvedValue({
+        payments: [fullyRefundedPayment, legacyRefundedPayment],
+        total: 2,
+      });
+    mockCreateManualRefund.mockResolvedValue({
+      payment: fullyRefundedPayment,
+      refund: {
+        id: 'full-refund',
+        amountCents: 12550,
+        currency: 'USD',
+        executionMode: 'MANUAL',
+        status: 'SUCCEEDED',
+        reason: null,
+        externalReference: null,
+        resultingRegistrationStatus: null,
+        createdAt: '2026-07-14T01:00:00.000Z',
+        updatedAt: '2026-07-14T01:00:00.000Z',
+      },
+      paymentAmountCents: 12550,
+      successfulRefundCents: 12550,
+      pendingRefundCents: 0,
+      availableRefundCents: 0,
+    });
+    renderPage();
+
+    expect(await screen.findAllByText('No ledger history')).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Refund' })).toHaveLength(1);
+    expect(screen.getAllByText('Unavailable')).toHaveLength(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Refund' }));
+    fireEvent.click(screen.getByLabelText('Full available refund'));
+    fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
+
+    await screen.findByText('Manual refund recorded: USD 125.50.');
+    expect(mockCreateManualRefund).toHaveBeenCalledWith(
+      'payment-id',
+      expect.objectContaining({
+        fullRefund: true,
+        executionMode: 'MANUAL',
+      })
+    );
+    expect(mockCreateManualRefund.mock.calls[0]?.[1]).not.toHaveProperty('amountCents');
+  });
+
+  it.each(['1.001', '125.51'])(
+    'should reject invalid or excessive partial amount %s before submission',
+    async inputAmount => {
+      mockGetPayments.mockResolvedValue({ payments: [payment], total: 1 });
+      renderPage();
+      fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
+      fireEvent.change(screen.getByLabelText('Partial refund amount'), {
+        target: { value: inputAmount },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
+
+      expect(
+        await screen.findByText(/Enter a positive amount with at most two decimals/)
+      ).toBeInTheDocument();
+      expect(mockCreateManualRefund).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
@@ -20,7 +20,8 @@ vi.mock('../../lib/api/admin-payments', async () => {
     adminPaymentsApi: {
       getPayments: vi.fn(),
       recordExternalPayment: vi.fn(),
-      createManualRefund: vi.fn(),
+      createRefund: vi.fn(),
+      retryStripeRefund: vi.fn(),
     },
   };
 });
@@ -28,7 +29,8 @@ vi.mock('../../lib/api/admin-payments', async () => {
 const mockGetRegistrations = vi.mocked(adminRegistrationsApi.getRegistrations);
 const mockGetPayments = vi.mocked(adminPaymentsApi.getPayments);
 const mockRecordExternalPayment = vi.mocked(adminPaymentsApi.recordExternalPayment);
-const mockCreateManualRefund = vi.mocked(adminPaymentsApi.createManualRefund);
+const mockCreateRefund = vi.mocked(adminPaymentsApi.createRefund);
+const mockRetryStripeRefund = vi.mocked(adminPaymentsApi.retryStripeRefund);
 
 const registration = {
   id: '6adf7e80-3035-4d12-a2d4-45c591bb2441',
@@ -71,6 +73,7 @@ const payment = {
   pendingRefundCents: 0,
   availableRefundCents: 12550,
   refundUnavailableReason: null,
+  stripeRefundEligible: false,
 };
 
 function renderPage(): void {
@@ -213,7 +216,10 @@ describe('AdminPaymentsPage', () => {
         status: 409,
       },
     });
-    mockCreateManualRefund.mockRejectedValueOnce(axiosError).mockResolvedValueOnce(refundResult);
+    mockCreateRefund.mockRejectedValueOnce(axiosError).mockResolvedValueOnce({
+      ...refundResult,
+      outcome: 'SUCCEEDED',
+    });
     renderPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
@@ -242,9 +248,9 @@ describe('AdminPaymentsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
 
     expect(await screen.findByText('Manual refund recorded: USD 50.50.')).toBeInTheDocument();
-    expect(mockCreateManualRefund).toHaveBeenCalledTimes(2);
-    const firstRequest = mockCreateManualRefund.mock.calls[0]?.[1];
-    const secondRequest = mockCreateManualRefund.mock.calls[1]?.[1];
+    expect(mockCreateRefund).toHaveBeenCalledTimes(2);
+    const firstRequest = mockCreateRefund.mock.calls[0]?.[1];
+    const secondRequest = mockCreateRefund.mock.calls[1]?.[1];
     expect(firstRequest).toEqual(
       expect.objectContaining({
         amountCents: 5050,
@@ -283,7 +289,7 @@ describe('AdminPaymentsPage', () => {
         payments: [fullyRefundedPayment, legacyRefundedPayment],
         total: 2,
       });
-    mockCreateManualRefund.mockResolvedValue({
+    mockCreateRefund.mockResolvedValue({
       payment: fullyRefundedPayment,
       refund: {
         id: 'full-refund',
@@ -302,6 +308,7 @@ describe('AdminPaymentsPage', () => {
       pendingRefundCents: 0,
       availableRefundCents: 0,
       refundUnavailableReason: null,
+      outcome: 'SUCCEEDED',
     });
     renderPage();
 
@@ -313,14 +320,14 @@ describe('AdminPaymentsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
 
     await screen.findByText('Manual refund recorded: USD 125.50.');
-    expect(mockCreateManualRefund).toHaveBeenCalledWith(
+    expect(mockCreateRefund).toHaveBeenCalledWith(
       'payment-id',
       expect.objectContaining({
         fullRefund: true,
         executionMode: 'MANUAL',
       })
     );
-    expect(mockCreateManualRefund.mock.calls[0]?.[1]).not.toHaveProperty('amountCents');
+    expect(mockCreateRefund.mock.calls[0]?.[1]).not.toHaveProperty('amountCents');
   });
 
   it('should show a legacy precision reason without rounding or offering a refund action', async () => {
@@ -382,7 +389,7 @@ describe('AdminPaymentsPage', () => {
       },
     });
     mockGetPayments.mockResolvedValue({ payments: [payment], total: 1 });
-    mockCreateManualRefund.mockRejectedValue(axiosError);
+    mockCreateRefund.mockRejectedValue(axiosError);
     renderPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
@@ -409,7 +416,158 @@ describe('AdminPaymentsPage', () => {
       expect(
         await screen.findByText(/Enter a positive amount with at most two decimals/)
       ).toBeInTheDocument();
-      expect(mockCreateManualRefund).not.toHaveBeenCalled();
+      expect(mockCreateRefund).not.toHaveBeenCalled();
     }
   );
+
+  it('should offer Stripe mode only for an eligible Stripe payment with distinct copy', async () => {
+    const stripePayment = {
+      ...payment,
+      provider: 'STRIPE',
+      externalMethod: null,
+      externalReference: null,
+      stripeRefundEligible: true,
+    };
+    mockGetPayments.mockResolvedValue({ payments: [stripePayment], total: 1 });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
+    expect(screen.getByLabelText('Initiate Stripe refund')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Initiate Stripe refund'));
+
+    expect(screen.getByText(/Stripe mode initiates a processor refund/)).toBeInTheDocument();
+    expect(screen.queryByLabelText('Manual refund reference')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Initiate Stripe refund' })).toBeInTheDocument();
+    expect(screen.getByText(/A full refund does not cancel the registration/)).toBeInTheDocument();
+  });
+
+  it('should keep an ambiguous Stripe refund reserved and retry it from history', async () => {
+    const pendingRefund = {
+      id: 'pending-refund',
+      amountCents: 2500,
+      currency: 'USD',
+      executionMode: 'STRIPE' as const,
+      status: 'PENDING' as const,
+      reason: 'customer request',
+      externalReference: null,
+      resultingRegistrationStatus: null,
+      createdAt: '2026-07-14T01:00:00.000Z',
+      updatedAt: '2026-07-14T01:00:00.000Z',
+    };
+    const stripePayment = {
+      ...payment,
+      provider: 'STRIPE',
+      externalMethod: null,
+      externalReference: null,
+      stripeRefundEligible: true,
+    };
+    const pendingPayment = {
+      ...stripePayment,
+      refunds: [pendingRefund],
+      pendingRefundCents: 2500,
+      availableRefundCents: 10050,
+    };
+    const succeededPayment = {
+      ...pendingPayment,
+      status: 'PARTIALLY_REFUNDED',
+      refunds: [{ ...pendingRefund, status: 'SUCCEEDED' as const }],
+      successfulRefundCents: 2500,
+      pendingRefundCents: 0,
+    };
+    mockGetPayments
+      .mockResolvedValueOnce({ payments: [stripePayment], total: 1 })
+      .mockResolvedValueOnce({ payments: [pendingPayment], total: 1 })
+      .mockResolvedValue({ payments: [succeededPayment], total: 1 });
+    mockCreateRefund.mockResolvedValue({
+      payment: pendingPayment,
+      refund: pendingRefund,
+      paymentAmountCents: 12550,
+      successfulRefundCents: 0,
+      pendingRefundCents: 2500,
+      availableRefundCents: 10050,
+      refundUnavailableReason: null,
+      outcome: 'PENDING_UNKNOWN',
+    });
+    mockRetryStripeRefund.mockResolvedValue({
+      payment: succeededPayment,
+      refund: succeededPayment.refunds[0],
+      paymentAmountCents: 12550,
+      successfulRefundCents: 2500,
+      pendingRefundCents: 0,
+      availableRefundCents: 10050,
+      refundUnavailableReason: null,
+      outcome: 'SUCCEEDED',
+    });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
+    fireEvent.click(screen.getByLabelText('Initiate Stripe refund'));
+    fireEvent.change(screen.getByLabelText('Partial refund amount'), {
+      target: { value: '25.00' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Initiate Stripe refund' }));
+
+    expect(await screen.findByText(/Stripe outcome is pending or unknown/)).toBeInTheDocument();
+    expect(mockCreateRefund.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        amountCents: 2500,
+        executionMode: 'STRIPE',
+      })
+    );
+    expect(mockCreateRefund.mock.calls[0]?.[1]).not.toHaveProperty('externalReference');
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+
+    await screen.findByText('Stripe refund reconciliation succeeded.');
+    expect(mockRetryStripeRefund).toHaveBeenCalledWith('payment-id', 'pending-refund');
+    expect(mockGetPayments).toHaveBeenLastCalledWith(0, 25);
+  });
+
+  it('should show a definite Stripe failure and released reservation', async () => {
+    const failedRefund = {
+      id: 'failed-refund',
+      amountCents: 2500,
+      currency: 'USD',
+      executionMode: 'STRIPE' as const,
+      status: 'FAILED' as const,
+      reason: null,
+      externalReference: null,
+      resultingRegistrationStatus: null,
+      createdAt: '2026-07-14T01:00:00.000Z',
+      updatedAt: '2026-07-14T01:00:00.000Z',
+    };
+    const stripePayment = {
+      ...payment,
+      provider: 'STRIPE',
+      stripeRefundEligible: true,
+    };
+    const failedPayment = {
+      ...stripePayment,
+      refunds: [failedRefund],
+    };
+    mockGetPayments
+      .mockResolvedValueOnce({ payments: [stripePayment], total: 1 })
+      .mockResolvedValue({ payments: [failedPayment], total: 1 });
+    mockCreateRefund.mockResolvedValue({
+      payment: failedPayment,
+      refund: failedRefund,
+      paymentAmountCents: 12550,
+      successfulRefundCents: 0,
+      pendingRefundCents: 0,
+      availableRefundCents: 12550,
+      refundUnavailableReason: null,
+      outcome: 'FAILED',
+    });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
+    fireEvent.click(screen.getByLabelText('Initiate Stripe refund'));
+    fireEvent.change(screen.getByLabelText('Partial refund amount'), {
+      target: { value: '25.00' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Initiate Stripe refund' }));
+
+    expect(await screen.findByText(/Stripe rejected the refund/)).toBeInTheDocument();
+    expect(await screen.findByText(/USD 25.00 FAILED \/ STRIPE/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AdminPaymentsPage from '../AdminPaymentsPage';
@@ -6,6 +6,7 @@ import { adminRegistrationsApi, type Registration } from '../../lib/api/admin-re
 import {
   adminPaymentsApi,
   type ExternalPaymentSearchRegistration,
+  type RefundCommandResult,
 } from '../../lib/api/admin-payments';
 
 void adminRegistrationsApi.getRegistrations<Registration>;
@@ -512,6 +513,65 @@ describe('AdminPaymentsPage', () => {
     expect(screen.getByText(/A full refund does not cancel the registration/)).toBeInTheDocument();
   });
 
+  it('should use Stripe form context after switching from manual feedback', async () => {
+    const stripePayment = {
+      ...payment,
+      provider: 'STRIPE',
+      externalMethod: null,
+      externalReference: null,
+      stripeRefundEligible: true,
+    };
+    mockGetPayments.mockResolvedValue({ payments: [stripePayment], total: 1 });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
+    fireEvent.change(screen.getByLabelText('Partial refund amount'), {
+      target: { value: '1.001' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
+    await screen.findByText(/Enter a positive amount with at most two decimals/);
+    fireEvent.click(screen.getByLabelText('Initiate Stripe refund'));
+
+    expect(screen.getByRole('heading', { name: 'Initiate Stripe refund' })).toBeInTheDocument();
+    expect(screen.getByText(/Stripe mode initiates a processor refund/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Initiate Stripe refund' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Record completed manual refund' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Manual mode records a refund/)).not.toBeInTheDocument();
+  });
+
+  it('should use manual form context after switching from Stripe feedback', async () => {
+    const stripePayment = {
+      ...payment,
+      provider: 'STRIPE',
+      externalMethod: null,
+      externalReference: null,
+      stripeRefundEligible: true,
+    };
+    mockGetPayments.mockResolvedValue({ payments: [stripePayment], total: 1 });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
+    fireEvent.click(screen.getByLabelText('Initiate Stripe refund'));
+    fireEvent.change(screen.getByLabelText('Partial refund amount'), {
+      target: { value: '1.001' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Initiate Stripe refund' }));
+    await screen.findByText(/Enter a positive amount with at most two decimals/);
+    fireEvent.click(screen.getByLabelText('Record completed external refund'));
+
+    expect(
+      screen.getByRole('heading', { name: 'Record completed manual refund' })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Manual mode records a refund/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Record manual refund' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Initiate Stripe refund' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Stripe mode initiates a processor refund/)).not.toBeInTheDocument();
+  });
+
   it('should keep an ambiguous Stripe refund reserved and retry it from history', async () => {
     const pendingRefund = {
       id: 'pending-refund',
@@ -664,6 +724,76 @@ describe('AdminPaymentsPage', () => {
       expect(screen.queryByText(/Manual mode records a refund/)).not.toBeInTheDocument();
     }
   );
+
+  it('should keep create form context when an in-flight Retry finishes', async () => {
+    const pendingRefund = {
+      id: 'pending-refund',
+      amountCents: 2500,
+      currency: 'USD',
+      executionMode: 'STRIPE' as const,
+      status: 'PENDING' as const,
+      reason: null,
+      externalReference: null,
+      resultingRegistrationStatus: null,
+      createdAt: '2026-07-14T01:00:00.000Z',
+      updatedAt: '2026-07-14T01:00:00.000Z',
+    };
+    const pendingPayment = {
+      ...payment,
+      provider: 'STRIPE',
+      stripeRefundEligible: true,
+      refunds: [pendingRefund],
+      pendingRefundCents: 2500,
+      availableRefundCents: 10050,
+    };
+    const succeededRefund = { ...pendingRefund, status: 'SUCCEEDED' as const };
+    const succeededPayment = {
+      ...pendingPayment,
+      status: 'PARTIALLY_REFUNDED',
+      refunds: [succeededRefund],
+      successfulRefundCents: 2500,
+      pendingRefundCents: 0,
+    };
+    const retryResult: RefundCommandResult = {
+      payment: succeededPayment,
+      refund: succeededRefund,
+      paymentAmountCents: 12550,
+      successfulRefundCents: 2500,
+      pendingRefundCents: 0,
+      availableRefundCents: 10050,
+      refundUnavailableReason: null,
+      outcome: 'SUCCEEDED',
+    };
+    let resolveRetry!: (result: RefundCommandResult) => void;
+    mockGetPayments.mockResolvedValue({ payments: [pendingPayment], total: 1 });
+    mockRetryStripeRefund.mockImplementation(
+      () =>
+        new Promise<RefundCommandResult>(resolve => {
+          resolveRetry = resolve;
+        })
+    );
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+    await waitFor(() => expect(mockRetryStripeRefund).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: 'Refund' }));
+    expect(
+      screen.getByRole('heading', { name: 'Record completed manual refund' })
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      resolveRetry(retryResult);
+    });
+
+    expect(await screen.findByText('Stripe refund reconciliation succeeded.')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Record completed manual refund' })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Manual mode records a refund/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Reconcile Stripe refund' })
+    ).not.toBeInTheDocument();
+  });
 
   it('should render a direct Stripe retry error without manual recording context', async () => {
     const pendingRefund = {

--- a/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AdminPaymentsPage.test.tsx
@@ -443,6 +443,29 @@ describe('AdminPaymentsPage', () => {
     expect(screen.queryByText('Internal database connection details')).not.toBeInTheDocument();
   });
 
+  it('should show actionable refund validation arrays for a 400 response', async () => {
+    mockGetPayments.mockResolvedValue({ payments: [payment], total: 1 });
+    mockCreateManualRefund.mockRejectedValue(
+      createAxiosError(400, [
+        'amountCents must be within the supported range',
+        'reason must not exceed 500 characters',
+      ])
+    );
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refund' }));
+    fireEvent.change(screen.getByLabelText('Partial refund amount'), {
+      target: { value: '1.00' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Record manual refund' }));
+
+    expect(
+      await screen.findByText(
+        'amountCents must be within the supported range; reason must not exceed 500 characters'
+      )
+    ).toBeInTheDocument();
+  });
+
   it.each(['1.001', '125.51'])(
     'should reject invalid or excessive partial amount %s before submission',
     async inputAmount => {


### PR DESCRIPTION
## Stack

Layer 4 of #71, stacked directly on draft PR #210 (`chrisromp-chrisromp-issue-71-manual-refund`), which follows External Payment #209 and Foundation #208. This PR contains only the Stripe Refund vertical slice. No fifth integration PR is planned.

## Summary

- Extends the existing nested ADMIN-only refund command with `executionMode: STRIPE` while preserving the Layer 3 MANUAL path.
- Reserves refundable balance in a short Serializable transaction by creating one PENDING Stripe refund and its audit-attempt row atomically.
- Submits integer cents to Stripe outside every database transaction using the durable local idempotency key and local refund ID metadata.
- Finalizes definite success on the same ledger row, recomputes payment status, and records the result audit; definite rejection marks the reservation FAILED with a bounded sanitized message; ambiguous transport or local-finalization outcomes remain PENDING and recoverable.
- Reconciles through the sole ADMIN-only `POST /payments/:paymentId/refunds/:refundId/retry` route. Retry exhaustively paginates Stripe refunds metadata-first before any resubmission and reuses the exact stored request and idempotency key.
- Re-reads registration state during successful finalization, preserves concurrent CANCELLED/application states with an audited skip reason, and conditionally guards ordinary status transitions so conflicts remain locally recoverable without another processor refund.
- Extends the existing admin payments page with eligible-only Stripe mode, distinct manual/processor copy, visible pending and failed ledger results, and Retry with refresh.

## Transaction and recovery guarantees

- Stripe network calls never run inside Prisma transactions.
- PENDING reservations remain included in available-balance calculations.
- Partial Stripe inspection never produces NOT_FOUND or a resubmission.
- Processor success followed by local conflict/failure keeps the same local refund recoverable; no replacement refund is created or submitted.
- Provider IDs, idempotency keys, failure details, and audit internals are not exposed through admin responses.

## Validation

- API focused Jest: 5 suites, 191 tests passed.
- Web focused Vitest: 2 files, 17 tests passed.
- Exact 13-file ESLint passed with zero warnings.
- API and web production builds passed.
- `git diff --check` passed; manifests and lockfile are unchanged.
- Coordinator final correctness review: clean.
- Coordinator rubber-duck review: clean.

## Scope

Approved Layer 4 delta: 13 files. Cumulative unique stack scope: 35 files.

Explicit non-goals: PayPal automated refunds; participant response/dashboard changes; reports, CSV, charts, notifications, cancellation changes, registration search, checkout/webhook/payment-update redesign, schema or dependency changes, workers/schedulers, generalized reconciliation, additional retry endpoints, or unrelated refactors.
