### PR TITLE
test: add critical payment E2E coverage

### DIFF
--- a/apps/api/test/payments.e2e-spec.ts
+++ b/apps/api/test/payments.e2e-spec.ts
@@ -1,0 +1,267 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  PaymentProvider,
+  PaymentRefundStatus,
+  PaymentStatus,
+  RefundExecutionMode,
+  RegistrationStatus,
+  UserRole,
+} from '@prisma/client';
+import { randomUUID } from 'node:crypto';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/common/prisma/prisma.service';
+import { StripeService } from '../src/payments/services/stripe.service';
+
+interface StripeServiceMock {
+  readonly createAdminRefund: jest.MockedFunction<StripeService['createAdminRefund']>;
+  readonly findAdminRefund: jest.MockedFunction<StripeService['findAdminRefund']>;
+}
+
+describe('Admin payment refunds (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let adminToken: string;
+  let adminUserId: string;
+  let participantUserId: string;
+  let registrationId: string;
+
+  const suiteId = randomUUID();
+  const stripeServiceMock: StripeServiceMock = {
+    createAdminRefund: jest.fn<StripeService['createAdminRefund']>(),
+    findAdminRefund: jest.fn<StripeService['findAdminRefund']>(),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(StripeService)
+      .useValue(stripeServiceMock)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+    await app.init();
+    prisma = app.get(PrismaService);
+    const jwtService = app.get(JwtService);
+    const admin = await prisma.user.create({
+      data: {
+        email: `payments-admin-${suiteId}@e2e.test`,
+        firstName: 'Payments',
+        lastName: 'Admin',
+        role: UserRole.ADMIN,
+        isEmailVerified: true,
+      },
+    });
+    const participant = await prisma.user.create({
+      data: {
+        email: `payments-participant-${suiteId}@e2e.test`,
+        firstName: 'Payments',
+        lastName: 'Participant',
+        role: UserRole.PARTICIPANT,
+        isEmailVerified: true,
+      },
+    });
+    const registration = await prisma.registration.create({
+      data: {
+        userId: participant.id,
+        year: new Date().getFullYear(),
+        status: RegistrationStatus.CONFIRMED,
+      },
+    });
+
+    adminUserId = admin.id;
+    participantUserId = participant.id;
+    registrationId = registration.id;
+    adminToken = jwtService.sign({
+      sub: admin.id,
+      email: admin.email,
+      role: admin.role,
+    });
+  });
+
+  beforeEach(() => {
+    stripeServiceMock.createAdminRefund.mockReset();
+    stripeServiceMock.findAdminRefund.mockReset();
+  });
+
+  afterEach(async () => {
+    await prisma.adminAudit.deleteMany({ where: { adminUserId } });
+    await prisma.paymentRefund.deleteMany({ where: { processedByUserId: adminUserId } });
+    await prisma.payment.deleteMany({ where: { userId: participantUserId } });
+  });
+
+  afterAll(async () => {
+    await prisma.registration.delete({ where: { id: registrationId } });
+    await prisma.user.deleteMany({
+      where: { id: { in: [adminUserId, participantUserId] } },
+    });
+    await app.close();
+  });
+
+  async function createStripePayment(providerRefId: string) {
+    return prisma.payment.create({
+      data: {
+        amount: 100,
+        currency: 'USD',
+        status: PaymentStatus.COMPLETED,
+        provider: PaymentProvider.STRIPE,
+        providerRefId,
+        userId: participantUserId,
+        registrationId,
+      },
+    });
+  }
+
+  it('should persist a successful Stripe refund through the HTTP endpoint', async () => {
+    const payment = await createStripePayment('pi_e2e_immediate_success');
+    const idempotencyKey = randomUUID();
+    const providerRefundId = `re_${suiteId}_immediate`;
+    stripeServiceMock.createAdminRefund.mockResolvedValueOnce({
+      outcome: 'SUCCEEDED',
+      providerRefundId,
+    });
+
+    const response = await request(app.getHttpServer())
+      .post(`/payments/${payment.id}/refunds`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        amountCents: 2500,
+        executionMode: RefundExecutionMode.STRIPE,
+        reason: 'Immediate success E2E',
+        idempotencyKey,
+      })
+      .expect(201);
+
+    expect(response.body).toMatchObject({
+      outcome: 'SUCCEEDED',
+      paymentAmountCents: 10_000,
+      successfulRefundCents: 2500,
+      pendingRefundCents: 0,
+      availableRefundCents: 7500,
+      payment: { id: payment.id, status: PaymentStatus.PARTIALLY_REFUNDED },
+      refund: {
+        amountCents: 2500,
+        currency: 'USD',
+        executionMode: RefundExecutionMode.STRIPE,
+        status: PaymentRefundStatus.SUCCEEDED,
+      },
+    });
+    expect(stripeServiceMock.createAdminRefund).toHaveBeenCalledWith({
+      providerRefId: payment.providerRefId,
+      amountCents: 2500,
+      idempotencyKey,
+      localRefundId: response.body.refund.id,
+    });
+
+    const persistedPayment = await prisma.payment.findUniqueOrThrow({
+      where: { id: payment.id },
+      include: { refunds: true },
+    });
+    expect(persistedPayment.status).toBe(PaymentStatus.PARTIALLY_REFUNDED);
+    expect(persistedPayment.refunds).toEqual([
+      expect.objectContaining({
+        id: response.body.refund.id,
+        amountCents: 2500,
+        status: PaymentRefundStatus.SUCCEEDED,
+        providerRefundId,
+        idempotencyKey,
+      }),
+    ]);
+  });
+
+  it('should recover an ambiguous Stripe refund on retry without a duplicate ledger row', async () => {
+    const payment = await createStripePayment('pi_e2e_ambiguous_retry');
+    const idempotencyKey = randomUUID();
+    const providerRefundId = `re_${suiteId}_retry`;
+    stripeServiceMock.createAdminRefund
+      .mockResolvedValueOnce({ outcome: 'PENDING_UNKNOWN' })
+      .mockResolvedValueOnce({
+        outcome: 'SUCCEEDED',
+        providerRefundId,
+      });
+    stripeServiceMock.findAdminRefund.mockResolvedValueOnce({ outcome: 'NOT_FOUND' });
+
+    const pendingResponse = await request(app.getHttpServer())
+      .post(`/payments/${payment.id}/refunds`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        amountCents: 4000,
+        executionMode: RefundExecutionMode.STRIPE,
+        reason: 'Ambiguous retry E2E',
+        idempotencyKey,
+      })
+      .expect(201);
+
+    expect(pendingResponse.body).toMatchObject({
+      outcome: 'PENDING_UNKNOWN',
+      successfulRefundCents: 0,
+      pendingRefundCents: 4000,
+      availableRefundCents: 6000,
+      payment: { id: payment.id, status: PaymentStatus.COMPLETED },
+      refund: {
+        amountCents: 4000,
+        status: PaymentRefundStatus.PENDING,
+      },
+    });
+    const refundId = pendingResponse.body.refund.id as string;
+
+    const pendingRows = await prisma.paymentRefund.findMany({
+      where: { paymentId: payment.id },
+    });
+    expect(pendingRows).toHaveLength(1);
+    expect(pendingRows[0]).toMatchObject({
+      id: refundId,
+      status: PaymentRefundStatus.PENDING,
+      idempotencyKey,
+    });
+
+    const retryResponse = await request(app.getHttpServer())
+      .post(`/payments/${payment.id}/refunds/${refundId}/retry`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send()
+      .expect(201);
+
+    expect(retryResponse.body).toMatchObject({
+      outcome: 'SUCCEEDED',
+      successfulRefundCents: 4000,
+      pendingRefundCents: 0,
+      availableRefundCents: 6000,
+      payment: { id: payment.id, status: PaymentStatus.PARTIALLY_REFUNDED },
+      refund: {
+        id: refundId,
+        amountCents: 4000,
+        status: PaymentRefundStatus.SUCCEEDED,
+      },
+    });
+    expect(stripeServiceMock.findAdminRefund).toHaveBeenCalledWith(
+      payment.providerRefId,
+      refundId,
+    );
+    expect(stripeServiceMock.createAdminRefund).toHaveBeenCalledTimes(2);
+    expect(stripeServiceMock.createAdminRefund.mock.calls[1][0]).toEqual(
+      stripeServiceMock.createAdminRefund.mock.calls[0][0],
+    );
+
+    const persistedRefunds = await prisma.paymentRefund.findMany({
+      where: { paymentId: payment.id },
+    });
+    expect(persistedRefunds).toHaveLength(1);
+    expect(persistedRefunds[0]).toMatchObject({
+      id: refundId,
+      amountCents: 4000,
+      status: PaymentRefundStatus.SUCCEEDED,
+      providerRefundId,
+      idempotencyKey,
+    });
+  });
+});

