### PR TITLE
Default year filters to the configured registration year

### DIFF
--- a/apps/web/src/pages/ManageRegistrationsPage.test.tsx
+++ b/apps/web/src/pages/ManageRegistrationsPage.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ManageRegistrationsPage } from './ManageRegistrationsPage';
+import { adminRegistrationsApi } from '../lib/api/admin-registrations';
+import { ConfigContext, ConfigContextType } from '../store/ConfigContextDefinition';
+
+vi.mock('../lib/api/admin-registrations', () => ({
+  adminRegistrationsApi: {
+    getRegistrations: vi.fn(),
+    getAvailableJobs: vi.fn(),
+    getAvailableCampingOptions: vi.fn(),
+    getUserCampingOptions: vi.fn(),
+  },
+}));
+
+vi.mock('../components/admin/registrations/RegistrationSearchTable', () => ({
+  default: () => <div data-testid="registration-search-table" />,
+}));
+
+vi.mock('../components/common/LoadingSpinner', () => ({
+  LoadingSpinner: () => <div data-testid="loading-spinner">Loading...</div>,
+}));
+
+const createConfigContextValue = (currentYear?: number, isLoading = false): ConfigContextType => ({
+  config: currentYear === undefined
+    ? null
+    : {
+        name: 'Test Camp',
+        description: 'Test camp',
+        homePageBlurb: '',
+        registrationOpen: true,
+        earlyRegistrationOpen: false,
+        currentYear,
+      },
+  isLoading,
+  error: null,
+  refreshConfig: vi.fn(),
+  isConnecting: false,
+  isConnected: true,
+  connectionError: null,
+});
+
+describe('ManageRegistrationsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(adminRegistrationsApi.getRegistrations).mockResolvedValue({
+      registrations: [],
+      total: 0,
+      page: 1,
+      limit: 25,
+      totalPages: 0,
+    });
+    vi.mocked(adminRegistrationsApi.getAvailableJobs).mockResolvedValue([]);
+    vi.mocked(adminRegistrationsApi.getAvailableCampingOptions).mockResolvedValue([]);
+  });
+
+  it('should request and display the configured registration year by default', async () => {
+    render(
+      <ConfigContext.Provider value={createConfigContextValue(2025)}>
+        <MemoryRouter>
+          <ManageRegistrationsPage />
+        </MemoryRouter>
+      </ConfigContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(adminRegistrationsApi.getRegistrations).toHaveBeenCalledWith({ year: 2025 });
+    });
+    expect(adminRegistrationsApi.getRegistrations).not.toHaveBeenCalledWith({});
+
+    fireEvent.click(screen.getByText('Filters'));
+
+    const yearSelect = screen.getByLabelText('Year') as HTMLSelectElement;
+    expect(yearSelect).toHaveValue('2025');
+    expect(Array.from(yearSelect.options).map(option => option.value)).toContain('2025');
+
+    fireEvent.click(screen.getByText('Clear all'));
+
+    expect(yearSelect).toHaveValue('');
+    await waitFor(() => {
+      expect(adminRegistrationsApi.getRegistrations).toHaveBeenCalledWith({});
+    });
+    expect(yearSelect).toHaveValue('');
+  });
+
+  it('should wait for configuration before requesting registrations', async () => {
+    const { rerender } = render(
+      <ConfigContext.Provider value={createConfigContextValue(undefined, true)}>
+        <MemoryRouter>
+          <ManageRegistrationsPage />
+        </MemoryRouter>
+      </ConfigContext.Provider>
+    );
+
+    expect(adminRegistrationsApi.getRegistrations).not.toHaveBeenCalled();
+
+    rerender(
+      <ConfigContext.Provider value={createConfigContextValue(2026)}>
+        <MemoryRouter>
+          <ManageRegistrationsPage />
+        </MemoryRouter>
+      </ConfigContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(adminRegistrationsApi.getRegistrations).toHaveBeenCalledWith({ year: 2026 });
+    });
+    expect(adminRegistrationsApi.getRegistrations).not.toHaveBeenCalledWith({});
+  });
+});

--- a/apps/web/src/pages/ManageRegistrationsPage.test.tsx
+++ b/apps/web/src/pages/ManageRegistrationsPage.test.tsx
@@ -107,5 +107,8 @@ describe('ManageRegistrationsPage', () => {
       expect(adminRegistrationsApi.getRegistrations).toHaveBeenCalledWith({ year: 2026 });
     });
     expect(adminRegistrationsApi.getRegistrations).not.toHaveBeenCalledWith({});
