### PR TITLE
fix(deps): remediate npm vulnerabilities without router upgrade

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -45,7 +45,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.27",
-    "@nestjs/swagger": "^11.4.4",
+    "@nestjs/swagger": "11.4.5",
     "@nestjs/throttler": "^6.4.0",
     "@playa-plan/types": "file:../../libs/types",
     "@prisma/client": "^6.19.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,7 @@
     "postcss-value-parser": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.0.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -45,7 +45,7 @@
     "globals": "^15.15.0",
     "jsdom": "^26.1.0",
     "msw": "^2.7.5",
-    "postcss": "^8.4.35",
+    "postcss": "^8.5.26",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.62.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,7 @@
     "postcss-value-parser": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.0.0",
+    "react-router-dom": "^6.30.4",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import LoginPage from './LoginPage';
+import { useConfig } from '../hooks/useConfig';
+import { useAuth } from '../store/authUtils';
+
+vi.mock('../hooks/useConfig', () => ({
+  useConfig: vi.fn(),
+}));
+
+vi.mock('../store/authUtils', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../components/auth/LoginForm', () => ({
+  default: () => <div>Login Form</div>,
+}));
+
+const mockUseAuth = vi.mocked(useAuth);
+const mockUseConfig = vi.mocked(useConfig);
+
+const renderLoginPage = (inputReturnTo: string): void => {
+  const inputEntry = `/login?returnTo=${encodeURIComponent(inputReturnTo)}`;
+
+  render(
+    <MemoryRouter initialEntries={[inputEntry]}>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/dashboard" element={<div>Dashboard Page</div>} />
+        <Route path="/registration" element={<div>Registration Page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      user: null,
+      error: null,
+      requestVerificationCode: vi.fn().mockResolvedValue(false),
+      verifyCode: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn().mockResolvedValue(undefined),
+    });
+    mockUseConfig.mockReturnValue({
+      config: null,
+      isLoading: false,
+      error: null,
+      refreshConfig: vi.fn(),
+      isConnecting: false,
+      isConnected: true,
+      connectionError: null,
+    });
+  });
+
+  it('should navigate authenticated users to a safe return path', async () => {
+    renderLoginPage('/registration?step=2');
+
+    expect(await screen.findByText('Registration Page')).toBeInTheDocument();
+  });
+
+  it.each([
+    'https://evil.example',
+    '//evil.example',
+    '\\\\evil.example',
+    '/administrator',
+  ])('should navigate unsafe return target %s to the dashboard', async inputReturnTo => {
+    renderLoginPage(inputReturnTo);
+
+    expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -2,8 +2,8 @@ import { useEffect, lazy, Suspense } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../store/authUtils';
 import { useConfig } from '../hooks/useConfig';
-import { PATHS } from '../routes';
 import { ConnectionStatus } from '../components/common/ConnectionStatus';
+import { getSafeReturnTo } from '../utils/returnToUtils';
 
 /**
  * Login page wrapper component
@@ -17,13 +17,12 @@ const LoginPage: React.FC = () => {
   
   // Extract the returnTo path from URL query params if present
   const searchParams = new URLSearchParams(location.search);
-  const returnTo = searchParams.get('returnTo');
+  const returnTo = getSafeReturnTo(searchParams.get('returnTo'));
   
   // Redirect to dashboard or requested page if already authenticated
   useEffect(() => {
     if (isAuthenticated) {
-      // Navigate to the returnTo path if available, or to dashboard
-      navigate(returnTo ? decodeURIComponent(returnTo) : PATHS.DASHBOARD, { replace: true });
+      navigate(returnTo, { replace: true });
     }
   }, [isAuthenticated, navigate, returnTo]);
 

--- a/apps/web/src/utils/__tests__/returnToUtils.test.ts
+++ b/apps/web/src/utils/__tests__/returnToUtils.test.ts
@@ -33,6 +33,8 @@ describe('getSafeReturnTo', () => {
     '/unknown',
     '/login',
     '/dashboard#unexpected',
+    '/.//dashboard',
+    '/%2e//dashboard',
     ' /dashboard',
     '/dashboard ',
     '/dashboard\u0000',

--- a/apps/web/src/utils/__tests__/returnToUtils.test.ts
+++ b/apps/web/src/utils/__tests__/returnToUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { PATHS } from '../../routes';
+import { getSafeReturnTo } from '../returnToUtils';
+
+describe('getSafeReturnTo', () => {
+  it.each([
+    '/dashboard',
+    '/admin/users',
+    '/registration?step=2',
+    '/admin/camping-options/option-1/fields',
+  ])('should allow authenticated application route %s', inputReturnTo => {
+    const actualReturnTo = getSafeReturnTo(inputReturnTo);
+
+    expect(actualReturnTo).toBe(inputReturnTo);
+  });
+
+  it.each([
+    null,
+    '',
+    'dashboard',
+    'https://evil.example',
+    '//evil.example',
+    '\\\\evil.example',
+    '/\\evil.example',
+    '\\/evil.example',
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    '%2F%2Fevil.example',
+    '%252F%252Fevil.example',
+    '/%5Cevil.example',
+    '/%255Cevil.example',
+    '/administrator',
+    '/unknown',
+    '/login',
+    '/dashboard#unexpected',
+    ' /dashboard',
+    '/dashboard ',
+    '/dashboard\u0000',
+    '/%E0%A4%A',
+  ])('should replace unsafe return target %s with the dashboard', inputReturnTo => {
+    const actualReturnTo = getSafeReturnTo(inputReturnTo);
+
+    expect(actualReturnTo).toBe(PATHS.DASHBOARD);
+  });
+});

--- a/apps/web/src/utils/returnToUtils.ts
+++ b/apps/web/src/utils/returnToUtils.ts
@@ -1,0 +1,63 @@
+import { PATHS, ROUTES } from '../routes';
+
+const RETURN_TARGET_BASE = 'https://return-target.invalid';
+const CONTROL_OR_BACKSLASH_PATTERN = /[\u0000-\u001f\u007f\\]/;
+const ENCODED_PATH_SEPARATOR_PATTERN = /%(?:25)*(?:2f|5c)/i;
+const AUTHENTICATED_ROUTE_PATTERNS = Object.values(ROUTES)
+  .filter(route => route.requiresAuth)
+  .map(route => route.path);
+
+const matchesRoutePattern = (pathname: string, pattern: string): boolean => {
+  const pathSegments = pathname.split('/').filter(Boolean);
+  const patternSegments = pattern.split('/').filter(Boolean);
+
+  return patternSegments.length === pathSegments.length
+    && patternSegments.every((segment, index) =>
+      segment.startsWith(':') || segment === pathSegments[index]
+    );
+};
+
+const parseReturnTarget = (value: string): URL | null => {
+  try {
+    return new URL(value, RETURN_TARGET_BASE);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Returns a safe authenticated application path for post-login navigation.
+ */
+export const getSafeReturnTo = (value: string | null): string => {
+  if (
+    !value
+    || value !== value.trim()
+    || !value.startsWith('/')
+    || value.startsWith('//')
+    || CONTROL_OR_BACKSLASH_PATTERN.test(value)
+    || ENCODED_PATH_SEPARATOR_PATTERN.test(value)
+  ) {
+    return PATHS.DASHBOARD;
+  }
+
+  const targetUrl = parseReturnTarget(value);
+  if (!targetUrl) {
+    return PATHS.DASHBOARD;
+  }
+
+  const isAllowedRoute = AUTHENTICATED_ROUTE_PATTERNS.some(pattern =>
+    matchesRoutePattern(targetUrl.pathname, pattern)
+  );
+
+  if (
+    targetUrl.origin !== RETURN_TARGET_BASE
+    || targetUrl.username
+    || targetUrl.password
+    || targetUrl.hash
+    || !isAllowedRoute
+  ) {
+    return PATHS.DASHBOARD;
+  }
+
+  return `${targetUrl.pathname}${targetUrl.search}`;
+};

--- a/apps/web/src/utils/returnToUtils.ts
+++ b/apps/web/src/utils/returnToUtils.ts
@@ -54,6 +54,7 @@ export const getSafeReturnTo = (value: string | null): string => {
     || targetUrl.username
     || targetUrl.password
     || targetUrl.hash
+    || targetUrl.pathname.startsWith('//')
     || !isAllowedRoute
   ) {
     return PATHS.DASHBOARD;

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
                 "postcss-value-parser": "^4.2.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
-                "react-router-dom": "^6.30.4",
+                "react-router-dom": "^7.0.0",
                 "zod": "^3.25.76"
             },
             "devDependencies": {
@@ -142,7 +142,7 @@
                 "globals": "^15.15.0",
                 "jsdom": "^26.1.0",
                 "msw": "^2.7.5",
-                "postcss": "^8.4.35",
+                "postcss": "^8.5.26",
                 "tailwindcss": "^3.4.19",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.62.0",
@@ -161,6 +161,35 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/web/node_modules/postcss": {
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.17",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
         "libs/types": {
@@ -2947,9 +2976,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3028,9 +3057,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4466,9 +4495,9 @@
             "license": "MIT"
         },
         "node_modules/@jest/reporters/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6005,15 +6034,6 @@
                 "@prisma/debug": "6.19.3"
             }
         },
-        "node_modules/@remix-run/router": {
-            "version": "1.23.3",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-            "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-beta.27",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -6761,6 +6781,12 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/cookie": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+            "license": "MIT"
         },
         "node_modules/@types/cookiejar": {
             "version": "2.1.5",
@@ -8782,16 +8808,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -10364,9 +10390,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10802,9 +10828,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "dev": true,
             "funding": [
                 {
@@ -11058,9 +11084,9 @@
             "license": "MIT"
         },
         "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12555,9 +12581,9 @@
             "license": "MIT"
         },
         "node_modules/jest-config/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13796,9 +13822,9 @@
             "license": "MIT"
         },
         "node_modules/jest-runtime/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15811,9 +15837,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",
@@ -17298,36 +17324,63 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.30.4",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-            "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.0.tgz",
+            "integrity": "sha512-1xf+yMVhUjAzZGY90ZnYJ9KVe1R8FggpugzRBkh+p6vl4cC1sHDe3nO+r5rxWTAgCMf8uN5hfoV2M7rLVTWPUA==",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.3"
+                "@types/cookie": "^0.6.0",
+                "cookie": "^1.0.1",
+                "set-cookie-parser": "^2.6.0",
+                "turbo-stream": "2.4.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "react": ">=16.8"
+                "react": ">=18",
+                "react-dom": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.30.4",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-            "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.0.tgz",
+            "integrity": "sha512-2QAxXpwgQuh423C64oZiV2cCKPCNUgZxcvZaS8O0PAHPZ/z8kTq7YbGD4KTNZm6Yj66d+HAfGkWPp8MCpdtD+Q==",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.3",
-                "react-router": "6.30.4"
+                "react-router": "7.0.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8"
+                "react": ">=18",
+                "react-dom": ">=18"
             }