--- a/tests/admin/payments.spec.ts
+++ b/tests/admin/payments.spec.ts
@@ -2,13 +2,35 @@
  * Coverage:
  *  - Payment Reports page loads with the expected heading, filter toggle, and
  *    export button.
- *
- * Manual payment recording, refunds, and provider/status filters live in their
- * own admin-flow components and are large enough to deserve dedicated specs —
- * out of scope here for now.
+ *  - An admin records an external payment against a deferred registration,
+ *    durably linking the payment and confirming the registration.
+ *  - An admin records a partial manual refund and then refunds the remaining
+ *    balance, with the ledger and payment status updated after each command.
  */
+import { Locator, Page } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
 import { test, expect } from '../helpers/fixtures';
 import { webUrl } from '../helpers/env';
+import { getPrisma } from '../helpers/db';
+import { loginViaUi, logoutViaUi } from '../helpers/auth';
+
+const ADMIN_EMAIL = 'e2e-admin@test.playaplan.local';
+
+function getPaymentRow(page: Page, email: string): Locator {
+  return page
+    .getByRole('heading', { name: 'Recent payments' })
+    .locator('..')
+    .getByRole('row')
+    .filter({ hasText: email })
+    .first();
+}
+
+async function loginAsAdmin(page: Page): Promise<void> {
+  await logoutViaUi(page);
+  await loginViaUi(page, ADMIN_EMAIL);
+  await page.goto(webUrl('/admin/payments'));
+  await expect(page.getByRole('heading', { name: 'Admin Payments' })).toBeVisible();
+}
 
 test.describe(
   'Admin: payments report',
@@ -23,6 +45,174 @@ test.describe(
       });
       await expect(page.getByRole('button', { name: 'Toggle filters' })).toBeVisible();
       await expect(page.getByRole('button', { name: 'Export payments data' })).toBeVisible();
