### PR TITLE
Add job deactivation controls

### DIFF
--- a/apps/api/prisma/migrations/20260716053000_add_job_active/migration.sql
+++ b/apps/api/prisma/migrations/20260716053000_add_job_active/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "jobs"
+ADD COLUMN "active" BOOLEAN NOT NULL DEFAULT true;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -173,6 +173,7 @@ model Job {
   categoryId       String
   shiftId          String
   maxRegistrations Int
+  active           Boolean           @default(true)
   alwaysRequired   Boolean           @default(false)
   staffOnly        Boolean           @default(false)
   category         JobCategory       @relation(fields: [categoryId], references: [id])

--- a/apps/api/src/jobs/dto/create-job.dto.ts
+++ b/apps/api/src/jobs/dto/create-job.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsUUID, IsInt, IsOptional } from 'class-validator';
+import { IsBoolean, IsString, IsNotEmpty, IsUUID, IsInt, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateJobDto {
@@ -42,4 +42,13 @@ export class CreateJobDto {
   @IsInt()
   @IsOptional()
   maxRegistrations?: number;
-} 
+
+  @ApiProperty({
+    description: 'Whether the job is available for new registrations',
+    default: true,
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  active?: boolean;
+}

--- a/apps/api/src/jobs/jobs.controller.spec.ts
+++ b/apps/api/src/jobs/jobs.controller.spec.ts
@@ -188,7 +188,18 @@ describe('JobsController', () => {
       const result = await controller.findAll(mockReq);
 
       expect(result).toEqual(expectedJobs);
-      expect(mockJobsService.findAll).toHaveBeenCalledWith(UserRole.ADMIN);
+      expect(mockJobsService.findAll).toHaveBeenCalledWith(UserRole.ADMIN, false);
+    });
+
+    it('should pass the inactive inclusion request to the service', async () => {
+      mockJobsService.findAll.mockResolvedValue([]);
+      const mockReq = {
+        user: { id: 'user-id', role: UserRole.ADMIN },
+      } as unknown as Parameters<typeof controller.findAll>[0];
+
+      await controller.findAll(mockReq, 'true');
+
+      expect(mockJobsService.findAll).toHaveBeenCalledWith(UserRole.ADMIN, true);
     });
   });
 

--- a/apps/api/src/jobs/jobs.controller.ts
+++ b/apps/api/src/jobs/jobs.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, Req, ForbiddenException } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, Req, ForbiddenException, Query } from '@nestjs/common';
 import { JobsService } from './jobs.service';
 import { CreateJobDto } from './dto/create-job.dto';
 import { UpdateJobDto } from './dto/update-job.dto';
@@ -6,7 +6,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { UserRole } from '@prisma/client';
-import { ApiTags, ApiBearerAuth, ApiCreatedResponse, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiQuery } from '@nestjs/swagger';
 import { RegistrationsService } from '../registrations/registrations.service';
 import { CoreConfigService } from '../core-config/services/core-config.service';
 import { Request } from 'express';