+        },
+        "node_modules/react-router/node_modules/cookie": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/react-router/node_modules/set-cookie-parser": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+            "license": "MIT"
         },
         "node_modules/read-cache": {
             "version": "1.0.0",
@@ -18738,9 +18791,9 @@
             "license": "MIT"
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19271,6 +19324,12 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "license": "0BSD"
+        },
+        "node_modules/turbo-stream": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+            "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+            "license": "ISC"
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "@nestjs/jwt": "^11.0.0",
                 "@nestjs/passport": "^11.0.5",
                 "@nestjs/platform-express": "^11.1.27",
-                "@nestjs/swagger": "^11.4.4",
+                "@nestjs/swagger": "11.4.5",
                 "@nestjs/throttler": "^6.4.0",
                 "@playa-plan/types": "file:../../libs/types",
                 "@prisma/client": "^6.19.3",
@@ -100,6 +100,39 @@
                 "tsconfig-paths": "^4.2.0"
             }
         },
+        "apps/api/node_modules/@nestjs/swagger": {
+            "version": "11.4.5",
+            "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.5.tgz",
+            "integrity": "sha512-lvndlJmWBVDOUT0uEtLi6sSpW1syK2/nbAlHBhiELBORMpJGe9+EiWAT9qHtB10jW91L2Jmlwkr0/lttsYZrig==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/tsdoc": "0.16.0",
+                "@nestjs/mapped-types": "2.1.1",
+                "js-yaml": "4.3.0",
+                "lodash": "4.18.1",
+                "path-to-regexp": "8.4.2",
+                "swagger-ui-dist": "5.32.8"
+            },
+            "peerDependencies": {
+                "@fastify/static": "^8.0.0 || ^9.0.0",
+                "@nestjs/common": "^11.0.1",
+                "@nestjs/core": "^11.0.1",
+                "class-transformer": "*",
+                "class-validator": "*",
+                "reflect-metadata": "^0.1.12 || ^0.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@fastify/static": {
+                    "optional": true
+                },
+                "class-transformer": {
+                    "optional": true
+                },
+                "class-validator": {
+                    "optional": true
+                }
+            }
+        },
         "apps/api/node_modules/keyv": {
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
@@ -124,7 +157,7 @@
                 "postcss-value-parser": "^4.2.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
-                "react-router-dom": "^7.0.0",
+                "react-router-dom": "^6.30.4",
                 "zod": "^3.25.76"
             },
             "devDependencies": {
@@ -163,33 +196,36 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "apps/web/node_modules/postcss": {
-            "version": "8.5.26",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
+        "apps/web/node_modules/react-router-dom": {
+            "version": "6.30.4",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+            "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.17",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
+                "@remix-run/router": "1.23.3",
+                "react-router": "6.30.4"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14"
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
+            }
+        },
+        "apps/web/node_modules/react-router-dom/node_modules/react-router": {
+            "version": "6.30.4",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+            "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+            "license": "MIT",
+            "dependencies": {
+                "@remix-run/router": "1.23.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8"
             }
         },
         "libs/types": {
@@ -3684,6 +3720,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3696,6 +3742,20 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -5531,39 +5591,6 @@
                 "tslib": "^2.1.0"
             }
         },