+    });
+  },
+);
+
+test.describe(
+  'Admin: payment commands',
+  { tag: ['@admin', '@admin-payments', '@payment'] },
+  () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test('records an external payment and confirms a deferred registration', async ({
+      page,
+      freshDeferredParticipant,
+    }) => {
+      const prisma = getPrisma();
+      const registration = await prisma.registration.create({
+        data: {
+          userId: freshDeferredParticipant.id,
+          year: new Date().getFullYear(),
+          status: 'PENDING',
+          paymentDeferred: true,
+        },
+      });
+
+      await loginAsAdmin(page);
+      await page.getByLabel('Registration email').fill(freshDeferredParticipant.email);
+      await page.getByRole('button', { name: 'Search registrations' }).click();
+      await page
+        .getByRole('radio', {
+          name: `Select ${freshDeferredParticipant.firstName} ${freshDeferredParticipant.lastName}`,
+        })
+        .check();
+      await expect(
+        page.getByText(
+          'The registration will become CONFIRMED and payment deferral will be cleared.',
+        ),
+      ).toBeVisible();
+
+      await page.getByLabel('External payment amount').fill('123.45');
+      await page.getByLabel('External payment method').selectOption('CHECK');
+      await page.getByLabel('External payment reference').fill('e2e-check-123');
+      await page.getByLabel('Confirm external payment').check();
+      await page.getByRole('button', { name: 'Record external payment' }).click();
+
+      await expect(page.getByText('External payment recorded')).toBeVisible();
+      const paymentRow = getPaymentRow(page, freshDeferredParticipant.email);
+      await expect(paymentRow).toContainText('USD 123.45');
+      await expect(paymentRow).toContainText('COMPLETED');
+      await expect(paymentRow).toContainText('MANUAL');
+      await expect(paymentRow).toContainText('CHECK');
+      await expect(paymentRow).toContainText('e2e-check-123');
+
+      const payments = await prisma.payment.findMany({
+        where: { registrationId: registration.id },
+      });
+      expect(payments).toHaveLength(1);
+      expect(payments[0]).toMatchObject({
+        amount: 123.45,
+        currency: 'USD',
+        status: 'COMPLETED',
+        provider: 'MANUAL',
+        externalMethod: 'CHECK',
+        externalReference: 'e2e-check-123',
+        userId: freshDeferredParticipant.id,
+        registrationId: registration.id,
+      });
+
+      const updatedRegistration = await prisma.registration.findUniqueOrThrow({
+        where: { id: registration.id },
+      });
+      expect(updatedRegistration.status).toBe('CONFIRMED');
+      expect(updatedRegistration.paymentDeferred).toBe(false);
+    });
+
+    test('records a partial manual refund and then refunds the remaining balance', async ({
+      page,
+      freshParticipant,
+    }) => {
+      const prisma = getPrisma();
+      const registration = await prisma.registration.create({
+        data: {
+          userId: freshParticipant.id,
+          year: new Date().getFullYear(),
+          status: 'CONFIRMED',
+        },
+      });
+      const payment = await prisma.payment.create({
+        data: {
+          amount: 100,
+          currency: 'USD',
+          status: 'COMPLETED',
+          provider: 'MANUAL',
+          externalMethod: 'CHECK',
+          externalReference: 'e2e-original-payment',
+          idempotencyKey: randomUUID(),
+          userId: freshParticipant.id,
+          registrationId: registration.id,
+        },
+      });
+
+      await loginAsAdmin(page);
+      let paymentRow = getPaymentRow(page, freshParticipant.email);
+      await expect(paymentRow).toBeVisible();
+      await paymentRow.getByRole('button', { name: 'Refund' }).click();
+
+      await page.getByLabel('Partial refund amount').fill('25.00');
+      await page.getByLabel('Manual refund reason').fill('Partial E2E refund');
+      await page.getByLabel('Manual refund reference').fill('e2e-refund-partial');
+      await page.getByRole('button', { name: 'Record manual refund' }).click();
+
+      await expect(page.getByRole('status')).toContainText(
+        'Manual refund recorded: USD 25.00.',
+      );
+      paymentRow = getPaymentRow(page, freshParticipant.email);
+      await expect(paymentRow).toContainText('PARTIALLY_REFUNDED');
+      await expect(paymentRow).toContainText('Successful: USD 25.00');
+      await expect(paymentRow).toContainText('Pending: USD 0.00');
+      await expect(paymentRow).toContainText('Available: USD 75.00');
+      await expect(paymentRow).toContainText('USD 25.00 SUCCEEDED / MANUAL');
+
+      await paymentRow.getByRole('button', { name: 'Refund' }).click();
+      await page.getByLabel('Full available refund').check();
+      await page.getByLabel('Manual refund reason').fill('Complete E2E refund');
+      await page.getByLabel('Manual refund reference').fill('e2e-refund-full');
+      await page.getByRole('button', { name: 'Record manual refund' }).click();
+
+      await expect(page.getByRole('status')).toContainText(
+        'Manual refund recorded: USD 75.00.',
+      );
+      paymentRow = getPaymentRow(page, freshParticipant.email);
+      await expect(paymentRow).toContainText('REFUNDED');
+      await expect(paymentRow).toContainText('Successful: USD 100.00');
+      await expect(paymentRow).toContainText('Pending: USD 0.00');
+      await expect(paymentRow).toContainText('Available: USD 0.00');
+      await expect(paymentRow).toContainText('USD 25.00 SUCCEEDED / MANUAL');
+      await expect(paymentRow).toContainText('USD 75.00 SUCCEEDED / MANUAL');
+      await expect(paymentRow.getByRole('button', { name: 'Refund' })).toHaveCount(0);
+
+      const updatedPayment = await prisma.payment.findUniqueOrThrow({
+        where: { id: payment.id },
+        include: { refunds: { orderBy: { createdAt: 'asc' } } },
+      });
+      expect(updatedPayment.status).toBe('REFUNDED');
+      expect(updatedPayment.refunds).toHaveLength(2);
+      expect(updatedPayment.refunds).toEqual([
+        expect.objectContaining({
+          amountCents: 2500,
+          currency: 'USD',
+          executionMode: 'MANUAL',
+          status: 'SUCCEEDED',
+          externalReference: 'e2e-refund-partial',
+        }),
+        expect.objectContaining({
+          amountCents: 7500,
+          currency: 'USD',
+          executionMode: 'MANUAL',
+          status: 'SUCCEEDED',
+          externalReference: 'e2e-refund-full',
+        }),
+      ]);
+      expect(
+        updatedPayment.refunds.reduce((total, refund) => total + refund.amountCents, 0),
+      ).toBe(10_000);
+
+      const unchangedRegistration = await prisma.registration.findUniqueOrThrow({
+        where: { id: registration.id },
+      });
+      expect(unchangedRegistration.status).toBe('CONFIRMED');
     });
   },
 );