+
+    await new Promise(resolve => setTimeout(resolve, 550));
+    expect(adminRegistrationsApi.getRegistrations).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/pages/ManageRegistrationsPage.tsx
+++ b/apps/web/src/pages/ManageRegistrationsPage.tsx
@@ -149,7 +149,15 @@ export function ManageRegistrationsPage() {
     }
 
     debounceTimerRef.current = setTimeout(() => {
-      setFilters(localFilters);
+      setFilters(currentFilters => {
+        const filtersUnchanged =
+          currentFilters.year === localFilters.year &&
+          currentFilters.status === localFilters.status &&
+          currentFilters.email === localFilters.email &&
+          currentFilters.name === localFilters.name;
+
+        return filtersUnchanged ? currentFilters : localFilters;
+      });
     }, 500); // 500ms debounce
 
     return () => {

--- a/apps/web/src/pages/ManageRegistrationsPage.tsx
+++ b/apps/web/src/pages/ManageRegistrationsPage.tsx
@@ -9,6 +9,7 @@ import RegistrationCancelForm from '../components/admin/registrations/Registrati
 import AuditTrailView from '../components/admin/registrations/AuditTrailView';
 import { useRegistrationManagement } from '../hooks/useRegistrationManagement';
 import { adminRegistrationsApi, PaginatedRegistrationsResponse, Job, CampingOption, UserCampingOptionRegistration } from '../lib/api/admin-registrations';
+import { useConfig } from '../hooks/useConfig';
 
 // TODO: Replace with actual API types when implemented
 interface Registration {
@@ -58,15 +59,24 @@ interface RegistrationFilters {
  * Allows admins to view, edit, and cancel user registrations
  */
 export function ManageRegistrationsPage() {
+  const { config, isLoading: configLoading } = useConfig();
+  const configuredYear = config?.currentYear;
+  const initialFilters = useRef<RegistrationFilters>(
+    configuredYear === undefined ? {} : { year: configuredYear }
+  );
   const [registrations, setRegistrations] = useState<Registration[]>([]);
   const [availableJobs, setAvailableJobs] = useState<Job[]>([]);
   const [availableCampingOptions, setAvailableCampingOptions] = useState<CampingOption[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [filters, setFilters] = useState<RegistrationFilters>({});
-  const [localFilters, setLocalFilters] = useState<RegistrationFilters>({});
+  const [filters, setFilters] = useState<RegistrationFilters>(initialFilters.current);
+  const [localFilters, setLocalFilters] = useState<RegistrationFilters>(initialFilters.current);
+  const [yearFilterReady, setYearFilterReady] = useState(
+    configuredYear !== undefined || !configLoading
+  );
   const [showFilters, setShowFilters] = useState(false);
   const debounceTimerRef = useRef<NodeJS.Timeout>();
+  const defaultYearApplied = useRef(configuredYear !== undefined || !configLoading);
 
   // Registration management state and actions
   const {
@@ -79,6 +89,20 @@ export function ManageRegistrationsPage() {
     cancelRegistration,
     clearMessages,
   } = useRegistrationManagement();
+
+  useEffect(() => {
+    if (defaultYearApplied.current || configLoading) {
+      return;
+    }
+
+    defaultYearApplied.current = true;
+    if (configuredYear !== undefined) {
+      const defaultFilters = { year: configuredYear };
+      setFilters(defaultFilters);
+      setLocalFilters(defaultFilters);
+    }
+    setYearFilterReady(true);
+  }, [configuredYear, configLoading]);
 
   // Fetch available options for edit form
   const fetchAvailableOptions = useCallback(async () => {
@@ -116,6 +140,10 @@ export function ManageRegistrationsPage() {
 
   // Debounced effect to update filters
   useEffect(() => {
+    if (!yearFilterReady) {
+      return;
+    }
+
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
     }
@@ -129,11 +157,13 @@ export function ManageRegistrationsPage() {
         clearTimeout(debounceTimerRef.current);
       }
     };
-  }, [localFilters]);
+  }, [localFilters, yearFilterReady]);
 
   useEffect(() => {
-    fetchRegistrations();
-  }, [fetchRegistrations]);
+    if (yearFilterReady) {
+      fetchRegistrations();
+    }
+  }, [fetchRegistrations, yearFilterReady]);
 
   // Fetch available options on component mount
   useEffect(() => {
@@ -155,9 +185,12 @@ export function ManageRegistrationsPage() {
   // Get unique years for filter dropdown
   const availableYears = useMemo(() => {
     const regArray = Array.isArray(registrations) ? registrations : [];
-    const years = [...new Set(regArray.map(reg => reg.year))].sort((a, b) => b - a);
-    return years;
-  }, [registrations]);
+    const years = new Set(regArray.map(registration => registration.year));
+    if (configuredYear !== undefined) {
+      years.add(configuredYear);
+    }
+    return [...years].sort((a, b) => b - a);
+  }, [registrations, configuredYear]);
 
   const handleFilterChange = (key: keyof RegistrationFilters, value: string) => {
     setLocalFilters(prev => ({
@@ -167,8 +200,9 @@ export function ManageRegistrationsPage() {
   };
 
   const clearFilters = () => {
-    setLocalFilters({});
-    setFilters({});
+    const clearedFilters = {};
+    setLocalFilters(clearedFilters);
+    setFilters(clearedFilters);
   };
 
   // Convert API registration format to component format with camping options
@@ -325,10 +359,11 @@ export function ManageRegistrationsPage() {
             </div>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="registration-year-filter" className="block text-sm font-medium text-gray-700 mb-1">
                   Year
                 </label>
                 <select
+                  id="registration-year-filter"
                   value={localFilters.year || ''}
                   onChange={(e) => handleFilterChange('year', e.target.value)}
                   className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-amber-500 focus:border-amber-500"

--- a/apps/web/src/pages/PaymentReportsPage.tsx
+++ b/apps/web/src/pages/PaymentReportsPage.tsx
@@ -20,7 +20,7 @@ interface PaymentReportFilters {
  * Displays all payments in a filterable, sortable table for admin users
  */
 export function PaymentReportsPage() {
-  const { config } = useConfig();
+  const { config, isLoading: configLoading } = useConfig();
   const [payments, setPayments] = useState<Payment[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -28,14 +28,22 @@ export function PaymentReportsPage() {
     config ? { year: config.currentYear } : {}
   );
   const [showFilters, setShowFilters] = useState(false);
-  const defaultYearApplied = useRef(config !== null);
+  const [yearFilterReady, setYearFilterReady] = useState(
+    config !== null || !configLoading
+  );
+  const defaultYearApplied = useRef(config !== null || !configLoading);
 
   useEffect(() => {
-    if (config && !defaultYearApplied.current) {
-      defaultYearApplied.current = true;
+    if (defaultYearApplied.current || configLoading) {
+      return;
+    }
+
+    defaultYearApplied.current = true;
+    if (config) {
       setFilters(previousFilters => ({ ...previousFilters, year: config.currentYear }));
     }
-  }, [config]);
+    setYearFilterReady(true);
+  }, [config, configLoading]);
 
   // Fetch payments data
   const fetchPayments = useCallback(async () => {
@@ -243,7 +251,7 @@ export function PaymentReportsPage() {
     downloadCsv(headers, csvData, { filename });
   };
 
-  if (loading) {
+  if (loading || !yearFilterReady) {
     return (
       <div className="container mx-auto px-4 py-8">
         <LoadingSpinner />

--- a/apps/web/src/pages/PaymentReportsPage.tsx
+++ b/apps/web/src/pages/PaymentReportsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { ArrowLeft, Download, Filter, X } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { DataTable, DataTableColumn } from '../components/common/DataTable/DataTable';
@@ -7,6 +7,7 @@ import { Payment } from '../types';
 import { PATHS } from '../routes';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
 import { downloadCsv } from '../utils/csv';
+import { useConfig } from '../hooks/useConfig';
 
 interface PaymentReportFilters {
   year?: number;
@@ -19,11 +20,22 @@ interface PaymentReportFilters {
  * Displays all payments in a filterable, sortable table for admin users
  */
 export function PaymentReportsPage() {
+  const { config } = useConfig();
   const [payments, setPayments] = useState<Payment[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [filters, setFilters] = useState<PaymentReportFilters>({});
+  const [filters, setFilters] = useState<PaymentReportFilters>(() =>
+    config ? { year: config.currentYear } : {}
+  );
   const [showFilters, setShowFilters] = useState(false);
+  const defaultYearApplied = useRef(config !== null);
+
+  useEffect(() => {
+    if (config && !defaultYearApplied.current) {
+      defaultYearApplied.current = true;
+      setFilters(previousFilters => ({ ...previousFilters, year: config.currentYear }));
+    }
+  }, [config]);
 
   // Fetch payments data
   const fetchPayments = useCallback(async () => {
@@ -54,18 +66,17 @@ export function PaymentReportsPage() {
 
   // Get unique years for filter dropdown
   const availableYears = useMemo(() => {
-    // Extract years from payment dates
-    if (!Array.isArray(payments) || payments.length === 0) {
-      return []; // Return empty array if no payments data
+    const years = new Set<number>();
+
+    if (Array.isArray(payments)) {
+      payments.forEach(payment => years.add(new Date(payment.createdAt).getFullYear()));
     }
-    
-    // Extract unique years from payment data
-    const years = [...new Set(
-      payments.map(payment => new Date(payment.createdAt).getFullYear())
-    )];
-    
-    return years.sort((a, b) => b - a); // Sort descending
-  }, [payments]);
+    if (config) {
+      years.add(config.currentYear);
+    }
+
+    return [...years].sort((a, b) => b - a);
+  }, [payments, config]);
 
   // Apply client-side filtering
   const filteredPayments = useMemo(() => {

--- a/apps/web/src/pages/RegistrationReportsPage.tsx
+++ b/apps/web/src/pages/RegistrationReportsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { ArrowLeft, Download, Filter, X } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { DataTable, DataTableColumn } from '../components/common/DataTable/DataTable';
@@ -7,6 +7,7 @@ import { PATHS } from '../routes';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
 import { downloadCsv } from '../utils/csv';
 import { formatRegistrationStatus } from '../utils/registrationUtils';
+import { useConfig } from '../hooks/useConfig';
 
 // Extended user type for registration reports that includes profile fields
 interface UserWithProfile {
@@ -39,11 +40,15 @@ const USER_PROFILE_FIELDS = [
  * Displays all registrations in a filterable, sortable table for staff/admin
  */
 export function RegistrationReportsPage() {
+  const { config } = useConfig();
   const [registrations, setRegistrations] = useState<Registration[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [filters, setFilters] = useState<RegistrationReportFilters>({});
+  const [filters, setFilters] = useState<RegistrationReportFilters>(() =>
+    config ? { year: config.currentYear } : {}
+  );
   const [showFilters, setShowFilters] = useState(false);
+  const defaultYearApplied = useRef(config !== null);
   const [showCampingOptions, setShowCampingOptions] = useState(() => {
     // Restore from localStorage
     return localStorage.getItem('registrationReports_showCampingOptions') === 'true';
@@ -54,6 +59,13 @@ export function RegistrationReportsPage() {
   });
   const [campingOptionData, setCampingOptionData] = useState<CampingOptionRegistrationWithFields[]>([]);
   const [campingOptionsLoading, setCampingOptionsLoading] = useState(false);
+
+  useEffect(() => {
+    if (config && !defaultYearApplied.current) {
+      defaultYearApplied.current = true;
+      setFilters(previousFilters => ({ ...previousFilters, year: config.currentYear }));
+    }
+  }, [config]);
 
   // Fetch registrations data
   const fetchRegistrations = useCallback(async () => {
@@ -145,9 +157,12 @@ export function RegistrationReportsPage() {
 
   // Get unique years for filter dropdown
   const availableYears = useMemo(() => {
-    const years = [...new Set(registrations.map(reg => reg.year))].sort((a, b) => b - a);
-    return years;
-  }, [registrations]);
+    const years = new Set(registrations.map(registration => registration.year));
+    if (config) {
+      years.add(config.currentYear);
+    }
+    return [...years].sort((a, b) => b - a);
+  }, [registrations, config]);
 
   // Get unique field display names from camping option data
   const uniqueFields = useMemo(() => {

--- a/apps/web/src/pages/RegistrationReportsPage.tsx
+++ b/apps/web/src/pages/RegistrationReportsPage.tsx
@@ -40,7 +40,7 @@ const USER_PROFILE_FIELDS = [
  * Displays all registrations in a filterable, sortable table for staff/admin
  */
 export function RegistrationReportsPage() {
-  const { config } = useConfig();
+  const { config, isLoading: configLoading } = useConfig();
   const [registrations, setRegistrations] = useState<Registration[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -48,7 +48,10 @@ export function RegistrationReportsPage() {
     config ? { year: config.currentYear } : {}
   );
   const [showFilters, setShowFilters] = useState(false);
-  const defaultYearApplied = useRef(config !== null);
+  const [yearFilterReady, setYearFilterReady] = useState(
+    config !== null || !configLoading
+  );
+  const defaultYearApplied = useRef(config !== null || !configLoading);
   const [showCampingOptions, setShowCampingOptions] = useState(() => {
     // Restore from localStorage
     return localStorage.getItem('registrationReports_showCampingOptions') === 'true';
@@ -61,11 +64,16 @@ export function RegistrationReportsPage() {
   const [campingOptionsLoading, setCampingOptionsLoading] = useState(false);
 
   useEffect(() => {
-    if (config && !defaultYearApplied.current) {
-      defaultYearApplied.current = true;
+    if (defaultYearApplied.current || configLoading) {
+      return;
+    }
+
+    defaultYearApplied.current = true;
+    if (config) {
       setFilters(previousFilters => ({ ...previousFilters, year: config.currentYear }));
     }
-  }, [config]);
+    setYearFilterReady(true);
+  }, [config, configLoading]);
 
   // Fetch registrations data
   const fetchRegistrations = useCallback(async () => {
@@ -480,7 +488,7 @@ export function RegistrationReportsPage() {
     downloadCsv(headers, csvData, { filename });
   };
 
-  if (loading) {
+  if (loading || !yearFilterReady) {
     return (
       <div className="container mx-auto px-4 py-8">
         <LoadingSpinner />

--- a/apps/web/src/pages/UserReportsPage.tsx
+++ b/apps/web/src/pages/UserReportsPage.tsx
@@ -19,7 +19,7 @@ interface UserReportFilters {
  * Displays all users in a filterable, sortable table for staff/admin
  */
 export function UserReportsPage() {
-  const { config } = useConfig();
+  const { config, isLoading: configLoading } = useConfig();
   const [users, setUsers] = useState<User[]>([]);
   const [registrationYearUsers, setRegistrationYearUsers] = useState<{ year: number; userId: string }[]>([]);
   const [loading, setLoading] = useState(true);
@@ -28,14 +28,22 @@ export function UserReportsPage() {
     config ? { year: config.currentYear } : {}
   );
   const [showFilters, setShowFilters] = useState(false);
-  const defaultYearApplied = useRef(config !== null);
+  const [yearFilterReady, setYearFilterReady] = useState(
+    config !== null || !configLoading
+  );
+  const defaultYearApplied = useRef(config !== null || !configLoading);
 
   useEffect(() => {
-    if (config && !defaultYearApplied.current) {
-      defaultYearApplied.current = true;
+    if (defaultYearApplied.current || configLoading) {
+      return;
+    }
+
+    defaultYearApplied.current = true;
+    if (config) {
       setFilters(previousFilters => ({ ...previousFilters, year: config.currentYear }));
     }
-  }, [config]);
+    setYearFilterReady(true);
+  }, [config, configLoading]);
 
   // Fetch users and registrations data
   const fetchData = useCallback(async () => {
@@ -222,7 +230,7 @@ export function UserReportsPage() {
     downloadCsv(headers, csvData, { filename });
   };
 
-  if (loading) {
+  if (loading || !yearFilterReady) {
     return (
       <div className="container mx-auto px-4 py-8">
         <LoadingSpinner />

--- a/apps/web/src/pages/UserReportsPage.tsx
+++ b/apps/web/src/pages/UserReportsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { ArrowLeft, Download, Filter, X } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { DataTable, DataTableColumn } from '../components/common/DataTable/DataTable';
@@ -19,22 +19,23 @@ interface UserReportFilters {
  * Displays all users in a filterable, sortable table for staff/admin
  */
 export function UserReportsPage() {
+  const { config } = useConfig();
   const [users, setUsers] = useState<User[]>([]);
   const [registrationYearUsers, setRegistrationYearUsers] = useState<{ year: number; userId: string }[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [filters, setFilters] = useState<UserReportFilters>({});
+  const [filters, setFilters] = useState<UserReportFilters>(() =>
+    config ? { year: config.currentYear } : {}
+  );
   const [showFilters, setShowFilters] = useState(false);
-  const { config } = useConfig();
-  const [defaultYearApplied, setDefaultYearApplied] = useState(false);
+  const defaultYearApplied = useRef(config !== null);
 
-  // Set default year filter to registrationYear from config once config is loaded
   useEffect(() => {
-    if (config?.currentYear && !defaultYearApplied) {
-      setFilters(prev => ({ ...prev, year: config.currentYear }));
-      setDefaultYearApplied(true);
+    if (config && !defaultYearApplied.current) {
+      defaultYearApplied.current = true;
+      setFilters(previousFilters => ({ ...previousFilters, year: config.currentYear }));
     }
-  }, [config?.currentYear, defaultYearApplied]);
+  }, [config]);
 
   // Fetch users and registrations data
   const fetchData = useCallback(async () => {
@@ -97,9 +98,12 @@ export function UserReportsPage() {
 
   // Get unique years for filter dropdown from actual registration data
   const availableYears = useMemo(() => {
-    const years = [...new Set(registrationYearUsers.map(reg => reg.year))].sort((a, b) => b - a);
-    return years;
-  }, [registrationYearUsers]);
+    const years = new Set(registrationYearUsers.map(registration => registration.year));
+    if (config) {
+      years.add(config.currentYear);
+    }
+    return [...years].sort((a, b) => b - a);
+  }, [registrationYearUsers, config]);
 
   // Calculate summary statistics based on filtered data
   const summaryStats = useMemo(() => {

--- a/apps/web/src/pages/__tests__/PaymentReportsPage.basic.test.tsx
+++ b/apps/web/src/pages/__tests__/PaymentReportsPage.basic.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PaymentReportsPage } from '../PaymentReportsPage';
+import { ConfigContext } from '../../store/ConfigContextDefinition';
 
 // Mock just the API
 vi.mock('../../lib/api', () => ({
@@ -14,9 +15,21 @@ vi.mock('../../lib/api', () => ({
 describe('PaymentReportsPage - Basic Render Test', () => {
   it('should render PaymentReportsPage component', async () => {
     render(
-      <MemoryRouter>
-        <PaymentReportsPage />
-      </MemoryRouter>
+      <ConfigContext.Provider
+        value={{
+          config: null,
+          isLoading: false,
+          error: null,
+          refreshConfig: vi.fn(),
+          isConnecting: false,
+          isConnected: true,
+          connectionError: null,
+        }}
+      >
+        <MemoryRouter>
+          <PaymentReportsPage />
+        </MemoryRouter>
+      </ConfigContext.Provider>
     );
     
     await waitFor(() => {

--- a/apps/web/src/pages/__tests__/PaymentReportsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/PaymentReportsPage.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PaymentReportsPage } from '../PaymentReportsPage';
 import { reports } from '../../lib/api';
 import { Payment } from '../../types';
+import { ConfigContext, ConfigContextType } from '../../store/ConfigContextDefinition';
 
 // Mock the api module
 vi.mock('../../lib/api', () => ({
@@ -119,11 +120,32 @@ const mockPayments: Payment[] = [
   },
 ];
 
-const renderComponent = () => {
+const createConfigContextValue = (currentYear?: number): ConfigContextType => ({
+  config: currentYear === undefined
+    ? null
+    : {
+        name: 'Test Camp',
+        description: 'Test camp',
+        homePageBlurb: '',
+        registrationOpen: true,
+        earlyRegistrationOpen: false,
+        currentYear,
+      },
+  isLoading: false,
+  error: null,
+  refreshConfig: vi.fn(),
+  isConnecting: false,
+  isConnected: true,
+  connectionError: null,
+});
+
+const renderComponent = (currentYear?: number) => {
   return render(
-    <MemoryRouter>
-      <PaymentReportsPage />
-    </MemoryRouter>
+    <ConfigContext.Provider value={createConfigContextValue(currentYear)}>
+      <MemoryRouter>
+        <PaymentReportsPage />
+      </MemoryRouter>
+    </ConfigContext.Provider>
   );
 };
 
@@ -353,6 +375,27 @@ describe('PaymentReportsPage', () => {
 
       // Verify the filter value is set
       expect(yearSelect).toHaveValue('2024');
+    });
+
+    it('should default to the configured year and preserve an explicit clear', async () => {
+      renderComponent(2025);
+
+      await waitFor(() => {
+        expect(screen.getByText('Filters')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Filters'));
+
+      const yearSelect = screen.getByLabelText('Year') as HTMLSelectElement;
+      expect(yearSelect).toHaveValue('2025');
+      expect(Array.from(yearSelect.options).map(option => option.value)).toContain('2025');
+      expect(screen.getByTestId('empty-message')).toHaveTextContent('No payments found');
+
+      fireEvent.click(screen.getByText('Clear All'));
+
+      expect(yearSelect).toHaveValue('');
+      expect(screen.getByTestId('payment-payment1')).toBeInTheDocument();
+      expect(screen.getByTestId('payment-payment4')).toBeInTheDocument();
     });
 
     it('should clear all filters', async () => {

--- a/apps/web/src/pages/__tests__/PaymentReportsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/PaymentReportsPage.test.tsx
@@ -120,7 +120,7 @@ const mockPayments: Payment[] = [
   },
 ];
 
-const createConfigContextValue = (currentYear?: number): ConfigContextType => ({
+const createConfigContextValue = (currentYear?: number, isLoading = false): ConfigContextType => ({
   config: currentYear === undefined
     ? null
     : {
@@ -131,7 +131,7 @@ const createConfigContextValue = (currentYear?: number): ConfigContextType => ({
         earlyRegistrationOpen: false,
         currentYear,
       },
-  isLoading: false,
+  isLoading,
   error: null,
   refreshConfig: vi.fn(),
   isConnecting: false,
@@ -139,9 +139,9 @@ const createConfigContextValue = (currentYear?: number): ConfigContextType => ({
   connectionError: null,
 });
 
-const renderComponent = (currentYear?: number) => {
+const renderComponent = (currentYear?: number, isLoading = false) => {
   return render(
-    <ConfigContext.Provider value={createConfigContextValue(currentYear)}>
+    <ConfigContext.Provider value={createConfigContextValue(currentYear, isLoading)}>
       <MemoryRouter>
         <PaymentReportsPage />
       </MemoryRouter>
@@ -396,6 +396,33 @@ describe('PaymentReportsPage', () => {
       expect(yearSelect).toHaveValue('');
       expect(screen.getByTestId('payment-payment1')).toBeInTheDocument();
       expect(screen.getByTestId('payment-payment4')).toBeInTheDocument();
+    });
+
+    it('should keep filters unavailable until configuration resolves', async () => {
+      const renderResult = renderComponent(undefined, true);
+
+      await waitFor(() => {
+        expect(reports.getPayments).toHaveBeenCalledTimes(1);
+      });
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+      expect(screen.queryByText('Filters')).not.toBeInTheDocument();
+
+      renderResult.rerender(
+        <ConfigContext.Provider value={createConfigContextValue(2025)}>
+          <MemoryRouter>
+            <PaymentReportsPage />
+          </MemoryRouter>
+        </ConfigContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Filters')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Filters'));
+      expect(screen.getByLabelText('Year')).toHaveValue('2025');
     });
 
     it('should clear all filters', async () => {

--- a/apps/web/src/pages/__tests__/RegistrationReportsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/RegistrationReportsPage.test.tsx
@@ -167,7 +167,7 @@ const mockRegistrations: Registration[] = [
   },
 ];
 
-const createConfigContextValue = (currentYear?: number): ConfigContextType => ({
+const createConfigContextValue = (currentYear?: number, isLoading = false): ConfigContextType => ({
   config: currentYear === undefined
     ? null
     : {
@@ -178,7 +178,7 @@ const createConfigContextValue = (currentYear?: number): ConfigContextType => ({
         earlyRegistrationOpen: false,
         currentYear,
       },
-  isLoading: false,
+  isLoading,
   error: null,
   refreshConfig: vi.fn(),
   isConnecting: false,
@@ -186,9 +186,9 @@ const createConfigContextValue = (currentYear?: number): ConfigContextType => ({
   connectionError: null,
 });
 
-const renderComponent = (currentYear?: number) => {
+const renderComponent = (currentYear?: number, isLoading = false) => {
   return render(
-    <ConfigContext.Provider value={createConfigContextValue(currentYear)}>
+    <ConfigContext.Provider value={createConfigContextValue(currentYear, isLoading)}>
       <MemoryRouter>
         <RegistrationReportsPage />
       </MemoryRouter>
@@ -434,6 +434,33 @@ describe('RegistrationReportsPage', () => {
       expect(screen.getByTestId('registration-3')).toBeInTheDocument();
     });
 
+    it('should keep filters unavailable until configuration resolves', async () => {
+      const renderResult = renderComponent(undefined, true);
+
+      await waitFor(() => {
+        expect(reports.getRegistrations).toHaveBeenCalledTimes(1);
+      });
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+      expect(screen.queryByText('Filters')).not.toBeInTheDocument();
+
+      renderResult.rerender(
+        <ConfigContext.Provider value={createConfigContextValue(2025)}>
+          <MemoryRouter>
+            <RegistrationReportsPage />
+          </MemoryRouter>
+        </ConfigContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Filters')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Filters'));
+      expect(screen.getByLabelText('Year')).toHaveValue('2025');
+    });
+
     it('should filter by status when status filter is changed', async () => {
       const mockGetRegistrations = vi.mocked(reports.getRegistrations);
       // Mock multiple registrations with different statuses
@@ -486,57 +513,6 @@ describe('RegistrationReportsPage', () => {
         expect(screen.getByTestId('registration-1')).toBeInTheDocument();
         expect(screen.queryByTestId('registration-5')).not.toBeInTheDocument();
       });
-    });
-
-    // Note: This test has issues with React state updates in the test environment
-    // The clear filters functionality works in the actual component but has timing issues in tests
-    it.skip('should clear all filters when clear filters button is clicked', async () => {
-      const mockGetRegistrations = vi.mocked(reports.getRegistrations);
-      
-      renderComponent();
-
-      await waitFor(() => {
-        expect(screen.getByText('Filters')).toBeInTheDocument();
-      });
-
-      // Open filters panel
-      const filtersButton = screen.getByText('Filters');
-      fireEvent.click(filtersButton);
-
-      // Set some filters
-      const yearSelect = screen.getByLabelText('Year');
-      const statusSelect = screen.getByLabelText('Status');
-      
-      // Set year filter first
-      fireEvent.change(yearSelect, { target: { value: '2024' } });
-      
-      await waitFor(() => {
-        expect(mockGetRegistrations).toHaveBeenCalledWith({ year: 2024 });
-      });
-
-      // Set status filter
-      fireEvent.change(statusSelect, { target: { value: 'CONFIRMED' } });
-
-      // Verify that both filters are applied in the UI
-      expect((yearSelect as HTMLSelectElement).value).toBe('2024');
-      expect((statusSelect as HTMLSelectElement).value).toBe('CONFIRMED');
-
-      // Clear filters - verify button exists and is clickable
-      const clearButton = screen.getByText('Clear Filters');
-      expect(clearButton).toBeInTheDocument();
-      
-      fireEvent.click(clearButton);
-
-      // Wait for any potential API call or state updates
-      await new Promise(resolve => setTimeout(resolve, 200));
-
-      // Verify that clear button was clicked and could trigger an API call
-      // Note: Due to React batching, the UI might not immediately reflect the state change
-      // but the important thing is that the clear button is functional
-      expect(clearButton).toBeInTheDocument();
-      
-      // In a real application, this would clear the filters and trigger a new API call
-      // For now, we verify the button interaction works
     });
 
     it('should populate year dropdown with available years from data', async () => {

--- a/apps/web/src/pages/__tests__/RegistrationReportsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/RegistrationReportsPage.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { RegistrationReportsPage } from '../RegistrationReportsPage';
 import { reports, Registration } from '../../lib/api';
+import { ConfigContext, ConfigContextType } from '../../store/ConfigContextDefinition';
 
 // Mock the api module
 vi.mock('../../lib/api', () => ({
@@ -166,11 +167,32 @@ const mockRegistrations: Registration[] = [
   },
 ];
 
-const renderComponent = () => {
+const createConfigContextValue = (currentYear?: number): ConfigContextType => ({
+  config: currentYear === undefined
+    ? null
+    : {
+        name: 'Test Camp',
+        description: 'Test camp',
+        homePageBlurb: '',
+        registrationOpen: true,
+        earlyRegistrationOpen: false,
+        currentYear,
+      },
+  isLoading: false,
+  error: null,
+  refreshConfig: vi.fn(),
+  isConnecting: false,
+  isConnected: true,
+  connectionError: null,
+});
+
+const renderComponent = (currentYear?: number) => {
   return render(
-    <MemoryRouter>
-      <RegistrationReportsPage />
-    </MemoryRouter>
+    <ConfigContext.Provider value={createConfigContextValue(currentYear)}>
+      <MemoryRouter>
+        <RegistrationReportsPage />
+      </MemoryRouter>
+    </ConfigContext.Provider>
   );
 };
 
@@ -389,6 +411,27 @@ describe('RegistrationReportsPage', () => {
         expect(screen.getByTestId('registration-1')).toBeInTheDocument();
         expect(screen.queryByTestId('registration-4')).not.toBeInTheDocument();
       });
+    });
+
+    it('should default to the configured year and preserve an explicit clear', async () => {
+      renderComponent(2025);
+
+      await waitFor(() => {
+        expect(screen.getByText('Filters')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Filters'));
+
+      const yearSelect = screen.getByLabelText('Year') as HTMLSelectElement;
+      expect(yearSelect).toHaveValue('2025');
+      expect(Array.from(yearSelect.options).map(option => option.value)).toContain('2025');
+      expect(screen.getByTestId('empty-message')).toHaveTextContent('No registrations found');
+
+      fireEvent.click(screen.getByText('Clear Filters'));
+
+      expect(yearSelect).toHaveValue('');
+      expect(screen.getByTestId('registration-1')).toBeInTheDocument();
+      expect(screen.getByTestId('registration-3')).toBeInTheDocument();
     });
 
     it('should filter by status when status filter is changed', async () => {

--- a/apps/web/src/pages/__tests__/UserReportsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/UserReportsPage.test.tsx
@@ -131,6 +131,62 @@ describe('UserReportsPage', () => {
     expect(screen.queryByTestId('user-user3')).not.toBeInTheDocument();
   });
 
+  it('keeps filters unavailable until configuration resolves', async () => {
+    mockUseConfig.mockReturnValue({
+      config: null,
+      isLoading: true,
+      error: null,
+      refreshConfig: vi.fn(),
+      isConnecting: true,
+      isConnected: false,
+      connectionError: null,
+    });
+
+    const renderResult = render(
+      <MemoryRouter>
+        <UserReportsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(reports.getUsers).toHaveBeenCalledTimes(1);
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Toggle filters')).not.toBeInTheDocument();
+
+    mockUseConfig.mockReturnValue({
+      config: {
+        name: 'Test Camp',
+        description: 'Test',
+        homePageBlurb: '',
+        registrationOpen: true,
+        earlyRegistrationOpen: false,
+        currentYear: 2025,
+      },
+      isLoading: false,
+      error: null,
+      refreshConfig: vi.fn(),
+      isConnecting: false,
+      isConnected: true,
+      connectionError: null,
+    });
+
+    renderResult.rerender(
+      <MemoryRouter>
+        <UserReportsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Toggle filters')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('Toggle filters'));
+    expect(screen.getByLabelText('Year')).toHaveValue('2025');
+  });
+
   it('derives year options from registration data', async () => {
     render(
       <MemoryRouter>

--- a/apps/web/src/pages/__tests__/UserReportsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/UserReportsPage.test.tsx
@@ -151,6 +151,42 @@ describe('UserReportsPage', () => {
     expect(options).toEqual(['', '2024', '2023']);
   });
 
+  it('includes the configured year when registration data does not contain it', async () => {
+    mockUseConfig.mockReturnValue({
+      config: {
+        name: 'Test Camp',
+        description: 'Test',
+        homePageBlurb: '',
+        registrationOpen: true,
+        earlyRegistrationOpen: false,
+        currentYear: 2025,
+      },
+      isLoading: false,
+      error: null,
+      refreshConfig: vi.fn(),
+      isConnecting: false,
+      isConnected: true,
+      connectionError: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <UserReportsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('Toggle filters'));
+
+    const yearSelect = screen.getByLabelText('Year') as HTMLSelectElement;
+    expect(yearSelect).toHaveValue('2025');
+    expect(Array.from(yearSelect.options).map(option => option.value)).toEqual(['', '2025', '2024', '2023']);
+    expect(screen.getByTestId('empty-message')).toHaveTextContent('No users found');
+  });
+
   it('filters users by registrations for the selected year', async () => {
     render(
       <MemoryRouter>


### PR DESCRIPTION
## Summary

- default user, registration, payment, and admin registration year filters to the configured registration year
- keep the configured year selectable when no matching records exist
- preserve explicit “All Years” and clear-filter choices
- wait for asynchronous configuration before exposing report filters
- avoid duplicate admin registration requests from equivalent debounced filters

## Validation

- full web test suite: 706 passed, 3 skipped
- targeted ESLint checks
- production web build