@@ -42,8 +42,15 @@ export class JobsController {
   @Get()
   @ApiOperation({ summary: 'Get all jobs' })
   @ApiOkResponse({ description: 'Returns all jobs. Staff-only jobs are excluded for participants.' })
-  findAll(@Req() req: RequestWithUser) {
-    return this.jobsService.findAll(req.user.role);
+  @ApiQuery({ name: 'includeInactive', required: false, type: Boolean })
+  findAll(
+    @Req() req: RequestWithUser,
+    @Query('includeInactive') includeInactive?: boolean | string,
+  ) {
+    return this.jobsService.findAll(
+      req.user.role,
+      includeInactive === true || includeInactive === 'true',
+    );
   }
 
   @Get(':id')

--- a/apps/api/src/jobs/jobs.service.spec.ts
+++ b/apps/api/src/jobs/jobs.service.spec.ts
@@ -2,8 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { JobsService } from './jobs.service';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { CoreConfigService } from '../core-config/services/core-config.service';
-import { NotFoundException } from '@nestjs/common';
-import { UserRole } from '@prisma/client';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma, UserRole } from '@prisma/client';
 import { CreateJobDto } from './dto/create-job.dto';
 import { UpdateJobDto } from './dto/update-job.dto';
 
@@ -20,6 +20,9 @@ describe('JobsService', () => {
       update: jest.fn(),
       delete: jest.fn(),
     },
+    registrationJob: {
+      count: jest.fn(),
+    },
   };
 
   const mockCoreConfigService = {
@@ -27,6 +30,9 @@ describe('JobsService', () => {
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+    mockPrismaService.registrationJob.count.mockResolvedValue(0);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         JobsService,
@@ -107,6 +113,7 @@ describe('JobsService', () => {
           name: createJobDto.name,
           location: createJobDto.location,
           maxRegistrations: 10,
+          active: true,
           category: {
             connect: { id: createJobDto.categoryId }
           },
@@ -209,7 +216,7 @@ describe('JobsService', () => {
 
       expect(result).toEqual(expectedJobs);
       expect(mockPrismaService.job.findMany).toHaveBeenCalledWith({
-        where: {},
+        where: { active: true },
         include: {
           category: true,
           shift: true,
@@ -246,7 +253,7 @@ describe('JobsService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].staffOnly).toBe(false);
       expect(mockPrismaService.job.findMany).toHaveBeenCalledWith({
-        where: { category: { staffOnly: false } },
+        where: { active: true, category: { staffOnly: false } },
         include: {
           category: true,
           shift: true,
@@ -312,6 +319,31 @@ describe('JobsService', () => {
       const result = await service.findAll();
 
       expect(result).toHaveLength(1);
+    });
+
+    it('should include inactive jobs only when requested by an administrator', async () => {
+      mockPrismaService.job.findMany.mockResolvedValue([]);
+
+      await service.findAll(UserRole.ADMIN, true);
+
+      expect(mockPrismaService.job.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: {} }),
+      );
+    });
+
+    it('should ignore includeInactive for participants', async () => {
+      mockPrismaService.job.findMany.mockResolvedValue([]);
+
+      await service.findAll(UserRole.PARTICIPANT, true);
+
+      expect(mockPrismaService.job.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            active: true,
+            category: { staffOnly: false },
+          },
+        }),
+      );
     });
   });
 
@@ -470,6 +502,32 @@ describe('JobsService', () => {
 
       await expect(service.update(jobId, updateJobDto)).rejects.toThrow(NotFoundException);
     });
+
+    it('should persist active false', async () => {
+      const jobId = 'test-id';
+      mockPrismaService.job.update.mockResolvedValue({
+        id: jobId,
+        name: 'Test Job',
+        location: 'Test Location',
+        categoryId: 'category-id',
+        shiftId: 'shift-id',
+        maxRegistrations: 10,
+        active: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        category: { staffOnly: false, alwaysRequired: false },
+        shift: {},
+        registrations: [],
+      });
+
+      await service.update(jobId, { active: false });
+
+      expect(mockPrismaService.job.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { active: false },
+        }),
+      );
+    });
   });
 
   describe('remove', () => {
@@ -538,9 +596,45 @@ describe('JobsService', () => {
 
     it('should throw NotFoundException if job to remove is not found', async () => {
       const jobId = 'non-existent-id';
-      mockPrismaService.job.delete.mockRejectedValue(new Error());
+      mockPrismaService.job.delete.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Job not found', {
+          code: 'P2025',
+          clientVersion: '6.19.3',
+        }),
+      );
 
       await expect(service.remove(jobId)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should reject deleting a job with historical registrations', async () => {
+      mockPrismaService.registrationJob.count.mockResolvedValue(1);
+
+      await expect(service.remove('referenced-job')).rejects.toThrow(
+        new BadRequestException(
+          'Cannot delete job with ID referenced-job because it has historical registrations. Deactivate it instead.',
+        ),
+      );
+      expect(mockPrismaService.job.delete).not.toHaveBeenCalled();
+    });
+
+    it('should translate a raced foreign key failure to the lifecycle error', async () => {
+      mockPrismaService.job.delete.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Foreign key constraint failed', {
+          code: 'P2003',
+          clientVersion: '6.19.3',
+        }),
+      );
+
+      await expect(service.remove('raced-job')).rejects.toThrow(
+        'Deactivate it instead',
+      );
+    });
+
+    it('should propagate unrelated database errors', async () => {
+      const databaseError = new Error('Database unavailable');
+      mockPrismaService.job.delete.mockRejectedValue(databaseError);
+
+      await expect(service.remove('test-id')).rejects.toBe(databaseError);
     });
   });
 

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { CoreConfigService } from '../core-config/services/core-config.service';
 import { CreateJobDto } from './dto/create-job.dto';
@@ -55,6 +55,7 @@ export class JobsService {
         name: createJobDto.name,
         location: createJobDto.location,
         maxRegistrations: createJobDto.maxRegistrations || 10, // Default to 10 if not provided
+        active: createJobDto.active ?? true,
         category: {
           connect: { id: createJobDto.categoryId }
         },
@@ -82,10 +83,12 @@ export class JobsService {
    * Participants will not see staff-only jobs.
    * @param userRole - Optional role to filter results
    */
-  async findAll(userRole?: UserRole) {
+  async findAll(userRole?: UserRole, includeInactive = false) {
     const config = await this.coreConfigService.findCurrent();
+    const canIncludeInactive = userRole === UserRole.ADMIN && includeInactive;
     const jobs = await this.prisma.job.findMany({
       where: {
+        ...(!canIncludeInactive && { active: true }),
         ...(userRole === UserRole.PARTICIPANT && { category: { staffOnly: false } }),
       },
       include: {
@@ -134,6 +137,7 @@ export class JobsService {
       if (updateJobDto.name) updateData.name = updateJobDto.name;
       if (updateJobDto.location) updateData.location = updateJobDto.location;
       if (updateJobDto.maxRegistrations) updateData.maxRegistrations = updateJobDto.maxRegistrations;
+      if (updateJobDto.active !== undefined) updateData.active = updateJobDto.active;
       
       if (updateJobDto.categoryId) {
         updateData.category = { connect: { id: updateJobDto.categoryId } };
@@ -165,8 +169,15 @@ export class JobsService {
   }
 
   async remove(id: string) {
-    const config = await this.coreConfigService.findCurrent();
+    const historicalRegistrationCount = await this.prisma.registrationJob.count({
+      where: { jobId: id },
+    });
+    if (historicalRegistrationCount > 0) {
+      throw this.createHistoricalRegistrationError(id);
+    }
+
     try {
+      const config = await this.coreConfigService.findCurrent();
       const job = await this.prisma.job.delete({
         where: { id },
         include: {
@@ -182,9 +193,26 @@ export class JobsService {
 
       // Add derived properties from category and calculate current registrations
       return this.addDerivedPropertiesWithRegistrations(job, config.registrationYear);
-    } catch {
-      throw new NotFoundException(`Job with ID ${id} not found`);
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2003') {
+          throw this.createHistoricalRegistrationError(id);
+        }
+        if (error.code === 'P2025') {
+          throw new NotFoundException(`Job with ID ${id} not found`);
+        }
+      }
+      throw error;
     }
+  }
+
+  private createHistoricalRegistrationError(id: string): BadRequestException {
+    return new BadRequestException(
+      `Cannot delete job with ID ${id} because it has historical registrations. Deactivate it instead.`,
+    );
   }
 
   /**

--- a/apps/api/src/registrations/registrations.service.spec.ts
+++ b/apps/api/src/registrations/registrations.service.spec.ts
@@ -144,11 +144,15 @@ describe('RegistrationsService', () => {
     const mockJobs = [
       {
         id: 'job-id-1',
+        name: 'Kitchen',
+        active: true,
         maxRegistrations: 10,
         registrations: [],
       },
       {
         id: 'job-id-2',
+        name: 'Gate',
+        active: true,
         maxRegistrations: 5,
         registrations: [],
       },
@@ -219,6 +223,23 @@ describe('RegistrationsService', () => {
       mockPrismaService.job.findUnique.mockResolvedValue(null);
 
       await expect(service.create(createDto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should reject an inactive job', async () => {
+      mockPrismaService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        role: UserRole.STAFF,
+      });
+      mockPrismaService.registration.findFirst.mockResolvedValue(null);
+      mockPrismaService.job.findUnique.mockResolvedValue({
+        ...mockJobs[0],
+        active: false,
+      });
+
+      await expect(
+        service.create({ ...createDto, jobIds: ['job-id-1'] }),
+      ).rejects.toThrow('Inactive job cannot be assigned: Kitchen');
+      expect(mockPrismaService.registration.create).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException if user does not exist', async () => {
@@ -406,6 +427,8 @@ describe('RegistrationsService', () => {
 
     const mockJobWithRegistrations = {
       id: 'job-id-1',
+      name: 'Kitchen',
+      active: true,
       staffOnly: false,
       maxRegistrations: 10,
       registrations: [],
@@ -481,6 +504,19 @@ describe('RegistrationsService', () => {
 
       const result = await service.addJobToRegistration('registration-id', { jobId: 'job-id-1' });
       expect(result).toBeDefined();
+    });
+
+    it('should reject adding an inactive job', async () => {
+      mockPrismaService.registration.findUnique.mockResolvedValue(mockRegistrationWithJobs);
+      mockPrismaService.job.findUnique.mockResolvedValue({
+        ...mockJobWithRegistrations,
+        active: false,
+      });
+
+      await expect(
+        service.addJobToRegistration('registration-id', { jobId: 'job-id-1' }),
+      ).rejects.toThrow('Inactive job cannot be assigned: Kitchen');
+      expect(mockPrismaService.registrationJob.create).not.toHaveBeenCalled();
     });
   });
 
@@ -966,6 +1002,8 @@ describe('RegistrationsService', () => {
       mockPrismaService.job.findMany.mockResolvedValue([]);
       mockPrismaService.job.findUnique.mockImplementation(({ where }: { where: { id: string } }) => ({
         id: where.id,
+        name: 'Kitchen',
+        active: true,
         maxRegistrations: 10,
         registrations: [],
       }));
@@ -1079,6 +1117,21 @@ describe('RegistrationsService', () => {
       );
     });
 
+    it('should reject completion with an inactive job', async () => {
+      mockPrismaService.job.findUnique.mockResolvedValue({
+        id: 'job-1',
+        name: 'Kitchen',
+        active: false,
+        maxRegistrations: 10,
+        registrations: [],
+      });
+
+      await expect(service.completeRegistration(userId, completeDto)).rejects.toThrow(
+        'Inactive job cannot be assigned: Kitchen',
+      );
+      expect(mockPrismaService.registration.updateMany).not.toHaveBeenCalled();
+    });
+
     it('should reject completion with no jobs when the user is not allowNoJob', async () => {
       const noJobsDto: CompleteRegistrationDto = {
         jobs: [],
@@ -1160,6 +1213,8 @@ describe('RegistrationsService', () => {
       mockPrismaService.registration.findFirst.mockResolvedValue(null);
       mockPrismaService.job.findUnique.mockImplementation(({ where }: { where: { id: string } }) => ({
         id: where.id,
+        name: 'Kitchen',
+        active: true,
         maxRegistrations: 10,
         staffOnly: false,
         registrations: [],
@@ -1194,6 +1249,22 @@ describe('RegistrationsService', () => {
 
       expect(mockPrismaService.registration.create).toHaveBeenCalledTimes(1);
       expect(result.jobRegistration).toEqual(created);
+    });
+
+    it('rejects an inactive job before creating the registration', async () => {
+      mockPrismaService.job.findUnique.mockResolvedValue({
+        id: 'job-1',
+        name: 'Kitchen',
+        active: false,
+        maxRegistrations: 10,
+        staffOnly: false,
+        registrations: [],
+      });
+
+      await expect(service.createCampRegistration(userId, baseDto)).rejects.toThrow(
+        'Inactive job cannot be assigned: Kitchen',
+      );
+      expect(mockPrismaService.registration.create).not.toHaveBeenCalled();
     });
 
     it('creates deferred registration as CONFIRMED + paymentDeferred=true when no chosen job is over capacity', async () => {

--- a/apps/api/src/registrations/registrations.service.ts
+++ b/apps/api/src/registrations/registrations.service.ts
@@ -10,6 +10,7 @@ import {
   UpdateRegistrationDto,
 } from './dto';
 import {
+  Job,
   NotificationType,
   Prisma,
   Registration,
@@ -109,6 +110,7 @@ export class RegistrationsService {
         if (!job) {
           throw new NotFoundException(`Job with ID ${jobId} not found`);
         }
+        this.assertJobActive(job);
 
         const currentRegistrationCount = job.registrations.filter(
           r => isCapacityReservingStatus(r.registration.status)
@@ -204,6 +206,7 @@ export class RegistrationsService {
     if (!job) {
       throw new NotFoundException(`Job with ID ${addJobDto.jobId} not found`);
     }
+    this.assertJobActive(job);
 
     // Block participants from adding staff-only jobs
     if (!registration.user) {
@@ -887,6 +890,7 @@ export class RegistrationsService {
         if (!job) {
           throw new NotFoundException(`Job with ID ${jobId} not found`);
         }
+        this.assertJobActive(job);
 
         const currentRegistrationCount = job.registrations.filter(
           (currentJobRegistration) => isCapacityReservingStatus(currentJobRegistration.registration.status)
@@ -1114,6 +1118,7 @@ export class RegistrationsService {
         if (!job) {
           throw new NotFoundException(`Job with ID ${jobId} not found`);
         }
+        this.assertJobActive(job);
         const currentRegistrationCount = job.registrations.filter(
           (r) => isCapacityReservingStatus(r.registration.status)
             && r.registration.year === currentYear,
@@ -1707,6 +1712,12 @@ export class RegistrationsService {
     });
     if (staffOnlyJobs.length > 0) {
       throw new ForbiddenException('Participants cannot register for staff-only jobs');
+    }
+  }
+
+  private assertJobActive(job: Pick<Job, 'active' | 'name'>): void {
+    if (job.active === false) {
+      throw new BadRequestException(`Inactive job cannot be assigned: ${job.name}`);
     }
   }
 }

--- a/apps/api/src/registrations/services/registration-admin.service.spec.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.spec.ts
@@ -119,6 +119,8 @@ describe('RegistrationAdminService', () => {
 
     const mockCleanupService = {
       cleanupRegistration: jest.fn(),
+      cleanupWorkShifts: jest.fn(),
+      cleanupCampingOptions: jest.fn(),
     };
 
     const mockPaymentsService = {
@@ -286,8 +288,8 @@ describe('RegistrationAdminService', () => {
       };
 
       const mockJobs = [
-        { id: 'job-1', title: 'Kitchen Duty', enabled: true },
-        { id: 'job-2', title: 'Gate Duty', enabled: true },
+        { id: 'job-1', name: 'Kitchen Duty', active: true },
+        { id: 'job-2', name: 'Gate Duty', active: true },
       ];
 
       prismaService.$transaction.mockImplementation(async (callback) => {
@@ -310,6 +312,33 @@ describe('RegistrationAdminService', () => {
       expect(adminAuditService.createMultipleAuditRecords).toHaveBeenCalled();
 
       expect(result.message).toBe('Registration successfully updated');
+    });
+
+    it('should reject adding an inactive job while preserving existing assignments', async () => {
+      const editData: AdminEditRegistrationDto = {
+        jobIds: ['existing-job', 'inactive-job'],
+        notes: 'Test inactive assignment',
+      };
+      const registrationWithInactiveJob = {
+        ...mockRegistration,
+        jobs: [{ jobId: 'existing-job', job: { id: 'existing-job', active: false } }],
+      };
+
+      prismaService.$transaction.mockImplementation(async (callback) => callback(prismaService));
+      (prismaService.registration.findUnique as jest.Mock).mockResolvedValue(
+        registrationWithInactiveJob,
+      );
+      (prismaService.job.findUnique as jest.Mock).mockResolvedValue({
+        id: 'inactive-job',
+        name: 'Retired Job',
+        active: false,
+      });
+
+      await expect(
+        service.editRegistration('reg-123', editData, 'admin-123'),
+      ).rejects.toThrow('Inactive job cannot be assigned: Retired Job');
+      expect(prismaService.registrationJob.create).not.toHaveBeenCalled();
+      expect(cleanupService.cleanupWorkShifts).not.toHaveBeenCalled();
     });
 
     // Task 5.2.5: Test editRegistration() uses Prisma transactions for atomicity

--- a/apps/api/src/registrations/services/registration-admin.service.spec.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.spec.ts
@@ -316,12 +316,15 @@ describe('RegistrationAdminService', () => {
 
     it('should reject adding an inactive job while preserving existing assignments', async () => {
       const editData: AdminEditRegistrationDto = {
-        jobIds: ['existing-job', 'inactive-job'],
+        jobIds: ['retained-job', 'inactive-job'],
         notes: 'Test inactive assignment',
       };
       const registrationWithInactiveJob = {
         ...mockRegistration,
-        jobs: [{ jobId: 'existing-job', job: { id: 'existing-job', active: false } }],
+        jobs: [
+          { jobId: 'retained-job', job: { id: 'retained-job', name: 'Retained Job' } },
+          { jobId: 'removed-job', job: { id: 'removed-job', name: 'Removed Job' } },
+        ],
       };
 
       prismaService.$transaction.mockImplementation(async (callback) => callback(prismaService));
@@ -338,7 +341,49 @@ describe('RegistrationAdminService', () => {
         service.editRegistration('reg-123', editData, 'admin-123'),
       ).rejects.toThrow('Inactive job cannot be assigned: Retired Job');
       expect(prismaService.registrationJob.create).not.toHaveBeenCalled();
+      expect(prismaService.registrationJob.deleteMany).not.toHaveBeenCalled();
       expect(cleanupService.cleanupWorkShifts).not.toHaveBeenCalled();
+    });
+
+    it('should retain unaffected jobs when removing one assignment', async () => {
+      const editData: AdminEditRegistrationDto = {
+        jobIds: ['retained-job'],
+        notes: 'Remove one assignment',
+      };
+      const registrationWithJobs = {
+        ...mockRegistration,
+        jobs: [
+          { jobId: 'retained-job', job: { id: 'retained-job', name: 'Retained Job' } },
+          { jobId: 'removed-job', job: { id: 'removed-job', name: 'Removed Job' } },
+        ],
+      };
+
+      prismaService.$transaction.mockImplementation(async (callback) => callback(prismaService));
+      (prismaService.registration.findUnique as jest.Mock).mockResolvedValue(
+        registrationWithJobs,
+      );
+      (prismaService.registrationJob.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+      adminAuditService.createMultipleAuditRecords.mockResolvedValue([mockAuditRecord]);
+
+      await service.editRegistration('reg-123', editData, 'admin-123');
+
+      expect(prismaService.registrationJob.deleteMany).toHaveBeenCalledWith({
+        where: {
+          registrationId: 'reg-123',
+          jobId: { in: ['removed-job'] },
+        },
+      });
+      expect(prismaService.registrationJob.create).not.toHaveBeenCalled();
+      expect(cleanupService.cleanupWorkShifts).not.toHaveBeenCalled();
+      expect(adminAuditService.createMultipleAuditRecords).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            actionType: AdminAuditActionType.WORK_SHIFT_REMOVE,
+            targetRecordId: 'removed-job',
+          }),
+        ]),
+        expect.any(String),
+      );
     });
 
     // Task 5.2.5: Test editRegistration() uses Prisma transactions for atomicity

--- a/apps/api/src/registrations/services/registration-admin.service.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.ts
@@ -17,6 +17,7 @@ import {
   AdminAuditTargetType, 
   PaymentStatus,
   PaymentProvider,
+  Job,
   Prisma 
 } from '@prisma/client';
 import { 
@@ -309,21 +310,10 @@ export class RegistrationAdminService {
           const currentJobIds = currentRegistration.jobs.map(rj => rj.jobId);
           const newJobIds = editData.jobIds;
 
-          // Find jobs to remove
           const jobsToRemove = currentJobIds.filter(jobId => !newJobIds.includes(jobId));
-          if (jobsToRemove.length > 0) {
-            await this.cleanupService.cleanupWorkShifts(
-              registrationId,
-              adminUserId,
-              `Work shifts modified: ${editData.notes || 'No notes provided'}`,
-              transactionId,
-            );
-          }
-
-          // Find jobs to add
-          const jobsToAdd = newJobIds.filter(jobId => !currentJobIds.includes(jobId));
-          for (const jobId of jobsToAdd) {
-            // Validate job exists
+          const jobIdsToAdd = newJobIds.filter(jobId => !currentJobIds.includes(jobId));
+          const jobsToAdd: Job[] = [];
+          for (const jobId of jobIdsToAdd) {
             const job = await prisma.job.findUnique({ where: { id: jobId } });
             if (!job) {
               throw new BadRequestException(`Job ${jobId} not found`);
@@ -331,12 +321,43 @@ export class RegistrationAdminService {
             if (job.active === false) {
               throw new BadRequestException(`Inactive job cannot be assigned: ${job.name}`);
             }
+            jobsToAdd.push(job);
+          }
 
-            // Add job to registration
+          if (jobsToRemove.length > 0) {
+            await prisma.registrationJob.deleteMany({
+              where: {
+                registrationId,
+                jobId: { in: jobsToRemove },
+              },
+            });
+
+            for (const jobId of jobsToRemove) {
+              const registrationJob = currentRegistration.jobs.find(
+                currentJob => currentJob.jobId === jobId,
+              )!;
+              auditRecords.push({
+                adminUserId,
+                actionType: AdminAuditActionType.WORK_SHIFT_REMOVE,
+                targetRecordType: AdminAuditTargetType.WORK_SHIFT,
+                targetRecordId: jobId,
+                oldValues: {
+                  registrationId,
+                  jobId,
+                  jobName: registrationJob.job.name,
+                },
+                newValues: undefined,
+                reason: `Work shifts modified: ${editData.notes || 'No notes provided'}`,
+                transactionId,
+              });
+            }
+          }
+
+          for (const job of jobsToAdd) {
             await prisma.registrationJob.create({
               data: {
                 registrationId,
-                jobId,
+                jobId: job.id,
               },
             });
 
@@ -344,15 +365,15 @@ export class RegistrationAdminService {
               adminUserId,
               actionType: AdminAuditActionType.WORK_SHIFT_ADD,
               targetRecordType: AdminAuditTargetType.WORK_SHIFT,
-              targetRecordId: jobId,
+              targetRecordId: job.id,
               oldValues: undefined,
-              newValues: { registrationId, jobId, jobName: job.name },
+              newValues: { registrationId, jobId: job.id, jobName: job.name },
               reason: `Work shift added: ${editData.notes || 'No notes provided'}`,
               transactionId,
             });
           }
 
-          if (jobsToRemove.length > 0 || jobsToAdd.length > 0) {
+          if (jobsToRemove.length > 0 || jobIdsToAdd.length > 0) {
             auditRecords.push({
               adminUserId,
               actionType: AdminAuditActionType.REGISTRATION_EDIT,

--- a/apps/api/src/registrations/services/registration-admin.service.ts
+++ b/apps/api/src/registrations/services/registration-admin.service.ts
@@ -328,6 +328,9 @@ export class RegistrationAdminService {
             if (!job) {
               throw new BadRequestException(`Job ${jobId} not found`);
             }
+            if (job.active === false) {
+              throw new BadRequestException(`Inactive job cannot be assigned: ${job.name}`);
+            }
 
             // Add job to registration
             await prisma.registrationJob.create({

--- a/apps/api/src/shifts/shifts.controller.spec.ts
+++ b/apps/api/src/shifts/shifts.controller.spec.ts
@@ -198,6 +198,20 @@ describe('ShiftsController', () => {
         expect.objectContaining({
           include: expect.objectContaining({
             jobs: expect.objectContaining({
+              where: {
+                OR: [
+                  { active: true },
+                  {
+                    registrations: {
+                      some: {
+                        registration: {
+                          year: 2026,
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
               include: expect.objectContaining({
                 registrations: expect.objectContaining({
                   where: {

--- a/apps/api/src/shifts/shifts.controller.ts
+++ b/apps/api/src/shifts/shifts.controller.ts
@@ -48,6 +48,20 @@ export class ShiftsController {
     const shifts = await this.prisma.shift.findMany({
       include: {
         jobs: {
+          where: {
+            OR: [
+              { active: true },
+              {
+                registrations: {
+                  some: {
+                    registration: {
+                      year: registrationYear,
+                    },
+                  },
+                },
+              },
+            ],
+          },
           include: {
             category: true,
             registrations: {

--- a/apps/web/src/components/admin/registrations/RegistrationEditForm.test.tsx
+++ b/apps/web/src/components/admin/registrations/RegistrationEditForm.test.tsx
@@ -257,6 +257,9 @@ describe('RegistrationEditForm', () => {
 
       fireEvent.click(existingInactiveJob);
       expect(existingInactiveJob).not.toBeChecked();
+      expect(existingInactiveJob).toBeEnabled();
+      fireEvent.click(existingInactiveJob);
+      expect(existingInactiveJob).toBeChecked();
     });
 
     it('should handle camping option changes', () => {

--- a/apps/web/src/components/admin/registrations/RegistrationEditForm.test.tsx
+++ b/apps/web/src/components/admin/registrations/RegistrationEditForm.test.tsx
@@ -27,6 +27,7 @@ describe('RegistrationEditForm', () => {
         job: {
           id: 'job-1',
           name: 'Kitchen Helper',
+          active: true,
           category: {
             name: 'Kitchen',
           },
@@ -56,6 +57,7 @@ describe('RegistrationEditForm', () => {
     {
       id: 'job-1',
       name: 'Kitchen Helper',
+      active: true,
       category: {
         name: 'Kitchen',
       },
@@ -70,6 +72,7 @@ describe('RegistrationEditForm', () => {
     {
       id: 'job-2',
       name: 'Cleanup Crew',
+      active: true,
       category: {
         name: 'Maintenance',
       },
@@ -217,6 +220,43 @@ describe('RegistrationEditForm', () => {
       fireEvent.click(kitchenJobCheckbox);
 
       expect(kitchenJobCheckbox).not.toBeChecked();
+    });
+
+    it('should allow removing an existing inactive job but prevent adding another', () => {
+      const registrationWithInactiveJob = {
+        ...mockRegistration,
+        jobs: [
+          {
+            ...mockRegistration.jobs[0],
+            job: {
+              ...mockRegistration.jobs[0].job,
+              active: false,
+            },
+          },
+        ],
+      };
+      const availableJobs = [
+        { ...mockAvailableJobs[0], active: false },
+        { ...mockAvailableJobs[1], active: false },
+      ];
+
+      render(
+        <RegistrationEditForm
+          {...defaultProps}
+          registration={registrationWithInactiveJob}
+          availableJobs={availableJobs}
+        />,
+      );
+
+      const existingInactiveJob = screen.getByLabelText(/Kitchen Helper/);
+      const unassignedInactiveJob = screen.getByLabelText(/Cleanup Crew/);
+      expect(existingInactiveJob).toBeChecked();
+      expect(existingInactiveJob).toBeEnabled();
+      expect(unassignedInactiveJob).toBeDisabled();
+      expect(screen.getAllByText('Inactive')).toHaveLength(2);
+
+      fireEvent.click(existingInactiveJob);
+      expect(existingInactiveJob).not.toBeChecked();
     });
 
     it('should handle camping option changes', () => {
@@ -431,6 +471,7 @@ describe('RegistrationEditForm', () => {
         {
           id: 'job-3',
           name: 'Simple Job',
+          active: true,
           description: 'Job without category or shift',
         },
       ];

--- a/apps/web/src/components/admin/registrations/RegistrationEditForm.tsx
+++ b/apps/web/src/components/admin/registrations/RegistrationEditForm.tsx
@@ -120,6 +120,11 @@ export function RegistrationEditForm({
 
   const [errors, setErrors] = useState<Record<string, string>>({});
 
+  const originallyAssignedJobIds = useMemo(
+    () => new Set(registration.jobs.map((j) => j.job.id)),
+    [registration.jobs],
+  );
+
   // Check if form has changes
   const hasChanges = useMemo(() => {
     const originalJobIds = registration.jobs.map(j => j.job.id).sort();
@@ -301,7 +306,8 @@ export function RegistrationEditForm({
                   <div className="p-2">
                     {availableJobs.map((job) => {
                       const isSelected = formData.jobIds.includes(job.id);
-                      const cannotAddInactiveJob = !job.active && !isSelected;
+                      const cannotAddInactiveJob =
+                        !job.active && !originallyAssignedJobIds.has(job.id);
 
                       return (
                         <label

--- a/apps/web/src/components/admin/registrations/RegistrationEditForm.tsx
+++ b/apps/web/src/components/admin/registrations/RegistrationEditForm.tsx
@@ -21,6 +21,7 @@ interface Registration {
     job: {
       id: string;
       name: string;
+      active: boolean;
       category?: {
         name: string;
       };
@@ -46,6 +47,7 @@ interface Registration {
 interface Job {
   id: string;
   name: string;
+  active: boolean;
   category?: {
     name: string;
   };
@@ -297,27 +299,45 @@ export function RegistrationEditForm({
                   <p className="p-4 text-sm text-gray-500">No jobs available</p>
                 ) : (
                   <div className="p-2">
-                    {availableJobs.map((job) => (
-                      <label key={job.id} className="flex items-start p-2 hover:bg-gray-50 rounded">
-                        <input
-                          type="checkbox"
-                          checked={formData.jobIds.includes(job.id)}
-                          onChange={() => handleJobToggle(job.id)}
-                          className="h-4 w-4 text-amber-600 focus:ring-amber-500 border-gray-300 rounded mt-1"
-                        />
-                        <div className="ml-3 flex-1">
-                          <div className="text-sm font-medium text-gray-900">{job.name}</div>
-                          {job.category && (
-                            <div className="text-xs text-gray-500">{job.category.name}</div>
-                          )}
-                          {job.shift && (
-                            <div className="text-xs text-gray-500">
-                              {job.shift.dayOfWeek} {job.shift.startTime} - {job.shift.endTime}
+                    {availableJobs.map((job) => {
+                      const isSelected = formData.jobIds.includes(job.id);
+                      const cannotAddInactiveJob = !job.active && !isSelected;
+
+                      return (
+                        <label
+                          key={job.id}
+                          className={`flex items-start rounded p-2 ${
+                            cannotAddInactiveJob ? 'cursor-not-allowed bg-gray-50 opacity-60' : 'hover:bg-gray-50'
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            disabled={cannotAddInactiveJob}
+                            onChange={() => handleJobToggle(job.id)}
+                            className="mt-1 h-4 w-4 rounded border-gray-300 text-amber-600 focus:ring-amber-500"
+                          />
+                          <div className="ml-3 flex-1">
+                            <div className="text-sm font-medium text-gray-900">
+                              {job.name}
+                              {!job.active && (
+                                <span className="ml-2 rounded bg-gray-200 px-2 py-0.5 text-xs text-gray-700">
+                                  Inactive
+                                </span>
+                              )}
                             </div>
-                          )}
-                        </div>
-                      </label>
-                    ))}
+                            {job.category && (
+                              <div className="text-xs text-gray-500">{job.category.name}</div>
+                            )}
+                            {job.shift && (
+                              <div className="text-xs text-gray-500">
+                                {job.shift.dayOfWeek} {job.shift.startTime} - {job.shift.endTime}
+                              </div>
+                            )}
+                          </div>
+                        </label>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/apps/web/src/hooks/__tests__/useJobs.test.tsx
+++ b/apps/web/src/hooks/__tests__/useJobs.test.tsx
@@ -22,6 +22,7 @@ describe('useJobs', () => {
       description: 'Test Description 1', 
       location: 'Test Location 1',
       categoryId: 'category1',
+      active: true,
       staffOnly: false,
       alwaysRequired: false,
       category: {
@@ -38,6 +39,7 @@ describe('useJobs', () => {
       description: 'Test Description 2', 
       location: 'Test Location 2',
       categoryId: 'category2',
+      active: true,
       staffOnly: true,
       alwaysRequired: false,
       category: {
@@ -67,6 +69,24 @@ describe('useJobs', () => {
 
     expect(result.current.jobs).toEqual(mockJobs);
     expect(result.current.error).toBeNull();
+    expect(jobs.getAll).toHaveBeenCalledWith(false);
+  });
+
+  it('should request inactive jobs when enabled', async () => {
+    const { rerender } = renderHook(
+      ({ includeInactive }) => useJobs(includeInactive),
+      { initialProps: { includeInactive: false } },
+    );
+
+    await waitFor(() => {
+      expect(jobs.getAll).toHaveBeenCalledWith(false);
+    });
+
+    rerender({ includeInactive: true });
+
+    await waitFor(() => {
+      expect(jobs.getAll).toHaveBeenCalledWith(true);
+    });
   });
 
   it('should create a job', async () => {
@@ -80,6 +100,7 @@ describe('useJobs', () => {
     const createdJob = { 
       ...newJob, 
       id: '3',
+      active: true,
       staffOnly: false,
       alwaysRequired: false,
       category: {
@@ -138,6 +159,32 @@ describe('useJobs', () => {
     expect(result.current.jobs[0]).toEqual(updatedJob);
   });
 
+  it('should remove a deactivated job from the default list', async () => {
+    const updatedJob = { ...mockJobs[0], active: false };
+    (jobs.update as ReturnType<typeof vi.fn>).mockResolvedValue(updatedJob);
+    const { result } = renderHook(() => useJobs());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.updateJob('1', { active: false });
+    });
+
+    expect(result.current.jobs).toEqual([mockJobs[1]]);
+  });
+
+  it('should retain a deactivated job when inactive jobs are included', async () => {
+    const updatedJob = { ...mockJobs[0], active: false };
+    (jobs.update as ReturnType<typeof vi.fn>).mockResolvedValue(updatedJob);
+    const { result } = renderHook(() => useJobs(true));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.updateJob('1', { active: false });
+    });
+
+    expect(result.current.jobs[0]).toEqual(updatedJob);
+  });
+
   it('should delete a job', async () => {
     (jobs.delete as ReturnType<typeof vi.fn>).mockResolvedValue(mockJobs[0]);
 
@@ -154,6 +201,33 @@ describe('useJobs', () => {
 
     expect(jobs.delete).toHaveBeenCalledWith('1');
     expect(result.current.jobs).toEqual([mockJobs[1]]);
+  });
+
+  it('should propagate delete errors without retaining stale hook state', async () => {
+    const deleteError = Object.assign(new Error('Request failed'), {
+      isAxiosError: true,
+      response: {
+        data: {
+          message: 'Cannot delete this job because it has historical registrations. Deactivate it instead.',
+        },
+      },
+    });
+    (jobs.delete as ReturnType<typeof vi.fn>).mockRejectedValue(deleteError);
+    const { result } = renderHook(() => useJobs());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let caughtError: unknown;
+    await act(async () => {
+      try {
+        await result.current.deleteJob('1');
+      } catch (error) {
+        caughtError = error;
+      }
+    });
+
+    expect(caughtError).toBe(deleteError);
+    expect(result.current.error).toBeNull();
+    expect(result.current.jobs).toEqual(mockJobs);
   });
 
   it('should handle errors when fetching jobs', async () => {

--- a/apps/web/src/hooks/__tests__/useJobs.test.tsx
+++ b/apps/web/src/hooks/__tests__/useJobs.test.tsx
@@ -72,6 +72,51 @@ describe('useJobs', () => {
     expect(jobs.getAll).toHaveBeenCalledWith(false);
   });
 
+  it('should ignore a stale response when includeInactive changes before the first request resolves', async () => {
+    type Resolver = (value: typeof mockJobs) => void;
+    let resolveFirst!: Resolver;
+    let resolveSecond!: Resolver;
+
+    const allJobs = [
+      ...mockJobs,
+      {
+        id: '3',
+        name: 'Inactive Job',
+        description: 'Inactive',
+        location: 'Nowhere',
+        categoryId: 'category1',
+        active: false,
+        staffOnly: false,
+        alwaysRequired: false,
+        category: {
+          id: 'category1',
+          name: 'Test Category 1',
+          description: 'Test Category Description 1',
+          staffOnly: false,
+          alwaysRequired: false,
+        },
+      },
+    ] as typeof mockJobs;
+
+    (jobs.getAll as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(new Promise<typeof mockJobs>((res) => { resolveFirst = res; }))
+      .mockReturnValueOnce(new Promise<typeof mockJobs>((res) => { resolveSecond = res; }));
+
+    const { result, rerender } = renderHook(
+      ({ includeInactive }) => useJobs(includeInactive),
+      { initialProps: { includeInactive: false } },
+    );
+
+    rerender({ includeInactive: true });
+
+    await act(async () => { resolveSecond(allJobs); });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.jobs).toEqual(allJobs);
+
+    await act(async () => { resolveFirst(mockJobs); });
+    expect(result.current.jobs).toEqual(allJobs);
+  });
+
   it('should request inactive jobs when enabled', async () => {
     const { rerender } = renderHook(
       ({ includeInactive }) => useJobs(includeInactive),

--- a/apps/web/src/hooks/__tests__/useJobs.test.tsx
+++ b/apps/web/src/hooks/__tests__/useJobs.test.tsx
@@ -185,6 +185,23 @@ describe('useJobs', () => {
     expect(result.current.jobs[0]).toEqual(updatedJob);
   });
 
+  it('should use the latest inactive visibility immediately after toggling', async () => {
+    const updatedJob = { ...mockJobs[0], active: false };
+    (jobs.update as ReturnType<typeof vi.fn>).mockResolvedValue(updatedJob);
+    const { result, rerender } = renderHook(
+      ({ includeInactive }) => useJobs(includeInactive),
+      { initialProps: { includeInactive: false } },
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    rerender({ includeInactive: true });
+    await act(async () => {
+      await result.current.updateJob('1', { active: false });
+    });
+
+    expect(result.current.jobs[0]).toEqual(updatedJob);
+  });
+
   it('should delete a job', async () => {
     (jobs.delete as ReturnType<typeof vi.fn>).mockResolvedValue(mockJobs[0]);
 

--- a/apps/web/src/hooks/useJobs.tsx
+++ b/apps/web/src/hooks/useJobs.tsx
@@ -24,17 +24,25 @@ export function useJobs(includeInactive = false): UseJobsResult {
   const [error, setError] = useState<string | null>(null);
   const includeInactiveRef = useRef(includeInactive);
   includeInactiveRef.current = includeInactive;
+  const generationRef = useRef(0);
 
   const fetchJobs = useCallback(async (shouldIncludeInactive = false) => {
+    const generation = ++generationRef.current;
     setLoading(true);
     setError(null);
     try {
       const data = await jobs.getAll(shouldIncludeInactive);
-      setJobsList(data);
+      if (generation === generationRef.current) {
+        setJobsList(data);
+      }
     } catch {
-      setError('Failed to fetch jobs');
+      if (generation === generationRef.current) {
+        setError('Failed to fetch jobs');
+      }
     } finally {
-      setLoading(false);
+      if (generation === generationRef.current) {
+        setLoading(false);
+      }
     }
   }, []);
 

--- a/apps/web/src/hooks/useJobs.tsx
+++ b/apps/web/src/hooks/useJobs.tsx
@@ -23,11 +23,11 @@ export function useJobs(includeInactive = false): UseJobsResult {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const includeInactiveRef = useRef(includeInactive);
+  includeInactiveRef.current = includeInactive;
 
   const fetchJobs = useCallback(async (shouldIncludeInactive = false) => {
     setLoading(true);
     setError(null);
-    includeInactiveRef.current = shouldIncludeInactive;
     try {
       const data = await jobs.getAll(shouldIncludeInactive);
       setJobsList(data);

--- a/apps/web/src/hooks/useJobs.tsx
+++ b/apps/web/src/hooks/useJobs.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { jobs, Job } from '../lib/api';
 
 // Type for job inputs without derived/readonly fields
@@ -12,22 +12,24 @@ interface UseJobsResult {
   jobs: Job[];
   loading: boolean;
   error: string | null;
-  fetchJobs: () => Promise<void>;
+  fetchJobs: (includeInactive?: boolean) => Promise<void>;
   createJob: (data: JobInput) => Promise<Job | null>;
   updateJob: (id: string, data: Partial<JobInput>) => Promise<Job | null>;
   deleteJob: (id: string) => Promise<boolean>;
 }
 
-export function useJobs(): UseJobsResult {
+export function useJobs(includeInactive = false): UseJobsResult {
   const [jobsList, setJobsList] = useState<Job[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const includeInactiveRef = useRef(includeInactive);
 
-  const fetchJobs = useCallback(async () => {
+  const fetchJobs = useCallback(async (shouldIncludeInactive = false) => {
     setLoading(true);
     setError(null);
+    includeInactiveRef.current = shouldIncludeInactive;
     try {
-      const data = await jobs.getAll();
+      const data = await jobs.getAll(shouldIncludeInactive);
       setJobsList(data);
     } catch {
       setError('Failed to fetch jobs');
@@ -41,7 +43,9 @@ export function useJobs(): UseJobsResult {
     setError(null);
     try {
       const created = await jobs.create(data);
-      setJobsList((prev) => [...prev, created]);
+      if (created.active || includeInactiveRef.current) {
+        setJobsList((prev) => [...prev, created]);
+      }
       return created;
     } catch {
       setError('Failed to create job');
@@ -56,7 +60,12 @@ export function useJobs(): UseJobsResult {
     setError(null);
     try {
       const updated = await jobs.update(id, data);
-      setJobsList((prev) => prev.map((job) => (job.id === id ? updated : job)));
+      setJobsList((prev) => {
+        if (!updated.active && !includeInactiveRef.current) {
+          return prev.filter((job) => job.id !== id);
+        }
+        return prev.map((job) => (job.id === id ? updated : job));
+      });
       return updated;
     } catch {
       setError('Failed to update job');
@@ -73,17 +82,16 @@ export function useJobs(): UseJobsResult {
       await jobs.delete(id);
       setJobsList((prev) => prev.filter((job) => job.id !== id));
       return true;
-    } catch {
-      setError('Failed to delete job');
-      return false;
+    } catch (caughtError) {
+      throw caughtError;
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    fetchJobs();
-  }, [fetchJobs]);
+    fetchJobs(includeInactive);
+  }, [fetchJobs, includeInactive]);
 
   return {
     jobs: jobsList,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -379,6 +379,7 @@ export interface IJob {
   id: string;
   name: string;
   location: string;
+  active: boolean;
   categoryId: string;
   category?: IJobCategory;
   shiftId: string;
@@ -422,6 +423,7 @@ export const JobSchema: z.ZodType<IJob> = z.lazy(() =>
     id: z.string(),
     name: z.string(),
     location: z.string(),
+    active: z.boolean().default(true),
     categoryId: z.string(),
     category: JobCategorySchema.optional(),
     shiftId: z.string(),
@@ -1032,8 +1034,10 @@ export const jobCategories = {
 };
 
 export const jobs = {
-  getAll: async (): Promise<Job[]> => {
-    const response = await api.get<Job[]>("/jobs");
+  getAll: async (includeInactive = false): Promise<Job[]> => {
+    const response = await api.get<Job[]>("/jobs", {
+      params: includeInactive ? { includeInactive: true } : undefined,
+    });
     return response.data.map(item => {
       // Derive staffOnly and alwaysRequired from the category
       const jobWithDerivedProps = {

--- a/apps/web/src/lib/api/admin-registrations.ts
+++ b/apps/web/src/lib/api/admin-registrations.ts
@@ -19,6 +19,7 @@ interface Registration {
     job: {
       id: string;
       name: string;
+      active: boolean;
       category?: {
         name: string;
       };
@@ -34,6 +35,7 @@ interface Registration {
 interface Job {
   id: string;
   name: string;
+  active: boolean;
   description?: string;
   category?: {
     id: string;
@@ -160,7 +162,9 @@ export const adminRegistrationsApi = {
    * Get all available jobs for registration editing
    */
   getAvailableJobs: async (): Promise<Job[]> => {
-    const response = await api.get('/jobs');
+    const response = await api.get('/jobs', {
+      params: { includeInactive: true },
+    });
     return response.data;
   },
 

--- a/apps/web/src/pages/AdminJobsPage.test.tsx
+++ b/apps/web/src/pages/AdminJobsPage.test.tsx
@@ -39,19 +39,22 @@ const mockJobs = [
     active: false,
   },
 ];
+const mockActiveJobs = mockJobs.filter((job) => job.active);
 
 describe('AdminJobsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (useJobs as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      jobs: mockJobs,
-      loading: false,
-      error: null,
-      fetchJobs: vi.fn(),
-      createJob: vi.fn(),
-      updateJob: mockUpdateJob,
-      deleteJob: mockDeleteJob,
-    });
+    (useJobs as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (includeInactive: boolean) => ({
+        jobs: includeInactive ? mockJobs : mockActiveJobs,
+        loading: false,
+        error: null,
+        fetchJobs: vi.fn(),
+        createJob: vi.fn(),
+        updateJob: mockUpdateJob,
+        deleteJob: mockDeleteJob,
+      }),
+    );
     (useJobCategories as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       categories: [
         {
@@ -77,13 +80,15 @@ describe('AdminJobsPage', () => {
     });
   });
 
-  it('requests active jobs by default and renders job statuses', async () => {
+  it('requests and renders only active jobs by default', async () => {
     render(<AdminJobsPage />, { wrapper: MemoryRouter });
 
     await waitFor(() => expect(screen.getByText('Active Job')).toBeInTheDocument());
     expect(useJobs).toHaveBeenCalledWith(false);
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('Inactive')).toBeInTheDocument();
+    const activeRow = screen.getByText('Active Job').closest('tr');
+    expect(activeRow).not.toBeNull();
+    expect(within(activeRow!).getByText('Active')).toBeInTheDocument();
+    expect(screen.queryByText('Inactive Job')).not.toBeInTheDocument();
   });
 
   it('requests inactive jobs when the visibility control is enabled', () => {
@@ -96,6 +101,7 @@ describe('AdminJobsPage', () => {
 
   it('allows an administrator to reactivate an inactive job', async () => {
     render(<AdminJobsPage />, { wrapper: MemoryRouter });
+    fireEvent.click(screen.getByLabelText('Show inactive jobs'));
     await waitFor(() => expect(screen.getByText('Inactive Job')).toBeInTheDocument());
     const inactiveRow = screen.getByText('Inactive Job').closest('tr');
     expect(inactiveRow).not.toBeNull();

--- a/apps/web/src/pages/AdminJobsPage.test.tsx
+++ b/apps/web/src/pages/AdminJobsPage.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useJobCategories } from '../hooks/useJobCategories';
+import { useJobs } from '../hooks/useJobs';
+import { useShifts } from '../hooks/useShifts';
+import AdminJobsPage from './AdminJobsPage';
+
+vi.mock('../hooks/useJobs');
+vi.mock('../hooks/useJobCategories');
+vi.mock('../hooks/useShifts');
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+const mockUpdateJob = vi.fn();
+const mockDeleteJob = vi.fn();
+const mockJobs = [
+  {
+    id: 'active-job',
+    name: 'Active Job',
+    location: 'Gate',
+    categoryId: 'category-1',
+    shiftId: 'shift-1',
+    maxRegistrations: 5,
+    active: true,
+  },
+  {
+    id: 'inactive-job',
+    name: 'Inactive Job',
+    location: 'Kitchen',
+    categoryId: 'category-1',
+    shiftId: 'shift-1',
+    maxRegistrations: 5,
+    active: false,
+  },
+];
+
+describe('AdminJobsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useJobs as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      jobs: mockJobs,
+      loading: false,
+      error: null,
+      fetchJobs: vi.fn(),
+      createJob: vi.fn(),
+      updateJob: mockUpdateJob,
+      deleteJob: mockDeleteJob,
+    });
+    (useJobCategories as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      categories: [
+        {
+          id: 'category-1',
+          name: 'Operations',
+          staffOnly: false,
+          alwaysRequired: false,
+        },
+      ],
+      loading: false,
+    });
+    (useShifts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      shifts: [
+        {
+          id: 'shift-1',
+          name: 'Morning',
+          dayOfWeek: 'MONDAY',
+          startTime: '09:00',
+          endTime: '12:00',
+        },
+      ],
+      loading: false,
+    });
+  });
+
+  it('requests active jobs by default and renders job statuses', async () => {
+    render(<AdminJobsPage />, { wrapper: MemoryRouter });
+
+    await waitFor(() => expect(screen.getByText('Active Job')).toBeInTheDocument());
+    expect(useJobs).toHaveBeenCalledWith(false);
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('requests inactive jobs when the visibility control is enabled', () => {
+    render(<AdminJobsPage />, { wrapper: MemoryRouter });
+
+    fireEvent.click(screen.getByLabelText('Show inactive jobs'));
+
+    expect(useJobs).toHaveBeenLastCalledWith(true);
+  });
+
+  it('allows an administrator to reactivate an inactive job', async () => {
+    render(<AdminJobsPage />, { wrapper: MemoryRouter });
+    await waitFor(() => expect(screen.getByText('Inactive Job')).toBeInTheDocument());
+    const inactiveRow = screen.getByText('Inactive Job').closest('tr');
+    expect(inactiveRow).not.toBeNull();
+
+    fireEvent.click(within(inactiveRow!).getByText('Edit'));
+    const activeCheckbox = screen.getByLabelText(
+      'Active and available for new registrations',
+    );
+    expect(activeCheckbox).not.toBeChecked();
+    fireEvent.click(activeCheckbox);
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(mockUpdateJob).toHaveBeenCalledWith(
+        'inactive-job',
+        expect.objectContaining({ active: true }),
+      );
+    });
+  });
+
+  it('shows the actionable deletion failure', async () => {
+    mockDeleteJob.mockRejectedValue(
+      new Error('Cannot delete this job because it has historical registrations. Deactivate it instead.'),
+    );
+    render(<AdminJobsPage />, { wrapper: MemoryRouter });
+    await waitFor(() => expect(screen.getByText('Active Job')).toBeInTheDocument());
+    const activeRow = screen.getByText('Active Job').closest('tr');
+
+    fireEvent.click(within(activeRow!).getByText('Delete'));
+
+    expect(
+      await screen.findByText(/historical registrations\. Deactivate it instead\./),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/AdminJobsPage.tsx
+++ b/apps/web/src/pages/AdminJobsPage.tsx
@@ -14,10 +14,12 @@ interface JobFormState {
   categoryId: string;
   shiftId: string;
   maxRegistrations: number;
+  active: boolean;
 }
 
 export default function AdminJobsPage() {
   const navigate = useNavigate();
+  const [showInactive, setShowInactive] = useState(false);
   const {
     jobs,
     loading: jobsLoading,
@@ -25,7 +27,7 @@ export default function AdminJobsPage() {
     updateJob,
     deleteJob,
     error: jobsError,
-  } = useJobs();
+  } = useJobs(showInactive);
 
   const {
     categories,
@@ -45,6 +47,7 @@ export default function AdminJobsPage() {
     categoryId: '',
     shiftId: '',
     maxRegistrations: 5,
+    active: true,
   });
   const [formError, setFormError] = useState<string | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
@@ -193,6 +196,7 @@ export default function AdminJobsPage() {
       categoryId: categories.length > 0 ? categories[0].id : '',
       shiftId: shifts.length > 0 ? shifts[0].id : '',
       maxRegistrations: 5,
+      active: true,
     });
     setFormError(null);
     setDeleteError(null);
@@ -208,6 +212,7 @@ export default function AdminJobsPage() {
       categoryId: job.categoryId,
       shiftId: job.shiftId,
       maxRegistrations: job.maxRegistrations,
+      active: job.active,
     });
     setFormError(null);
     setDeleteError(null);
@@ -299,6 +304,15 @@ export default function AdminJobsPage() {
                 </svg>
               </span>
             </div>
+            <label className="mr-4 flex items-center text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={showInactive}
+                onChange={(event) => setShowInactive(event.target.checked)}
+                className="mr-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              Show inactive jobs
+            </label>
             <button
               onClick={() => navigate(PATHS.ADMIN)}
               className="px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300 transition-colors"
@@ -316,7 +330,7 @@ export default function AdminJobsPage() {
         </div>
       </div>
       
-      {(jobsError) && (
+      {jobsError && !deleteError && (
         <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
           {jobsError}
         </div>
@@ -389,27 +403,41 @@ export default function AdminJobsPage() {
                     )}
                   </div>
                 </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Status
+                </th>
                 <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
               {loading ? (
                 <tr>
-                  <td colSpan={5} className="px-6 py-4 text-center">Loading...</td>
+                  <td colSpan={6} className="px-6 py-4 text-center">Loading...</td>
                 </tr>
               ) : filteredJobs.length === 0 ? (
                 <tr>
-                  <td colSpan={5} className="px-6 py-4 text-center">No jobs found.</td>
+                  <td colSpan={6} className="px-6 py-4 text-center">No jobs found.</td>
                 </tr>
               ) : (
                 filteredJobs.map((job) => (
-                  <tr key={job.id}>
+                  <tr key={job.id} className={job.active ? undefined : 'bg-gray-50'}>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{job.name}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{getCategoryNameById(job.categoryId)}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                       {getShiftDetails(job)}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{job.maxRegistrations}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-1 text-xs font-semibold ${
+                          job.active
+                            ? 'bg-green-100 text-green-800'
+                            : 'bg-gray-200 text-gray-700'
+                        }`}
+                      >
+                        {job.active ? 'Active' : 'Inactive'}
+                      </span>
+                    </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                       <button
                         className="text-blue-600 hover:text-blue-900 mr-4"
@@ -515,6 +543,22 @@ export default function AdminJobsPage() {
                   onChange={handleFormChange}
                   required
                 />
+              </div>
+
+              <div className="mb-4">
+                <label className="flex items-center" htmlFor="active">
+                  <input
+                    id="active"
+                    name="active"
+                    type="checkbox"
+                    checked={form.active}
+                    onChange={handleFormChange}
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  <span className="ml-2 text-sm text-gray-700">
+                    Active and available for new registrations
+                  </span>
+                </label>
               </div>
               
               {/* Display derived properties from the selected category */}

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -143,6 +143,7 @@ export interface Job {
   id: string;
   name: string;
   location: string;
+  active: boolean;
   categoryId: string;
   shiftId: string;
   maxRegistrations: number;


### PR DESCRIPTION
## Summary
- add an `active` lifecycle state for jobs, with existing and new jobs active by default
- hide inactive jobs from normal job lists while allowing admins to include and manage them
- block inactive jobs from every new registration assignment path while preserving historical assignments
- retain hard deletion for unreferenced jobs and direct admins to deactivate historically referenced jobs
- keep inactive jobs with current-year registrations visible in work schedules
- update Admin Jobs and registration editing UX with inactive status handling

## Validation
- API and web builds
- repository lint
- full API and web unit test suites
- Prisma schema validation