-        "node_modules/@nestjs/swagger": {
-            "version": "11.4.4",
-            "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.4.tgz",
-            "integrity": "sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==",
-            "license": "MIT",
-            "dependencies": {
-                "@microsoft/tsdoc": "0.16.0",
-                "@nestjs/mapped-types": "2.1.1",
-                "js-yaml": "4.1.1",
-                "lodash": "4.18.1",
-                "path-to-regexp": "8.4.2",
-                "swagger-ui-dist": "5.32.6"
-            },
-            "peerDependencies": {
-                "@fastify/static": "^8.0.0 || ^9.0.0",
-                "@nestjs/common": "^11.0.1",
-                "@nestjs/core": "^11.0.1",
-                "class-transformer": "*",
-                "class-validator": "*",
-                "reflect-metadata": "^0.1.12 || ^0.2.0"
-            },
-            "peerDependenciesMeta": {
-                "@fastify/static": {
-                    "optional": true
-                },
-                "class-transformer": {
-                    "optional": true
-                },
-                "class-validator": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@nestjs/testing": {
             "version": "11.1.27",
             "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.27.tgz",
@@ -6032,6 +6059,15 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "6.19.3"
+            }
+        },
+        "node_modules/@remix-run/router": {
+            "version": "1.23.3",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+            "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@rolldown/pluginutils": {
@@ -6781,12 +6817,6 @@
             "dependencies": {
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/cookie": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-            "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-            "license": "MIT"
         },
         "node_modules/@types/cookiejar": {
             "version": "2.1.5",
@@ -14626,9 +14656,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "funding": [
                 {
                     "type": "github",
@@ -16651,9 +16681,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -16670,7 +16700,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -17322,65 +17352,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/react-router": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.0.tgz",
-            "integrity": "sha512-1xf+yMVhUjAzZGY90ZnYJ9KVe1R8FggpugzRBkh+p6vl4cC1sHDe3nO+r5rxWTAgCMf8uN5hfoV2M7rLVTWPUA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/cookie": "^0.6.0",
-                "cookie": "^1.0.1",
-                "set-cookie-parser": "^2.6.0",
-                "turbo-stream": "2.4.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=18",
-                "react-dom": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "react-dom": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/react-router-dom": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.0.tgz",
-            "integrity": "sha512-2QAxXpwgQuh423C64oZiV2cCKPCNUgZxcvZaS8O0PAHPZ/z8kTq7YbGD4KTNZm6Yj66d+HAfGkWPp8MCpdtD+Q==",
-            "license": "MIT",
-            "dependencies": {
-                "react-router": "7.0.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=18",
-                "react-dom": ">=18"
-            }
-        },
-        "node_modules/react-router/node_modules/cookie": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/react-router/node_modules/set-cookie-parser": {
-            "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-            "license": "MIT"
         },
         "node_modules/read-cache": {
             "version": "1.0.0",
@@ -18073,6 +18044,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
         "node_modules/stable-hash-x": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -18396,9 +18374,9 @@
             }
         },
         "node_modules/swagger-ui-dist": {
-            "version": "5.32.6",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
-            "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+            "version": "5.32.8",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+            "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@scarf/scarf": "=1.4.0"
@@ -19324,12 +19302,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "license": "0BSD"
-        },
-        "node_modules/turbo-stream": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-            "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-            "license": "ISC"
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,10 @@
         "path-to-regexp@>=8.0.0": "8.4.2",
         "effect": "3.21.0",
         "multer": "2.2.0",
-        "js-yaml": "4.2.0",
+        "@nestjs/swagger@11.4.5": {
+            "js-yaml": "4.3.1"
+        },
+        "js-yaml": "4.3.1",
         "form-data": "4.0.6",
         "ws": "8.21.0"
     }


### PR DESCRIPTION
## Summary

Remediates the actionable npm vulnerabilities from [#222](https://github.com/ChrisRomp/playa-plan/pull/222) without taking the React Router 7 major upgrade during peak PlayaPlan usage.

### What it does

- Updates PostCSS, nanoid, fast-uri, and all installed brace-expansion lines to patched releases.
- Pins `@nestjs/swagger` to `11.4.5` and resolves its vulnerable js-yaml dependency to `4.3.1`.
- Keeps `react-router-dom@6.30.4` temporarily and adds a strict allowlist for the query-string `returnTo` navigation path.
- Removes redundant URL decoding before post-login navigation.

### Key changes

- `apps/web/src/utils/returnToUtils.ts`: rejects external URLs, schemes, backslashes, encoded separators, control characters, fragments, and unknown application routes.
- `apps/web/src/pages/LoginPage.tsx`: only passes validated internal destinations to `navigate()`.
- `package.json` / `package-lock.json`: resolves all non-deferred high-severity dependency findings.

### Security

`npm audit` now reports zero high or critical findings. The two remaining moderate findings are the intentionally deferred React Router 6 advisories. PlayaPlan uses declarative `HashRouter` mode without SSR/data-router hydration, and the only user-controlled navigation sink is now guarded.

Swagger currently hard-pins vulnerable `js-yaml@4.3.0`; the root override installs patched `4.3.1`. npm's tree display marks that intentional exact-version override as invalid, but clean `npm ci`, application builds, and both test suites complete successfully.

### Validation

- Web: 770 passed, 3 skipped
- API: 1,286 passed
- Lint passed
- Build passed
- Clean `npm ci` passed