--- a/tests/admin/payments.spec.ts
+++ b/tests/admin/payments.spec.ts
@@ -3,7 +3,7 @@
  *  - Payment Reports page loads with the expected heading, filter toggle, and
  *    export button.
  *  - An admin records an external payment against a deferred registration,
- *    durably linking the payment and confirming the registration.
+ *    durably linking the payment while clearing payment deferral.
  *  - An admin records a partial manual refund and then refunds the remaining
  *    balance, with the ledger and payment status updated after each command.
  */
@@ -55,7 +55,7 @@ test.describe(
   () => {
     test.use({ storageState: { cookies: [], origins: [] } });
 
-    test('records an external payment and confirms a deferred registration', async ({
+    test('records an external payment and clears a deferred registration', async ({
       page,
       freshDeferredParticipant,
     }) => {
@@ -64,7 +64,7 @@ test.describe(
         data: {
           userId: freshDeferredParticipant.id,
           year: new Date().getFullYear(),
-          status: 'PENDING',
+          status: 'CONFIRMED',
           paymentDeferred: true,
         },
       });
@@ -79,7 +79,7 @@ test.describe(
         .check();
       await expect(
         page.getByText(
-          'The registration will become CONFIRMED and payment deferral will be cleared.',
+          'The registration will remain CONFIRMED and payment deferral will be cleared.',
         ),
       ).toBeVisible();
 

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -63,12 +63,36 @@ export async function cleanupRunData(): Promise<void> {
     const allUserIds = Array.from(new Set([...runUserIds, ...personaUserIds]));
     if (allUserIds.length === 0) return;
 
+    const [payments, registrations] = await Promise.all([
+      prisma.payment.findMany({
+        where: { userId: { in: allUserIds } },
+        select: { id: true },
+      }),
+      prisma.registration.findMany({
+        where: { userId: { in: allUserIds } },
+        select: { id: true },
+      }),
+    ]);
+    const ownedTargetRecordIds = [
+      ...payments.map((payment) => payment.id),
+      ...registrations.map((registration) => registration.id),
+    ];
+
     // Delete in FK-safe order. Each step is wrapped so a single failure doesn't
     // abort the rest of the cleanup.
     const steps: Array<[string, () => Promise<unknown>]> = [
       ['email_audit', () => prisma.emailAudit.deleteMany({ where: { userId: { in: allUserIds } } })],
       ['notifications', () => prisma.notification.deleteMany({ where: { recipient: { startsWith: prefix } } })],
-      ['admin_audit', () => prisma.adminAudit.deleteMany({ where: { adminUserId: { in: allUserIds } } })],
+      ['admin_audit', () =>
+        prisma.adminAudit.deleteMany({
+          where: {
+            OR: [
+              { targetRecordId: { in: ownedTargetRecordIds } },
+              { adminUserId: { in: runUserIds } },
+            ],
+          },
+        }),
+      ],
       ['payment_refunds', () =>
         prisma.paymentRefund.deleteMany({
           where: { payment: { userId: { in: allUserIds } } },

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -69,6 +69,11 @@ export async function cleanupRunData(): Promise<void> {
       ['email_audit', () => prisma.emailAudit.deleteMany({ where: { userId: { in: allUserIds } } })],
       ['notifications', () => prisma.notification.deleteMany({ where: { recipient: { startsWith: prefix } } })],
       ['admin_audit', () => prisma.adminAudit.deleteMany({ where: { adminUserId: { in: allUserIds } } })],
+      ['payment_refunds', () =>
+        prisma.paymentRefund.deleteMany({
+          where: { payment: { userId: { in: allUserIds } } },
+        }),
+      ],
       ['payments', () => prisma.payment.deleteMany({ where: { userId: { in: allUserIds } } })],
       ['registration_jobs', () =>
         prisma.registrationJob.deleteMany({


### PR DESCRIPTION
## Summary

- Add browser E2E coverage for recording an external payment against a deferred registration and verifying the durable payment plus registration transition.
- Add browser E2E coverage for partial-to-full manual refunds, including refund ledger entries, balances, and payment status.
- Add Nest/HTTP/PostgreSQL E2E coverage for Stripe refund success and ambiguous-outcome retry, mocking only `StripeService` and proving stable request reuse with exactly one durable refund row.
- Add FK-safe refund cleanup before payment deletion using the existing run/persona ownership scope.

These are the three conditionally recommended E2E scenarios from issue #71. This PR contains no product behavior changes.

## Validation

- `PLAYWRIGHT_HTML_OPEN=never ./scripts/test-e2e.sh tests/admin/payments.spec.ts --project=chromium --workers=1` — 9 tests passed, including setup.
- `cd apps/api && npx dotenv -e ../../.env.test -- npx jest --config ./test/jest-e2e.json test/payments.e2e-spec.ts --runInBand --silent` — 2 tests passed.
- `npx eslint tests/admin/payments.spec.ts tests/helpers/db.ts apps/api/test/payments.e2e-spec.ts --config eslint.config.cjs --report-unused-disable-directives --max-warnings 0` — passed with zero warnings.
- `./scripts/validate-e2e.sh` — passed.

Refs #71