### PR TITLE
Add printable work schedule PDF

### DIFF
--- a/apps/api/src/reports/controllers/reports.controller.spec.ts
+++ b/apps/api/src/reports/controllers/reports.controller.spec.ts
@@ -3,13 +3,16 @@ import { UserRole } from '@prisma/client';
 import { Response } from 'express';
 import { AuthenticatedRequest } from '../../auth/types/safe-user';
 import { GenerateTicketReceiptReportDto } from '../dto/generate-ticket-receipt-report.dto';
+import { GenerateWorkScheduleReportDto } from '../dto/generate-work-schedule-report.dto';
 import { ReportConfigurationService } from '../services/report-configuration.service';
 import { TicketReceiptReportService } from '../services/ticket-receipt-report.service';
+import { WorkScheduleReportService } from '../services/work-schedule-report.service';
 import { ReportsController } from './reports.controller';
 
 describe('ReportsController', () => {
   const mockGetSettings = jest.fn();
-  const mockGenerate = jest.fn();
+  const mockGenerateTicketReceipt = jest.fn();
+  const mockGenerateWorkSchedule = jest.fn();
   const mockSetHeader = jest.fn();
   let controller: ReportsController;
 
@@ -20,8 +23,11 @@ describe('ReportsController', () => {
         getTicketReceiptSettings: mockGetSettings,
       } as unknown as ReportConfigurationService,
       {
-        generate: mockGenerate,
-      } as unknown as TicketReceiptReportService
+        generate: mockGenerateTicketReceipt,
+      } as unknown as TicketReceiptReportService,
+      {
+        generate: mockGenerateWorkSchedule,
+      } as unknown as WorkScheduleReportService
     );
   });
 
@@ -55,7 +61,7 @@ describe('ReportsController', () => {
     const inputResponse = {
       setHeader: mockSetHeader,
     } as unknown as Response;
-    mockGenerate.mockResolvedValue({
+    mockGenerateTicketReceipt.mockResolvedValue({
       buffer: Buffer.from('%PDF'),
       contentType: 'application/pdf',
       contentDisposition: 'attachment; filename="tickets.pdf"',
@@ -69,11 +75,37 @@ describe('ReportsController', () => {
     );
 
     expect(actualFile).toBeInstanceOf(StreamableFile);
-    expect(mockGenerate).toHaveBeenCalledWith('user-id', inputOptions);
+    expect(mockGenerateTicketReceipt).toHaveBeenCalledWith('user-id', inputOptions);
     expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
     expect(mockSetHeader).toHaveBeenCalledWith(
       'Content-Disposition',
       'attachment; filename="tickets.pdf"'
+    );
+  });
+
+  it('shouldReturnAWorkSchedulePdfWithSafeDownloadHeaders', async () => {
+    const inputOptions = new GenerateWorkScheduleReportDto();
+    const inputResponse = {
+      setHeader: mockSetHeader,
+    } as unknown as Response;
+    mockGenerateWorkSchedule.mockResolvedValue({
+      buffer: Buffer.from('%PDF'),
+      contentType: 'application/pdf',
+      contentDisposition: 'attachment; filename="work-schedule.pdf"',
+      filename: 'work-schedule.pdf',
+    });
+
+    const actualFile = await controller.generateWorkScheduleReport(
+      inputOptions,
+      inputResponse
+    );
+
+    expect(actualFile).toBeInstanceOf(StreamableFile);
+    expect(mockGenerateWorkSchedule).toHaveBeenCalledWith(inputOptions);
+    expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+    expect(mockSetHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="work-schedule.pdf"'
     );
   });
 });

--- a/apps/api/src/reports/controllers/reports.controller.ts
+++ b/apps/api/src/reports/controllers/reports.controller.ts
@@ -18,9 +18,11 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { AuthenticatedRequest } from '../../auth/types/safe-user';
 import { GenerateTicketReceiptReportDto } from '../dto/generate-ticket-receipt-report.dto';
+import { GenerateWorkScheduleReportDto } from '../dto/generate-work-schedule-report.dto';
 import { TicketReceiptSettingsDto } from '../dto/ticket-receipt-settings.dto';
 import { ReportConfigurationService } from '../services/report-configuration.service';
 import { TicketReceiptReportService } from '../services/ticket-receipt-report.service';
+import { WorkScheduleReportService } from '../services/work-schedule-report.service';
 
 /** Staff/admin endpoints for report configuration and generation. */
 @ApiTags('Reports')
@@ -31,7 +33,8 @@ import { TicketReceiptReportService } from '../services/ticket-receipt-report.se
 export class ReportsController {
   constructor(
     private readonly configurationService: ReportConfigurationService,
-    private readonly ticketReceiptReportService: TicketReceiptReportService
+    private readonly ticketReceiptReportService: TicketReceiptReportService,
+    private readonly workScheduleReportService: WorkScheduleReportService
   ) {}
 
   @Get('ticket-receipt/configuration')
@@ -53,6 +56,23 @@ export class ReportsController {
     @Res({ passthrough: true }) response: Response
   ): Promise<StreamableFile> {
     const download = await this.ticketReceiptReportService.generate(request.user.id, options);
+    response.setHeader('Content-Type', download.contentType);
+    response.setHeader('Content-Disposition', download.contentDisposition);
+
+    return new StreamableFile(download.buffer);
+  }
+
+  @Post('work-schedule')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Generate a printable work schedule' })
+  @ApiProduces('application/pdf')
+  @ApiResponse({ status: 200, description: 'Generated PDF report' })
+  @ApiResponse({ status: 404, description: 'No schedule matches the selected day' })
+  async generateWorkScheduleReport(
+    @Body() options: GenerateWorkScheduleReportDto,
+    @Res({ passthrough: true }) response: Response
+  ): Promise<StreamableFile> {
+    const download = await this.workScheduleReportService.generate(options);
     response.setHeader('Content-Type', download.contentType);
     response.setHeader('Content-Disposition', download.contentDisposition);
 

--- a/apps/api/src/reports/dto/generate-work-schedule-report.dto.spec.ts
+++ b/apps/api/src/reports/dto/generate-work-schedule-report.dto.spec.ts
@@ -1,0 +1,32 @@
+import { DayOfWeek } from '@prisma/client';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { GenerateWorkScheduleReportDto } from './generate-work-schedule-report.dto';
+
+describe('GenerateWorkScheduleReportDto', () => {
+  it('shouldAllowAnEmptyRequestForTheFullSchedule', async () => {
+    const inputDto = plainToInstance(GenerateWorkScheduleReportDto, {});
+
+    const actualErrors = await validate(inputDto);
+
+    expect(actualErrors).toHaveLength(0);
+  });
+
+  it('shouldAllowAValidDayFilter', async () => {
+    const inputDto = plainToInstance(GenerateWorkScheduleReportDto, {
+      dayOfWeek: DayOfWeek.CLOSING_SUNDAY,
+    });
+
+    const actualErrors = await validate(inputDto);
+
+    expect(actualErrors).toHaveLength(0);
+  });
+
+  it.each([null, 'SUNDAY', ''])('shouldRejectInvalidDayFilter%s', async dayOfWeek => {
+    const inputDto = plainToInstance(GenerateWorkScheduleReportDto, { dayOfWeek });
+
+    const actualErrors = await validate(inputDto);
+
+    expect(actualErrors.some(error => error.property === 'dayOfWeek')).toBe(true);
+  });
+});

--- a/apps/api/src/reports/dto/generate-work-schedule-report.dto.ts
+++ b/apps/api/src/reports/dto/generate-work-schedule-report.dto.ts
@@ -1,0 +1,14 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { DayOfWeek } from '@prisma/client';
+import { IsEnum, ValidateIf } from 'class-validator';
+
+/** Validated options for generating a printable work schedule. */
+export class GenerateWorkScheduleReportDto {
+  @ApiPropertyOptional({
+    description: 'Event day to include; omit to include the full schedule',
+    enum: DayOfWeek,
+  })
+  @ValidateIf((_object, value) => value !== undefined)
+  @IsEnum(DayOfWeek)
+  dayOfWeek?: DayOfWeek;
+}

--- a/apps/api/src/reports/models/work-schedule-report-data.ts
+++ b/apps/api/src/reports/models/work-schedule-report-data.ts
@@ -1,0 +1,7 @@
+import { WorkScheduleData } from '../../shifts/models/work-schedule-data';
+
+/** Configuration and schedule rows required by the work-schedule PDF builder. */
+export interface WorkScheduleReportData extends WorkScheduleData {
+  readonly campName: string;
+  readonly year: number;
+}

--- a/apps/api/src/reports/reports.module.ts
+++ b/apps/api/src/reports/reports.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from '../common/prisma/prisma.module';
 import { CoreConfigModule } from '../core-config/core-config.module';
+import { ShiftsModule } from '../shifts/shifts.module';
 import { ReportsController } from './controllers/reports.controller';
 import { PdfRenderer } from './models/pdf-renderer';
 import { PdfDownloadService } from './services/pdf-download.service';
@@ -9,10 +10,13 @@ import { ReportConfigurationService } from './services/report-configuration.serv
 import { TicketReceiptDataService } from './services/ticket-receipt-data.service';
 import { TicketReceiptDocumentService } from './services/ticket-receipt-document.service';
 import { TicketReceiptReportService } from './services/ticket-receipt-report.service';
+import { WorkScheduleDataService } from './services/work-schedule-data.service';
+import { WorkScheduleDocumentService } from './services/work-schedule-document.service';
+import { WorkScheduleReportService } from './services/work-schedule-report.service';
 
 /** Reusable PDF infrastructure and concrete PlayaPlan reports. */
 @Module({
-  imports: [PrismaModule, CoreConfigModule],
+  imports: [PrismaModule, CoreConfigModule, ShiftsModule],
   controllers: [ReportsController],
   providers: [
     PdfDownloadService,
@@ -21,6 +25,9 @@ import { TicketReceiptReportService } from './services/ticket-receipt-report.ser
     TicketReceiptDataService,
     TicketReceiptDocumentService,
     TicketReceiptReportService,
+    WorkScheduleDataService,
+    WorkScheduleDocumentService,
+    WorkScheduleReportService,
     {
       provide: PdfRenderer,
       useExisting: PdfmakeRendererService,

--- a/apps/api/src/reports/services/work-schedule-data.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-data.service.spec.ts
@@ -1,0 +1,32 @@
+import { DayOfWeek } from '@prisma/client';
+import { CoreConfigService } from '../../core-config/services/core-config.service';
+import { ShiftsService } from '../../shifts/shifts.service';
+import { GenerateWorkScheduleReportDto } from '../dto/generate-work-schedule-report.dto';
+import { WorkScheduleDataService } from './work-schedule-data.service';
+
+describe('WorkScheduleDataService', () => {
+  it('shouldUseConfiguredCampYearAndSelectedDay', async () => {
+    const mockGetWorkSchedule = jest.fn().mockResolvedValue({ shifts: [] });
+    const service = new WorkScheduleDataService(
+      { getWorkSchedule: mockGetWorkSchedule } as unknown as ShiftsService,
+      {
+        findCurrent: jest.fn().mockResolvedValue({
+          campName: 'Burning Sky',
+          registrationYear: 2026,
+        }),
+      } as unknown as CoreConfigService
+    );
+    const inputOptions = Object.assign(new GenerateWorkScheduleReportDto(), {
+      dayOfWeek: DayOfWeek.CLOSING_SUNDAY,
+    });
+
+    const actualData = await service.getReportData(inputOptions);
+
+    expect(mockGetWorkSchedule).toHaveBeenCalledWith(DayOfWeek.CLOSING_SUNDAY, 2026);
+    expect(actualData).toEqual({
+      campName: 'Burning Sky',
+      year: 2026,
+      shifts: [],
+    });
+  });
+});

--- a/apps/api/src/reports/services/work-schedule-data.service.ts
+++ b/apps/api/src/reports/services/work-schedule-data.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { CoreConfigService } from '../../core-config/services/core-config.service';
+import { ShiftsService } from '../../shifts/shifts.service';
+import { GenerateWorkScheduleReportDto } from '../dto/generate-work-schedule-report.dto';
+import { WorkScheduleReportData } from '../models/work-schedule-report-data';
+
+/** Selects configuration and ordered shift assignments for work-schedule reports. */
+@Injectable()
+export class WorkScheduleDataService {
+  constructor(
+    private readonly shiftsService: ShiftsService,
+    private readonly coreConfigService: CoreConfigService
+  ) {}
+
+  async getReportData(options: GenerateWorkScheduleReportDto): Promise<WorkScheduleReportData> {
+    const configuration = await this.coreConfigService.findCurrent();
+    const schedule = await this.shiftsService.getWorkSchedule(
+      options.dayOfWeek,
+      configuration.registrationYear
+    );
+
+    return {
+      campName: configuration.campName,
+      year: configuration.registrationYear,
+      shifts: schedule.shifts,
+    };
+  }
+}

--- a/apps/api/src/reports/services/work-schedule-document.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.spec.ts
@@ -52,9 +52,11 @@ describe('WorkScheduleDocumentService', () => {
     );
     const day = (actualDocument.content as Content[])[0] as ContentStack;
     const shift = day.stack[1] as ContentStack;
-    const jobHeading = shift.stack[1] as { text: string };
-    const roster = shift.stack[2] as { ol: string[]; start: number };
+    const job = shift.stack[1] as ContentStack;
+    const jobHeading = job.stack[0] as { text: string };
+    const roster = job.stack[1] as { ol: string[]; start: number };
 
+    expect(job.unbreakable).toBe(true);
     expect(jobHeading.text).toBe('Teardown');
     expect(roster.ol).toHaveLength(7);
     expect(roster.ol).not.toContain(' ');
@@ -155,12 +157,14 @@ describe('WorkScheduleDocumentService', () => {
     );
     const day = (actualDocument.content as Content[])[0] as ContentStack;
     const columns = day.stack[1] as ContentColumns;
+    const leftJob = (columns.columns[0] as ContentStack).stack[1] as ContentStack;
+    const rightJob = (columns.columns[1] as ContentStack).stack[1] as ContentStack;
 
     expect(columns.columns).toHaveLength(2);
-    expect((columns.columns[0] as ContentStack).stack[2]).toEqual(
+    expect(leftJob.stack[1]).toEqual(
       expect.objectContaining({ ol: expect.any(Array), start: 1 })
     );
-    expect((columns.columns[1] as ContentStack).stack[2]).toEqual(
+    expect(rightJob.stack[1]).toEqual(
       expect.objectContaining({ ol: expect.any(Array), start: 1 })
     );
   });
@@ -184,10 +188,11 @@ describe('WorkScheduleDocumentService', () => {
     );
     const day = (actualDocument.content as Content[])[0] as ContentStack;
     const shift = day.stack[1] as ContentStack;
-    const smallJob = shift.stack[3] as ContentStack;
+    const largeJob = shift.stack[1] as ContentStack;
+    const smallJob = shift.stack[2] as ContentStack;
 
-    expect(shift.stack[1]).toEqual(expect.objectContaining({ text: 'Teardown' }));
-    expect(shift.stack[2]).toEqual(
+    expect(largeJob.stack[0]).toEqual(expect.objectContaining({ text: 'Teardown' }));
+    expect(largeJob.stack[1]).toEqual(
       expect.objectContaining({ ol: expect.any(Array), start: 1 })
     );
     expect(smallJob.stack[0]).toEqual(expect.objectContaining({ text: 'Cleanup' }));
@@ -251,6 +256,38 @@ describe('WorkScheduleDocumentService', () => {
     expect(day.stack).toHaveLength(3);
   });
 
+  it('shouldLetWrappedPageSizedRostersFlowAcrossPages', () => {
+    const inputShift = createShift('teardown', 22, 50);
+    const inputJob = inputShift.jobs[0];
+    const actualDocument = service.build(
+      createReportData([
+        {
+          ...inputShift,
+          jobs: [
+            {
+              ...inputJob,
+              registrations: inputJob.registrations.map(registration => ({
+                ...registration,
+                user: {
+                  ...registration.user,
+                  firstName: 'Extraordinarily Long Worker First Name',
+                  lastName: 'Extraordinarily Long Worker Last Name',
+                },
+              })),
+            },
+          ],
+        },
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+
+    expect(shift.stack[1]).toEqual(expect.objectContaining({ text: 'Teardown' }));
+    expect(shift.stack[2]).toEqual(
+      expect.objectContaining({ ol: expect.any(Array), start: 1 })
+    );
+  });
+
   it('shouldNotPairShiftsWhenWorkerNamesWrapAcrossLines', () => {
     const inputShift = createShift('morning', 22, 50);
     const inputJob = inputShift.jobs[0];
@@ -306,6 +343,38 @@ describe('WorkScheduleDocumentService', () => {
     expect(rightHeading.text).toBe('Teardown (continued)');
     expect(right.ol).toHaveLength(25);
     expect(right.start).toBe(26);
+  });
+
+  it('shouldNotSplitWrappedRostersIntoFixedColumns', () => {
+    const inputShift = createShift('teardown', 50, 60);
+    const inputJob = inputShift.jobs[0];
+    const actualDocument = service.build(
+      createReportData([
+        {
+          ...inputShift,
+          jobs: [
+            {
+              ...inputJob,
+              registrations: inputJob.registrations.map(registration => ({
+                ...registration,
+                user: {
+                  ...registration.user,
+                  firstName: 'Extraordinarily Long Worker First Name',
+                  lastName: 'Extraordinarily Long Worker Last Name',
+                },
+              })),
+            },
+          ],
+        },
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+    const roster = shift.stack[2] as { ol: string[]; start: number };
+
+    expect(shift.stack[1]).toEqual(expect.objectContaining({ text: 'Teardown' }));
+    expect(roster.ol).toHaveLength(50);
+    expect(roster.start).toBe(1);
   });
 
   it('shouldLetRostersLargerThanTwoColumnsFlowAcrossPages', () => {

--- a/apps/api/src/reports/services/work-schedule-document.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.spec.ts
@@ -18,10 +18,17 @@ describe('WorkScheduleDocumentService', () => {
 
     expect(actualDocument.pageOrientation).toBe('portrait');
     expect(actualDocument.info?.title).toBe('Burning Sky Work Schedule 2026');
+    expect(actualDocument.styles?.shiftHeading).toEqual(
+      expect.objectContaining({ margin: [18, 0, 0, 5] })
+    );
+    expect(actualDocument.styles?.jobHeading).toEqual(
+      expect.objectContaining({ margin: [30, 0, 0, 2] })
+    );
+    expect(roster).toEqual(expect.objectContaining({ margin: [44, 0, 0, 7] }));
     expect(roster.ul).toEqual(['Worker 1 Last 1 (Playa 1)', ' ', ' ']);
   });
 
-  it('shouldSwitchToAnAssignedOnlyNumberedRosterAtTenWorkers', () => {
+  it('shouldKeepTenWorkersInBulletedCapacityFormatting', () => {
     const actualDocument = service.build(
       createReportData([
         createShift('teardown', 10, 20),
@@ -29,9 +36,25 @@ describe('WorkScheduleDocumentService', () => {
     );
     const day = (actualDocument.content as Content[])[0] as ContentStack;
     const shift = day.stack[1] as ContentStack;
-    const roster = shift.stack[1] as { ol: string[]; start: number };
+    const roster = shift.stack[2] as { ul: string[] };
 
-    expect(roster.ol).toHaveLength(10);
+    expect(roster.ul).toHaveLength(20);
+    expect(roster.ul.filter(worker => worker === ' ')).toHaveLength(10);
+  });
+
+  it('shouldSwitchToAnAssignedOnlyNumberedRosterAboveTenWorkers', () => {
+    const actualDocument = service.build(
+      createReportData([
+        createShift('teardown', 11, 20),
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+    const jobHeading = shift.stack[1] as { text: string };
+    const roster = shift.stack[2] as { ol: string[]; start: number };
+
+    expect(jobHeading.text).toBe('Teardown');
+    expect(roster.ol).toHaveLength(11);
     expect(roster.ol).not.toContain(' ');
     expect(roster.start).toBe(1);
   });
@@ -47,11 +70,41 @@ describe('WorkScheduleDocumentService', () => {
     const columns = day.stack[1] as ContentColumns;
 
     expect(columns.columns).toHaveLength(2);
-    expect((columns.columns[0] as ContentStack).stack[1]).toEqual(
+    expect((columns.columns[0] as ContentStack).stack[2]).toEqual(
       expect.objectContaining({ ol: expect.any(Array), start: 1 })
     );
-    expect((columns.columns[1] as ContentStack).stack[1]).toEqual(
+    expect((columns.columns[1] as ContentStack).stack[2]).toEqual(
       expect.objectContaining({ ol: expect.any(Array), start: 1 })
+    );
+  });
+
+  it('shouldRetainJobHeadingsAndContinuousNumberingForLargeMultiJobShifts', () => {
+    const inputShift = createShift('teardown', 6, 10);
+    const inputSecondJob = createShift('cleanup', 6, 10).jobs[0];
+    const actualDocument = service.build(
+      createReportData([
+        {
+          ...inputShift,
+          jobs: [
+            inputShift.jobs[0],
+            {
+              ...inputSecondJob,
+              name: 'Cleanup',
+            },
+          ],
+        },
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+
+    expect(shift.stack[1]).toEqual(expect.objectContaining({ text: 'Teardown' }));
+    expect(shift.stack[2]).toEqual(
+      expect.objectContaining({ ol: expect.any(Array), start: 1 })
+    );
+    expect(shift.stack[3]).toEqual(expect.objectContaining({ text: 'Cleanup' }));
+    expect(shift.stack[4]).toEqual(
+      expect.objectContaining({ ol: expect.any(Array), start: 7 })
     );
   });
 
@@ -64,17 +117,21 @@ describe('WorkScheduleDocumentService', () => {
     const day = (actualDocument.content as Content[])[0] as ContentStack;
     const shift = day.stack[1] as ContentStack;
     const columns = shift.stack[1] as ContentColumns;
-    const left = (columns.columns[0] as ContentStack).stack[0] as {
+    const left = (columns.columns[0] as ContentStack).stack[1] as {
       ol: string[];
       start: number;
     };
-    const right = (columns.columns[1] as ContentStack).stack[0] as {
+    const rightHeading = (columns.columns[1] as ContentStack).stack[0] as {
+      text: string;
+    };
+    const right = (columns.columns[1] as ContentStack).stack[1] as {
       ol: string[];
       start: number;
     };
 
     expect(left.ol).toHaveLength(25);
     expect(left.start).toBe(1);
+    expect(rightHeading.text).toBe('Teardown (continued)');
     expect(right.ol).toHaveLength(25);
     expect(right.start).toBe(26);
   });

--- a/apps/api/src/reports/services/work-schedule-document.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.spec.ts
@@ -117,6 +117,19 @@ describe('WorkScheduleDocumentService', () => {
     expect(jobs.every(job => job.unbreakable === true)).toBe(true);
   });
 
+  it('shouldAllowOverCapacitySmallJobsToFlowAcrossPages', () => {
+    const actualDocument = service.build(
+      createReportData([createShift('waitlisted', 50, 10)])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+    const job = shift.stack[1] as ContentStack;
+    const roster = job.stack[1] as { ul: string[] };
+
+    expect(job.unbreakable).toBeUndefined();
+    expect(roster.ul).toHaveLength(50);
+  });
+
   it('shouldPreserveTheSuppliedShiftOrderAcrossSmallAndLargeJobs', () => {
     const actualDocument = service.build(
       createReportData([

--- a/apps/api/src/reports/services/work-schedule-document.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.spec.ts
@@ -1,10 +1,12 @@
 import { DayOfWeek } from '@prisma/client';
 import { Content, ContentColumns, ContentStack } from 'pdfmake/interfaces';
 import { WorkScheduleReportData } from '../models/work-schedule-report-data';
+import { PdfmakeRendererService } from './pdfmake-renderer.service';
 import { WorkScheduleDocumentService } from './work-schedule-document.service';
 
 describe('WorkScheduleDocumentService', () => {
   const service = new WorkScheduleDocumentService();
+  const renderer = new PdfmakeRendererService();
 
   it('shouldRenderSmallJobsWithAssignedAndVacantBulletSlots', () => {
     const actualDocument = service.build(
@@ -317,6 +319,18 @@ describe('WorkScheduleDocumentService', () => {
     expect(day.stack).toHaveLength(3);
   });
 
+  it('shouldNotNestSplitRostersInsideSideBySideShifts', () => {
+    const actualDocument = service.build(
+      createReportData([
+        createShift('morning', 43, 50),
+        createShift('afternoon', 43, 50),
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+
+    expect(day.stack).toHaveLength(3);
+  });
+
   it('shouldSplitAnOversizedRosterIntoContinuouslyNumberedColumns', () => {
     const actualDocument = service.build(
       createReportData([
@@ -377,7 +391,7 @@ describe('WorkScheduleDocumentService', () => {
     expect(roster.start).toBe(1);
   });
 
-  it('shouldLetRostersLargerThanTwoColumnsFlowAcrossPages', () => {
+  it('shouldRenderRostersLargerThanTwoColumnsAcrossPages', async () => {
     const actualDocument = service.build(
       createReportData([
         createShift('teardown', 85, 100),
@@ -391,6 +405,12 @@ describe('WorkScheduleDocumentService', () => {
     expect(jobHeading.text).toBe('Teardown');
     expect(roster.ol).toHaveLength(85);
     expect(roster.start).toBe(1);
+    expect(roster.ol.at(-1)).toBe('Worker 85 Last 85 (Playa 85)');
+
+    const actualPdf = await renderer.render(actualDocument);
+    const actualPageCount =
+      actualPdf.toString('latin1').match(/\/Type\s*\/Page\b/g)?.length ?? 0;
+    expect(actualPageCount).toBeGreaterThan(1);
   });
 
   function createReportData(

--- a/apps/api/src/reports/services/work-schedule-document.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.spec.ts
@@ -28,24 +28,24 @@ describe('WorkScheduleDocumentService', () => {
     expect(roster.ul).toEqual(['Worker 1 Last 1 (Playa 1)', ' ', ' ']);
   });
 
-  it('shouldKeepTenWorkersInBulletedCapacityFormatting', () => {
+  it('shouldKeepTenCapacitySlotsInBulletedCapacityFormatting', () => {
     const actualDocument = service.build(
       createReportData([
-        createShift('teardown', 10, 20),
+        createShift('teardown', 6, 10),
       ])
     );
     const day = (actualDocument.content as Content[])[0] as ContentStack;
     const shift = day.stack[1] as ContentStack;
     const roster = shift.stack[2] as { ul: string[] };
 
-    expect(roster.ul).toHaveLength(20);
-    expect(roster.ul.filter(worker => worker === ' ')).toHaveLength(10);
+    expect(roster.ul).toHaveLength(10);
+    expect(roster.ul.filter(worker => worker === ' ')).toHaveLength(4);
   });
 
-  it('shouldSwitchToAnAssignedOnlyNumberedRosterAboveTenWorkers', () => {
+  it('shouldSwitchToAnAssignedOnlyNumberedRosterAboveTenCapacitySlots', () => {
     const actualDocument = service.build(
       createReportData([
-        createShift('teardown', 11, 20),
+        createShift('teardown', 7, 50),
       ])
     );
     const day = (actualDocument.content as Content[])[0] as ContentStack;
@@ -54,7 +54,7 @@ describe('WorkScheduleDocumentService', () => {
     const roster = shift.stack[2] as { ol: string[]; start: number };
 
     expect(jobHeading.text).toBe('Teardown');
-    expect(roster.ol).toHaveLength(11);
+    expect(roster.ol).toHaveLength(7);
     expect(roster.ol).not.toContain(' ');
     expect(roster.start).toBe(1);
   });

--- a/apps/api/src/reports/services/work-schedule-document.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.spec.ts
@@ -1,0 +1,124 @@
+import { DayOfWeek } from '@prisma/client';
+import { Content, ContentColumns, ContentStack } from 'pdfmake/interfaces';
+import { WorkScheduleReportData } from '../models/work-schedule-report-data';
+import { WorkScheduleDocumentService } from './work-schedule-document.service';
+
+describe('WorkScheduleDocumentService', () => {
+  const service = new WorkScheduleDocumentService();
+
+  it('shouldRenderSmallJobsWithAssignedAndVacantBulletSlots', () => {
+    const actualDocument = service.build(
+      createReportData([
+        createShift('morning', 1, 3),
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+    const roster = shift.stack[2] as { ul: string[] };
+
+    expect(actualDocument.pageOrientation).toBe('portrait');
+    expect(actualDocument.info?.title).toBe('Burning Sky Work Schedule 2026');
+    expect(roster.ul).toEqual(['Worker 1 Last 1 (Playa 1)', ' ', ' ']);
+  });
+
+  it('shouldSwitchToAnAssignedOnlyNumberedRosterAtTenWorkers', () => {
+    const actualDocument = service.build(
+      createReportData([
+        createShift('teardown', 10, 20),
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+    const roster = shift.stack[1] as { ol: string[]; start: number };
+
+    expect(roster.ol).toHaveLength(10);
+    expect(roster.ol).not.toContain(' ');
+    expect(roster.start).toBe(1);
+  });
+
+  it('shouldPlaceTwoLargeShiftsSideBySideWhenEachFitsAColumn', () => {
+    const actualDocument = service.build(
+      createReportData([
+        createShift('morning', 40, 50),
+        createShift('afternoon', 16, 20),
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const columns = day.stack[1] as ContentColumns;
+
+    expect(columns.columns).toHaveLength(2);
+    expect((columns.columns[0] as ContentStack).stack[1]).toEqual(
+      expect.objectContaining({ ol: expect.any(Array), start: 1 })
+    );
+    expect((columns.columns[1] as ContentStack).stack[1]).toEqual(
+      expect.objectContaining({ ol: expect.any(Array), start: 1 })
+    );
+  });
+
+  it('shouldSplitAnOversizedRosterIntoContinuouslyNumberedColumns', () => {
+    const actualDocument = service.build(
+      createReportData([
+        createShift('teardown', 50, 60),
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+    const columns = shift.stack[1] as ContentColumns;
+    const left = (columns.columns[0] as ContentStack).stack[0] as {
+      ol: string[];
+      start: number;
+    };
+    const right = (columns.columns[1] as ContentStack).stack[0] as {
+      ol: string[];
+      start: number;
+    };
+
+    expect(left.ol).toHaveLength(25);
+    expect(left.start).toBe(1);
+    expect(right.ol).toHaveLength(25);
+    expect(right.start).toBe(26);
+  });
+
+  function createReportData(
+    shifts: WorkScheduleReportData['shifts']
+  ): WorkScheduleReportData {
+    return {
+      campName: 'Burning Sky',
+      year: 2026,
+      shifts,
+    };
+  }
+
+  function createShift(
+    id: string,
+    workerCount: number,
+    maxRegistrations: number
+  ): WorkScheduleReportData['shifts'][number] {
+    return {
+      id,
+      name: id === 'afternoon' ? 'Sunday PM' : 'Sunday AM',
+      dayOfWeek: DayOfWeek.CLOSING_SUNDAY,
+      startTime: id === 'afternoon' ? '15:00' : '10:00',
+      endTime: id === 'afternoon' ? '18:00' : '13:00',
+      jobs: [
+        {
+          id: `${id}-job`,
+          name: 'Teardown',
+          location: 'Camp',
+          maxRegistrations,
+          categoryId: 'category',
+          category: { id: 'category', name: 'Operations' },
+          registrations: Array.from({ length: workerCount }, (_, index) => ({
+            id: `${id}-registration-${index + 1}`,
+            user: {
+              id: `${id}-user-${index + 1}`,
+              firstName: `Worker ${index + 1}`,
+              lastName: `Last ${index + 1}`,
+              playaName: `Playa ${index + 1}`,
+            },
+          })),
+        },
+      ],
+    };
+  }
+});

--- a/apps/api/src/reports/services/work-schedule-document.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.spec.ts
@@ -14,7 +14,8 @@ describe('WorkScheduleDocumentService', () => {
     );
     const day = (actualDocument.content as Content[])[0] as ContentStack;
     const shift = day.stack[1] as ContentStack;
-    const roster = shift.stack[2] as { ul: string[] };
+    const job = shift.stack[1] as ContentStack;
+    const roster = job.stack[1] as { ul: string[] };
 
     expect(actualDocument.pageOrientation).toBe('portrait');
     expect(actualDocument.info?.title).toBe('Burning Sky Work Schedule 2026');
@@ -36,7 +37,8 @@ describe('WorkScheduleDocumentService', () => {
     );
     const day = (actualDocument.content as Content[])[0] as ContentStack;
     const shift = day.stack[1] as ContentStack;
-    const roster = shift.stack[2] as { ul: string[] };
+    const job = shift.stack[1] as ContentStack;
+    const roster = job.stack[1] as { ul: string[] };
 
     expect(roster.ul).toHaveLength(10);
     expect(roster.ul.filter(worker => worker === ' ')).toHaveLength(4);
@@ -78,12 +80,37 @@ describe('WorkScheduleDocumentService', () => {
     );
     const day = (actualDocument.content as Content[])[0] as ContentStack;
     const shift = day.stack[1] as ContentStack;
-    const firstRoster = shift.stack[2] as { ul: string[] };
-    const secondRoster = shift.stack[4] as { ul: string[] };
+    const firstJob = shift.stack[1] as ContentStack;
+    const secondJob = shift.stack[2] as ContentStack;
+    const firstRoster = firstJob.stack[1] as { ul: string[] };
+    const secondRoster = secondJob.stack[1] as { ul: string[] };
 
     expect(firstRoster.ul).toEqual([' ', ' ', ' ', ' ']);
     expect(secondRoster.ul).toHaveLength(7);
     expect(secondRoster.ul.filter(worker => worker === ' ')).toHaveLength(5);
+  });
+
+  it('shouldAllowSmallShiftsToBreakBetweenJobs', () => {
+    const inputShift = createShift('wednesday-am', 0, 10);
+    const actualDocument = service.build(
+      createReportData([
+        {
+          ...inputShift,
+          jobs: Array.from({ length: 6 }, (_, index) => ({
+            ...inputShift.jobs[0],
+            id: `job-${index + 1}`,
+            name: `Job ${index + 1}`,
+          })),
+        },
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+    const jobs = shift.stack.slice(1) as ContentStack[];
+
+    expect(shift.unbreakable).toBeUndefined();
+    expect(jobs).toHaveLength(6);
+    expect(jobs.every(job => job.unbreakable === true)).toBe(true);
   });
 
   it('shouldPreserveTheSuppliedShiftOrderAcrossSmallAndLargeJobs', () => {
@@ -157,16 +184,47 @@ describe('WorkScheduleDocumentService', () => {
     );
     const day = (actualDocument.content as Content[])[0] as ContentStack;
     const shift = day.stack[1] as ContentStack;
+    const smallJob = shift.stack[3] as ContentStack;
 
     expect(shift.stack[1]).toEqual(expect.objectContaining({ text: 'Teardown' }));
     expect(shift.stack[2]).toEqual(
       expect.objectContaining({ ol: expect.any(Array), start: 1 })
     );
-    expect(shift.stack[3]).toEqual(expect.objectContaining({ text: 'Cleanup' }));
-    expect(shift.stack[4]).toEqual(
+    expect(smallJob.stack[0]).toEqual(expect.objectContaining({ text: 'Cleanup' }));
+    expect(smallJob.stack[1]).toEqual(
       expect.objectContaining({ ul: expect.any(Array) })
     );
-    expect((shift.stack[4] as { ul: string[] }).ul).toHaveLength(3);
+    expect((smallJob.stack[1] as { ul: string[] }).ul).toHaveLength(3);
+  });
+
+  it('shouldNotPairShiftsWhenVacantSlotsWouldOverflowAColumn', () => {
+    const inputShift = createShift('morning', 1, 50);
+    const inputSmallJob = createShift('small', 0, 10).jobs[0];
+    const actualDocument = service.build(
+      createReportData([
+        {
+          ...inputShift,
+          jobs: [
+            inputShift.jobs[0],
+            ...Array.from({ length: 5 }, (_, index) => ({
+              ...inputSmallJob,
+              id: `small-job-${index + 1}`,
+              name: `Small Job ${index + 1}`,
+            })),
+          ],
+        },
+        createShift('afternoon', 16, 20),
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+
+    expect(day.stack).toHaveLength(3);
+    expect((day.stack[1] as ContentStack).stack[0]).toEqual(
+      expect.objectContaining({ text: 'Sunday AM - 10:00 - 13:00' })
+    );
+    expect((day.stack[2] as ContentStack).stack[0]).toEqual(
+      expect.objectContaining({ text: 'Sunday PM - 15:00 - 18:00' })
+    );
   });
 
   it('shouldSplitAnOversizedRosterIntoContinuouslyNumberedColumns', () => {
@@ -195,6 +253,22 @@ describe('WorkScheduleDocumentService', () => {
     expect(rightHeading.text).toBe('Teardown (continued)');
     expect(right.ol).toHaveLength(25);
     expect(right.start).toBe(26);
+  });
+
+  it('shouldLetRostersLargerThanTwoColumnsFlowAcrossPages', () => {
+    const actualDocument = service.build(
+      createReportData([
+        createShift('teardown', 85, 100),
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+    const jobHeading = shift.stack[1] as { text: string };
+    const roster = shift.stack[2] as { ol: string[]; start: number };
+
+    expect(jobHeading.text).toBe('Teardown');
+    expect(roster.ol).toHaveLength(85);
+    expect(roster.start).toBe(1);
   });
 
   function createReportData(

--- a/apps/api/src/reports/services/work-schedule-document.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.spec.ts
@@ -59,6 +59,66 @@ describe('WorkScheduleDocumentService', () => {
     expect(roster.start).toBe(1);
   });
 
+  it('shouldApplyTheThresholdToEachJobInsteadOfTotalShiftCapacity', () => {
+    const inputShift = createShift('wednesday-am', 0, 4);
+    const inputSecondJob = createShift('art-car', 2, 7).jobs[0];
+    const actualDocument = service.build(
+      createReportData([
+        {
+          ...inputShift,
+          jobs: [
+            inputShift.jobs[0],
+            {
+              ...inputSecondJob,
+              name: 'Art Car',
+            },
+          ],
+        },
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shift = day.stack[1] as ContentStack;
+    const firstRoster = shift.stack[2] as { ul: string[] };
+    const secondRoster = shift.stack[4] as { ul: string[] };
+
+    expect(firstRoster.ul).toEqual([' ', ' ', ' ', ' ']);
+    expect(secondRoster.ul).toHaveLength(7);
+    expect(secondRoster.ul.filter(worker => worker === ' ')).toHaveLength(5);
+  });
+
+  it('shouldPreserveTheSuppliedShiftOrderAcrossSmallAndLargeJobs', () => {
+    const actualDocument = service.build(
+      createReportData([
+        {
+          ...createShift('full', 0, 1),
+          name: 'Wednesday Full',
+          startTime: '09:00',
+        },
+        {
+          ...createShift('am', 7, 50),
+          name: 'Wednesday AM',
+          startTime: '09:30',
+        },
+        {
+          ...createShift('afternoon', 0, 1),
+          name: 'Wednesday PM',
+          startTime: '14:00',
+        },
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+    const shiftHeadings = day.stack.slice(1).map(content => {
+      const shift = content as ContentStack;
+      return (shift.stack[0] as { text: string }).text;
+    });
+
+    expect(shiftHeadings).toEqual([
+      'Wednesday Full - 09:00 - 13:00',
+      'Wednesday AM - 09:30 - 13:00',
+      'Wednesday PM - 14:00 - 18:00',
+    ]);
+  });
+
   it('shouldPlaceTwoLargeShiftsSideBySideWhenEachFitsAColumn', () => {
     const actualDocument = service.build(
       createReportData([
@@ -78,9 +138,9 @@ describe('WorkScheduleDocumentService', () => {
     );
   });
 
-  it('shouldRetainJobHeadingsAndContinuousNumberingForLargeMultiJobShifts', () => {
-    const inputShift = createShift('teardown', 6, 10);
-    const inputSecondJob = createShift('cleanup', 6, 10).jobs[0];
+  it('shouldFormatLargeAndSmallJobsIndependentlyWithinOneShift', () => {
+    const inputShift = createShift('teardown', 6, 50);
+    const inputSecondJob = createShift('cleanup', 1, 3).jobs[0];
     const actualDocument = service.build(
       createReportData([
         {
@@ -104,8 +164,9 @@ describe('WorkScheduleDocumentService', () => {
     );
     expect(shift.stack[3]).toEqual(expect.objectContaining({ text: 'Cleanup' }));
     expect(shift.stack[4]).toEqual(
-      expect.objectContaining({ ol: expect.any(Array), start: 7 })
+      expect.objectContaining({ ul: expect.any(Array) })
     );
+    expect((shift.stack[4] as { ul: string[] }).ul).toHaveLength(3);
   });
 
   it('shouldSplitAnOversizedRosterIntoContinuouslyNumberedColumns', () => {

--- a/apps/api/src/reports/services/work-schedule-document.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.spec.ts
@@ -227,6 +227,59 @@ describe('WorkScheduleDocumentService', () => {
     );
   });
 
+  it('shouldNotPairShiftsWhenJobHeadingsWouldOverflowAColumn', () => {
+    const inputShift = createShift('morning', 0, 50);
+    const inputEmptyJob = createShift('empty', 0, 0).jobs[0];
+    const actualDocument = service.build(
+      createReportData([
+        {
+          ...inputShift,
+          jobs: [
+            inputShift.jobs[0],
+            ...Array.from({ length: 22 }, (_, index) => ({
+              ...inputEmptyJob,
+              id: `empty-job-${index + 1}`,
+              name: `Empty Job ${index + 1}`,
+            })),
+          ],
+        },
+        createShift('afternoon', 16, 20),
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+
+    expect(day.stack).toHaveLength(3);
+  });
+
+  it('shouldNotPairShiftsWhenWorkerNamesWrapAcrossLines', () => {
+    const inputShift = createShift('morning', 22, 50);
+    const inputJob = inputShift.jobs[0];
+    const actualDocument = service.build(
+      createReportData([
+        {
+          ...inputShift,
+          jobs: [
+            {
+              ...inputJob,
+              registrations: inputJob.registrations.map(registration => ({
+                ...registration,
+                user: {
+                  ...registration.user,
+                  firstName: 'Extraordinarily Long Worker First Name',
+                  lastName: 'Extraordinarily Long Worker Last Name',
+                },
+              })),
+            },
+          ],
+        },
+        createShift('afternoon', 16, 20),
+      ])
+    );
+    const day = (actualDocument.content as Content[])[0] as ContentStack;
+
+    expect(day.stack).toHaveLength(3);
+  });
+
   it('shouldSplitAnOversizedRosterIntoContinuouslyNumberedColumns', () => {
     const actualDocument = service.build(
       createReportData([

--- a/apps/api/src/reports/services/work-schedule-document.service.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.ts
@@ -125,23 +125,19 @@ export class WorkScheduleDocumentService {
       nextShift !== undefined &&
       this.isLargeShift(shift) &&
       this.isLargeShift(nextShift) &&
-      this.getAssignedWorkers(shift).length <= MAX_ROSTER_ITEMS_PER_COLUMN &&
-      this.getAssignedWorkers(nextShift).length <= MAX_ROSTER_ITEMS_PER_COLUMN
+      this.getRenderedRosterItemCount(shift) <= MAX_ROSTER_ITEMS_PER_COLUMN &&
+      this.getRenderedRosterItemCount(nextShift) <= MAX_ROSTER_ITEMS_PER_COLUMN
     );
   }
 
   private buildSmallShift(shift: ScheduleShift): ContentStack {
     return {
-      stack: [
-        this.buildShiftHeading(shift),
-        ...shift.jobs.flatMap(job => this.buildSmallJob(job)),
-      ],
+      stack: [this.buildShiftHeading(shift), ...shift.jobs.map(job => this.buildSmallJob(job))],
       margin: [0, 0, 0, 10],
-      unbreakable: true,
     };
   }
 
-  private buildSmallJob(job: ScheduleJob): Content[] {
+  private buildSmallJob(job: ScheduleJob): ContentStack {
     const assignedWorkers = job.registrations.map(registration =>
       this.formatUserName(registration.user)
     );
@@ -151,17 +147,20 @@ export class WorkScheduleDocumentService {
       ...Array.from({ length: vacancyCount }, () => ' '),
     ];
 
-    return [
-      this.buildJobHeading(job),
-      ...(slots.length > 0
-        ? [
-            {
-              ul: slots,
-              margin: [ROSTER_INDENT, 0, 0, 7],
-            } as Content,
-          ]
-        : []),
-    ];
+    return {
+      stack: [
+        this.buildJobHeading(job),
+        ...(slots.length > 0
+          ? [
+              {
+                ul: slots,
+                margin: [ROSTER_INDENT, 0, 0, 7],
+              } as Content,
+            ]
+          : []),
+      ],
+      unbreakable: true,
+    };
   }
 
   private buildSideBySideLargeShifts(
@@ -197,12 +196,18 @@ export class WorkScheduleDocumentService {
 
   private buildShiftJobs(shift: ScheduleShift): Content[] {
     return shift.jobs.flatMap(job =>
-      this.isLargeJob(job) ? this.buildLargeJob(job) : this.buildSmallJob(job)
+      this.isLargeJob(job) ? this.buildLargeJob(job) : [this.buildSmallJob(job)]
     );
   }
 
   private buildLargeJob(job: ScheduleJob): Content[] {
     const workers = this.getAssignedWorkerNames(job);
+    if (workers.length > MAX_ROSTER_ITEMS_PER_COLUMN * 2) {
+      return [
+        this.buildJobHeading(job),
+        this.buildNumberedRoster(workers, 1),
+      ];
+    }
     if (workers.length > MAX_ROSTER_ITEMS_PER_COLUMN) {
       return [this.buildSplitLargeJob(job, workers)];
     }
@@ -269,8 +274,14 @@ export class WorkScheduleDocumentService {
     return job.maxRegistrations > MAX_BULLETED_SHIFT_CAPACITY;
   }
 
-  private getAssignedWorkers(shift: ScheduleShift): string[] {
-    return shift.jobs.flatMap(job => this.getAssignedWorkerNames(job));
+  private getRenderedRosterItemCount(shift: ScheduleShift): number {
+    return shift.jobs.reduce((count, job) => {
+      const assignedCount = job.registrations.length;
+      const rosterItemCount = this.isLargeJob(job)
+        ? assignedCount
+        : Math.max(job.maxRegistrations, assignedCount);
+      return count + rosterItemCount;
+    }, 0);
   }
 
   private getAssignedWorkerNames(job: ScheduleJob): string[] {

--- a/apps/api/src/reports/services/work-schedule-document.service.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.ts
@@ -3,7 +3,7 @@ import { DayOfWeek } from '@prisma/client';
 import { Content, ContentColumns, ContentStack, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { WorkScheduleReportData } from '../models/work-schedule-report-data';
 
-const MAX_BULLETED_SHIFT_ASSIGNMENTS = 10;
+const MAX_BULLETED_SHIFT_CAPACITY = 10;
 const MAX_ROSTER_ITEMS_PER_COLUMN = 42;
 const SHIFT_INDENT = 18;
 const JOB_INDENT = 30;
@@ -214,6 +214,7 @@ export class WorkScheduleDocumentService {
     rangeEnd: number
   ): Content[] {
     const content: Content[] = [];
+    const totalWorkers = this.getAssignedWorkers(shift).length;
     let workerOffset = 0;
 
     for (const job of shift.jobs) {
@@ -222,6 +223,10 @@ export class WorkScheduleDocumentService {
       const jobEnd = jobStart + workers.length;
       const sliceStart = Math.max(rangeStart, jobStart);
       const sliceEnd = Math.min(rangeEnd, jobEnd);
+      const emptyJobIsInRange =
+        workers.length === 0 &&
+        jobStart >= rangeStart &&
+        (jobStart < rangeEnd || (jobStart === rangeEnd && rangeEnd === totalWorkers));
 
       if (sliceStart < sliceEnd) {
         content.push(
@@ -231,6 +236,8 @@ export class WorkScheduleDocumentService {
             sliceStart + 1
           )
         );
+      } else if (emptyJobIsInRange) {
+        content.push(this.buildJobHeading(job));
       }
 
       workerOffset = jobEnd;
@@ -262,7 +269,8 @@ export class WorkScheduleDocumentService {
   }
 
   private isLargeShift(shift: ScheduleShift): boolean {
-    return this.getAssignedWorkers(shift).length > MAX_BULLETED_SHIFT_ASSIGNMENTS;
+    const capacity = shift.jobs.reduce((total, job) => total + job.maxRegistrations, 0);
+    return capacity > MAX_BULLETED_SHIFT_CAPACITY;
   }
 
   private getAssignedWorkers(shift: ScheduleShift): string[] {

--- a/apps/api/src/reports/services/work-schedule-document.service.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.ts
@@ -1,0 +1,252 @@
+import { Injectable } from '@nestjs/common';
+import { DayOfWeek } from '@prisma/client';
+import { Content, ContentColumns, ContentStack, TDocumentDefinitions } from 'pdfmake/interfaces';
+import { WorkScheduleReportData } from '../models/work-schedule-report-data';
+
+const LARGE_SHIFT_ASSIGNMENT_THRESHOLD = 10;
+const MAX_ROSTER_ITEMS_PER_COLUMN = 42;
+const DAY_NAMES: Readonly<Record<DayOfWeek, string>> = {
+  [DayOfWeek.PRE_OPENING]: 'Pre-Opening',
+  [DayOfWeek.OPENING_SUNDAY]: 'Opening Sunday',
+  [DayOfWeek.MONDAY]: 'Monday',
+  [DayOfWeek.TUESDAY]: 'Tuesday',
+  [DayOfWeek.WEDNESDAY]: 'Wednesday',
+  [DayOfWeek.THURSDAY]: 'Thursday',
+  [DayOfWeek.FRIDAY]: 'Friday',
+  [DayOfWeek.SATURDAY]: 'Saturday',
+  [DayOfWeek.CLOSING_SUNDAY]: 'Closing Sunday',
+  [DayOfWeek.POST_EVENT]: 'Post-Event',
+};
+
+type ScheduleShift = WorkScheduleReportData['shifts'][number];
+type ScheduleJob = ScheduleShift['jobs'][number];
+
+/** Builds the work-schedule-specific pdfmake document definition. */
+@Injectable()
+export class WorkScheduleDocumentService {
+  build(data: WorkScheduleReportData): TDocumentDefinitions {
+    const title = `${data.campName} Work Schedule ${data.year}`;
+    const days = this.groupShiftsByDay(data.shifts);
+
+    return {
+      pageSize: 'LETTER',
+      pageOrientation: 'portrait',
+      pageMargins: [36, 62, 36, 36],
+      info: {
+        title,
+        author: 'PlayaPlan',
+        subject: `Work schedule for ${data.year}`,
+      },
+      defaultStyle: {
+        font: 'Roboto',
+        fontSize: 10,
+      },
+      header: {
+        text: title,
+        alignment: 'center',
+        bold: true,
+        fontSize: 16,
+        margin: [36, 24, 36, 0],
+      },
+      footer: (currentPage: number, pageCount: number) => ({
+        text: `Page ${currentPage} of ${pageCount}`,
+        alignment: 'center',
+        fontSize: 8,
+        margin: [0, 12, 0, 0],
+      }),
+      content: days.map(([day, shifts], index) => ({
+        stack: [
+          {
+            text: DAY_NAMES[day],
+            style: 'dayHeading',
+          },
+          ...this.buildDayContent(shifts),
+        ],
+        ...(index > 0 ? { pageBreak: 'before' as const } : {}),
+      })),
+      styles: {
+        dayHeading: {
+          bold: true,
+          fontSize: 18,
+          margin: [0, 0, 0, 10],
+        },
+        shiftHeading: {
+          bold: true,
+          fontSize: 12,
+          margin: [0, 0, 0, 5],
+        },
+        jobHeading: {
+          bold: true,
+          margin: [0, 0, 0, 2],
+        },
+      },
+    };
+  }
+
+  private groupShiftsByDay(
+    shifts: WorkScheduleReportData['shifts']
+  ): ReadonlyArray<readonly [DayOfWeek, ReadonlyArray<ScheduleShift>]> {
+    const groups = new Map<DayOfWeek, ScheduleShift[]>();
+    for (const shift of shifts) {
+      const current = groups.get(shift.dayOfWeek) ?? [];
+      current.push(shift);
+      groups.set(shift.dayOfWeek, current);
+    }
+    return Array.from(groups.entries());
+  }
+
+  private buildDayContent(shifts: ReadonlyArray<ScheduleShift>): Content[] {
+    const smallShifts = shifts.filter(shift => !this.isLargeShift(shift));
+    const largeShifts = shifts.filter(shift => this.isLargeShift(shift));
+    const content: Content[] = smallShifts.map(shift => this.buildSmallShift(shift));
+
+    if (
+      largeShifts.length === 2 &&
+      largeShifts.every(
+        shift => this.getAssignedWorkers(shift).length <= MAX_ROSTER_ITEMS_PER_COLUMN
+      )
+    ) {
+      content.push(this.buildSideBySideLargeShifts(largeShifts[0], largeShifts[1]));
+      return content;
+    }
+
+    content.push(...largeShifts.map(shift => this.buildLargeShift(shift)));
+    return content;
+  }
+
+  private buildSmallShift(shift: ScheduleShift): ContentStack {
+    return {
+      stack: [
+        this.buildShiftHeading(shift),
+        ...shift.jobs.flatMap(job => this.buildSmallJob(job)),
+      ],
+      margin: [0, 0, 0, 10],
+      unbreakable: true,
+    };
+  }
+
+  private buildSmallJob(job: ScheduleJob): Content[] {
+    const assignedWorkers = job.registrations.map(registration =>
+      this.formatUserName(registration.user)
+    );
+    const vacancyCount = Math.max(job.maxRegistrations - assignedWorkers.length, 0);
+    const slots = [
+      ...assignedWorkers,
+      ...Array.from({ length: vacancyCount }, () => ' '),
+    ];
+
+    return [
+      {
+        text: job.name,
+        style: 'jobHeading',
+      },
+      ...(slots.length > 0
+        ? [
+            {
+              ul: slots,
+              margin: [14, 0, 0, 7],
+            } as Content,
+          ]
+        : []),
+    ];
+  }
+
+  private buildSideBySideLargeShifts(
+    leftShift: ScheduleShift,
+    rightShift: ScheduleShift
+  ): ContentColumns {
+    return {
+      columns: [
+        {
+          width: '*',
+          stack: this.buildLargeShiftStack(leftShift),
+        },
+        {
+          width: '*',
+          stack: this.buildLargeShiftStack(rightShift),
+        },
+      ],
+      columnGap: 20,
+      margin: [0, 0, 0, 10],
+    };
+  }
+
+  private buildLargeShift(shift: ScheduleShift): ContentStack {
+    const workers = this.getAssignedWorkers(shift);
+    const roster =
+      workers.length <= MAX_ROSTER_ITEMS_PER_COLUMN
+        ? [this.buildNumberedRoster(workers, 1)]
+        : this.buildSplitRoster(workers);
+
+    return {
+      stack: [this.buildShiftHeading(shift), ...roster],
+      margin: [0, 0, 0, 10],
+    };
+  }
+
+  private buildLargeShiftStack(shift: ScheduleShift): Content[] {
+    return [
+      this.buildShiftHeading(shift),
+      this.buildNumberedRoster(this.getAssignedWorkers(shift), 1),
+    ];
+  }
+
+  private buildSplitRoster(workers: ReadonlyArray<string>): ContentColumns[] {
+    const midpoint = Math.ceil(workers.length / 2);
+    return [
+      {
+        columns: [
+          {
+            width: '*',
+            stack: [this.buildNumberedRoster(workers.slice(0, midpoint), 1)],
+          },
+          {
+            width: '*',
+            stack: [
+              this.buildNumberedRoster(workers.slice(midpoint), midpoint + 1),
+            ],
+          },
+        ],
+        columnGap: 20,
+      },
+    ];
+  }
+
+  private buildNumberedRoster(workers: ReadonlyArray<string>, start: number): Content {
+    return {
+      ol: [...workers],
+      start,
+      margin: [14, 0, 0, 5],
+    };
+  }
+
+  private buildShiftHeading(shift: ScheduleShift): Content {
+    return {
+      text: `${shift.name} - ${shift.startTime} - ${shift.endTime}`,
+      style: 'shiftHeading',
+    };
+  }
+
+  private isLargeShift(shift: ScheduleShift): boolean {
+    return this.getAssignedWorkers(shift).length >= LARGE_SHIFT_ASSIGNMENT_THRESHOLD;
+  }
+
+  private getAssignedWorkers(shift: ScheduleShift): string[] {
+    const includeJobName = shift.jobs.length > 1;
+    return shift.jobs.flatMap(job =>
+      job.registrations.map(registration => {
+        const name = this.formatUserName(registration.user);
+        return includeJobName ? `${name} - ${job.name}` : name;
+      })
+    );
+  }
+
+  private formatUserName(user: {
+    readonly firstName: string;
+    readonly lastName: string;
+    readonly playaName: string | null;
+  }): string {
+    const fullName = `${user.firstName} ${user.lastName}`;
+    return user.playaName ? `${fullName} (${user.playaName})` : fullName;
+  }
+}

--- a/apps/api/src/reports/services/work-schedule-document.service.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.ts
@@ -127,6 +127,8 @@ export class WorkScheduleDocumentService {
       nextShift !== undefined &&
       this.isLargeShift(shift) &&
       this.isLargeShift(nextShift) &&
+      !this.hasRosterRequiringSplit(shift) &&
+      !this.hasRosterRequiringSplit(nextShift) &&
       this.getEstimatedShiftColumnLines(shift) <= MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN &&
       this.getEstimatedShiftColumnLines(nextShift) <= MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN
     );
@@ -311,6 +313,12 @@ export class WorkScheduleDocumentService {
 
   private isLargeJob(job: ScheduleJob): boolean {
     return job.maxRegistrations > MAX_BULLETED_SHIFT_CAPACITY;
+  }
+
+  private hasRosterRequiringSplit(shift: ScheduleShift): boolean {
+    return shift.jobs.some(
+      job => job.registrations.length > MAX_ROSTER_ITEMS_PER_COLUMN
+    );
   }
 
   private getEstimatedShiftColumnLines(shift: ScheduleShift): number {

--- a/apps/api/src/reports/services/work-schedule-document.service.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.ts
@@ -205,19 +205,56 @@ export class WorkScheduleDocumentService {
   private buildLargeJob(job: ScheduleJob): Content[] {
     const workers = this.getAssignedWorkerNames(job);
     if (workers.length > MAX_ROSTER_ITEMS_PER_COLUMN * 2) {
-      return [
-        this.buildJobHeading(job),
-        this.buildNumberedRoster(workers, 1),
-      ];
+      return this.buildFlowingLargeJob(job, workers);
     }
     if (workers.length > MAX_ROSTER_ITEMS_PER_COLUMN) {
-      return [this.buildSplitLargeJob(job, workers)];
+      return this.canSplitLargeJobIntoColumns(job, workers)
+        ? [this.buildSplitLargeJob(job, workers)]
+        : this.buildFlowingLargeJob(job, workers);
     }
 
+    return this.getEstimatedLargeJobLines(job.name, workers) <=
+      MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN
+      ? [this.buildUnbreakableLargeJob(job, workers)]
+      : this.buildFlowingLargeJob(job, workers);
+  }
+
+  private buildUnbreakableLargeJob(
+    job: ScheduleJob,
+    workers: ReadonlyArray<string>
+  ): ContentStack {
+    return {
+      stack: [
+        this.buildJobHeading(job),
+        ...(workers.length > 0 ? [this.buildNumberedRoster(workers, 1)] : []),
+      ],
+      unbreakable: true,
+    };
+  }
+
+  private buildFlowingLargeJob(
+    job: ScheduleJob,
+    workers: ReadonlyArray<string>
+  ): Content[] {
     return [
       this.buildJobHeading(job),
       ...(workers.length > 0 ? [this.buildNumberedRoster(workers, 1)] : []),
     ];
+  }
+
+  private canSplitLargeJobIntoColumns(
+    job: ScheduleJob,
+    workers: ReadonlyArray<string>
+  ): boolean {
+    const midpoint = Math.ceil(workers.length / 2);
+    return (
+      this.getEstimatedLargeJobLines(job.name, workers.slice(0, midpoint)) <=
+        MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN &&
+      this.getEstimatedLargeJobLines(
+        `${job.name} (continued)`,
+        workers.slice(midpoint)
+      ) <= MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN
+    );
   }
 
   private buildSplitLargeJob(
@@ -300,6 +337,17 @@ export class WorkScheduleDocumentService {
 
     const vacancyCount = Math.max(job.maxRegistrations - assignedNames.length, 0);
     return assignedLines + vacancyCount;
+  }
+
+  private getEstimatedLargeJobLines(
+    heading: string,
+    workers: ReadonlyArray<string>
+  ): number {
+    const rosterLines = workers.reduce(
+      (lineCount, worker) => lineCount + this.getEstimatedTextLines(worker),
+      0
+    );
+    return this.getEstimatedTextLines(heading) + 1 + rosterLines;
   }
 
   private getEstimatedTextLines(text: string): number {

--- a/apps/api/src/reports/services/work-schedule-document.service.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.ts
@@ -99,22 +99,35 @@ export class WorkScheduleDocumentService {
   }
 
   private buildDayContent(shifts: ReadonlyArray<ScheduleShift>): Content[] {
-    const smallShifts = shifts.filter(shift => !this.isLargeShift(shift));
-    const largeShifts = shifts.filter(shift => this.isLargeShift(shift));
-    const content: Content[] = smallShifts.map(shift => this.buildSmallShift(shift));
+    const content: Content[] = [];
 
-    if (
-      largeShifts.length === 2 &&
-      largeShifts.every(
-        shift => this.getAssignedWorkers(shift).length <= MAX_ROSTER_ITEMS_PER_COLUMN
-      )
-    ) {
-      content.push(this.buildSideBySideLargeShifts(largeShifts[0], largeShifts[1]));
-      return content;
+    for (let index = 0; index < shifts.length; index += 1) {
+      const shift = shifts[index];
+      const nextShift = shifts[index + 1];
+      if (this.canRenderSideBySide(shift, nextShift)) {
+        content.push(this.buildSideBySideLargeShifts(shift, nextShift));
+        index += 1;
+      } else {
+        content.push(
+          this.isLargeShift(shift) ? this.buildLargeShift(shift) : this.buildSmallShift(shift)
+        );
+      }
     }
 
-    content.push(...largeShifts.map(shift => this.buildLargeShift(shift)));
     return content;
+  }
+
+  private canRenderSideBySide(
+    shift: ScheduleShift,
+    nextShift: ScheduleShift | undefined
+  ): nextShift is ScheduleShift {
+    return (
+      nextShift !== undefined &&
+      this.isLargeShift(shift) &&
+      this.isLargeShift(nextShift) &&
+      this.getAssignedWorkers(shift).length <= MAX_ROSTER_ITEMS_PER_COLUMN &&
+      this.getAssignedWorkers(nextShift).length <= MAX_ROSTER_ITEMS_PER_COLUMN
+    );
   }
 
   private buildSmallShift(shift: ScheduleShift): ContentStack {
@@ -172,78 +185,58 @@ export class WorkScheduleDocumentService {
   }
 
   private buildLargeShift(shift: ScheduleShift): ContentStack {
-    const workers = this.getAssignedWorkers(shift);
-    const roster =
-      workers.length <= MAX_ROSTER_ITEMS_PER_COLUMN
-        ? this.buildLargeJobSections(shift, 0, workers.length)
-        : [this.buildSplitRoster(shift, workers.length)];
-
     return {
-      stack: [this.buildShiftHeading(shift), ...roster],
+      stack: [this.buildShiftHeading(shift), ...this.buildShiftJobs(shift)],
       margin: [0, 0, 0, 10],
     };
   }
 
   private buildLargeShiftStack(shift: ScheduleShift): Content[] {
+    return [this.buildShiftHeading(shift), ...this.buildShiftJobs(shift)];
+  }
+
+  private buildShiftJobs(shift: ScheduleShift): Content[] {
+    return shift.jobs.flatMap(job =>
+      this.isLargeJob(job) ? this.buildLargeJob(job) : this.buildSmallJob(job)
+    );
+  }
+
+  private buildLargeJob(job: ScheduleJob): Content[] {
+    const workers = this.getAssignedWorkerNames(job);
+    if (workers.length > MAX_ROSTER_ITEMS_PER_COLUMN) {
+      return [this.buildSplitLargeJob(job, workers)];
+    }
+
     return [
-      this.buildShiftHeading(shift),
-      ...this.buildLargeJobSections(shift, 0, this.getAssignedWorkers(shift).length),
+      this.buildJobHeading(job),
+      ...(workers.length > 0 ? [this.buildNumberedRoster(workers, 1)] : []),
     ];
   }
 
-  private buildSplitRoster(shift: ScheduleShift, workerCount: number): ContentColumns {
-    const midpoint = Math.ceil(workerCount / 2);
+  private buildSplitLargeJob(
+    job: ScheduleJob,
+    workers: ReadonlyArray<string>
+  ): ContentColumns {
+    const midpoint = Math.ceil(workers.length / 2);
     return {
       columns: [
         {
           width: '*',
-          stack: this.buildLargeJobSections(shift, 0, midpoint),
+          stack: [
+            this.buildJobHeading(job),
+            this.buildNumberedRoster(workers.slice(0, midpoint), 1),
+          ],
         },
         {
           width: '*',
-          stack: this.buildLargeJobSections(shift, midpoint, workerCount),
+          stack: [
+            this.buildJobHeading(job, true),
+            this.buildNumberedRoster(workers.slice(midpoint), midpoint + 1),
+          ],
         },
       ],
       columnGap: 20,
     };
-  }
-
-  private buildLargeJobSections(
-    shift: ScheduleShift,
-    rangeStart: number,
-    rangeEnd: number
-  ): Content[] {
-    const content: Content[] = [];
-    const totalWorkers = this.getAssignedWorkers(shift).length;
-    let workerOffset = 0;
-
-    for (const job of shift.jobs) {
-      const workers = this.getAssignedWorkerNames(job);
-      const jobStart = workerOffset;
-      const jobEnd = jobStart + workers.length;
-      const sliceStart = Math.max(rangeStart, jobStart);
-      const sliceEnd = Math.min(rangeEnd, jobEnd);
-      const emptyJobIsInRange =
-        workers.length === 0 &&
-        jobStart >= rangeStart &&
-        (jobStart < rangeEnd || (jobStart === rangeEnd && rangeEnd === totalWorkers));
-
-      if (sliceStart < sliceEnd) {
-        content.push(
-          this.buildJobHeading(job, sliceStart > jobStart),
-          this.buildNumberedRoster(
-            workers.slice(sliceStart - jobStart, sliceEnd - jobStart),
-            sliceStart + 1
-          )
-        );
-      } else if (emptyJobIsInRange) {
-        content.push(this.buildJobHeading(job));
-      }
-
-      workerOffset = jobEnd;
-    }
-
-    return content;
   }
 
   private buildNumberedRoster(workers: ReadonlyArray<string>, start: number): Content {
@@ -269,8 +262,11 @@ export class WorkScheduleDocumentService {
   }
 
   private isLargeShift(shift: ScheduleShift): boolean {
-    const capacity = shift.jobs.reduce((total, job) => total + job.maxRegistrations, 0);
-    return capacity > MAX_BULLETED_SHIFT_CAPACITY;
+    return shift.jobs.some(job => this.isLargeJob(job));
+  }
+
+  private isLargeJob(job: ScheduleJob): boolean {
+    return job.maxRegistrations > MAX_BULLETED_SHIFT_CAPACITY;
   }
 
   private getAssignedWorkers(shift: ScheduleShift): string[] {

--- a/apps/api/src/reports/services/work-schedule-document.service.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.ts
@@ -150,6 +150,8 @@ export class WorkScheduleDocumentService {
       ...assignedWorkers,
       ...Array.from({ length: vacancyCount }, () => ' '),
     ];
+    const isPageSized =
+      this.getEstimatedJobLines(job.name, slots) <= MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN;
 
     return {
       stack: [
@@ -163,7 +165,7 @@ export class WorkScheduleDocumentService {
             ]
           : []),
       ],
-      unbreakable: true,
+      ...(isPageSized ? { unbreakable: true } : {}),
     };
   }
 
@@ -215,7 +217,7 @@ export class WorkScheduleDocumentService {
         : this.buildFlowingLargeJob(job, workers);
     }
 
-    return this.getEstimatedLargeJobLines(job.name, workers) <=
+    return this.getEstimatedJobLines(job.name, workers) <=
       MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN
       ? [this.buildUnbreakableLargeJob(job, workers)]
       : this.buildFlowingLargeJob(job, workers);
@@ -250,9 +252,9 @@ export class WorkScheduleDocumentService {
   ): boolean {
     const midpoint = Math.ceil(workers.length / 2);
     return (
-      this.getEstimatedLargeJobLines(job.name, workers.slice(0, midpoint)) <=
+      this.getEstimatedJobLines(job.name, workers.slice(0, midpoint)) <=
         MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN &&
-      this.getEstimatedLargeJobLines(
+      this.getEstimatedJobLines(
         `${job.name} (continued)`,
         workers.slice(midpoint)
       ) <= MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN
@@ -347,12 +349,12 @@ export class WorkScheduleDocumentService {
     return assignedLines + vacancyCount;
   }
 
-  private getEstimatedLargeJobLines(
+  private getEstimatedJobLines(
     heading: string,
-    workers: ReadonlyArray<string>
+    rosterItems: ReadonlyArray<string>
   ): number {
-    const rosterLines = workers.reduce(
-      (lineCount, worker) => lineCount + this.getEstimatedTextLines(worker),
+    const rosterLines = rosterItems.reduce(
+      (lineCount, item) => lineCount + this.getEstimatedTextLines(item),
       0
     );
     return this.getEstimatedTextLines(heading) + 1 + rosterLines;

--- a/apps/api/src/reports/services/work-schedule-document.service.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.ts
@@ -5,6 +5,8 @@ import { WorkScheduleReportData } from '../models/work-schedule-report-data';
 
 const MAX_BULLETED_SHIFT_CAPACITY = 10;
 const MAX_ROSTER_ITEMS_PER_COLUMN = 42;
+const MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN = 46;
+const ESTIMATED_CHARACTERS_PER_COLUMN_LINE = 38;
 const SHIFT_INDENT = 18;
 const JOB_INDENT = 30;
 const ROSTER_INDENT = 44;
@@ -125,8 +127,8 @@ export class WorkScheduleDocumentService {
       nextShift !== undefined &&
       this.isLargeShift(shift) &&
       this.isLargeShift(nextShift) &&
-      this.getRenderedRosterItemCount(shift) <= MAX_ROSTER_ITEMS_PER_COLUMN &&
-      this.getRenderedRosterItemCount(nextShift) <= MAX_ROSTER_ITEMS_PER_COLUMN
+      this.getEstimatedShiftColumnLines(shift) <= MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN &&
+      this.getEstimatedShiftColumnLines(nextShift) <= MAX_ESTIMATED_LINES_PER_SHIFT_COLUMN
     );
   }
 
@@ -274,14 +276,34 @@ export class WorkScheduleDocumentService {
     return job.maxRegistrations > MAX_BULLETED_SHIFT_CAPACITY;
   }
 
-  private getRenderedRosterItemCount(shift: ScheduleShift): number {
-    return shift.jobs.reduce((count, job) => {
-      const assignedCount = job.registrations.length;
-      const rosterItemCount = this.isLargeJob(job)
-        ? assignedCount
-        : Math.max(job.maxRegistrations, assignedCount);
-      return count + rosterItemCount;
-    }, 0);
+  private getEstimatedShiftColumnLines(shift: ScheduleShift): number {
+    const shiftHeading = `${shift.name} - ${shift.startTime} - ${shift.endTime}`;
+    return shift.jobs.reduce(
+      (lineCount, job) =>
+        lineCount +
+        this.getEstimatedTextLines(job.name) +
+        1 +
+        this.getEstimatedRosterLines(job),
+      this.getEstimatedTextLines(shiftHeading)
+    );
+  }
+
+  private getEstimatedRosterLines(job: ScheduleJob): number {
+    const assignedNames = this.getAssignedWorkerNames(job);
+    const assignedLines = assignedNames.reduce(
+      (lineCount, name) => lineCount + this.getEstimatedTextLines(name),
+      0
+    );
+    if (this.isLargeJob(job)) {
+      return assignedLines;
+    }
+
+    const vacancyCount = Math.max(job.maxRegistrations - assignedNames.length, 0);
+    return assignedLines + vacancyCount;
+  }
+
+  private getEstimatedTextLines(text: string): number {
+    return Math.max(Math.ceil(text.length / ESTIMATED_CHARACTERS_PER_COLUMN_LINE), 1);
   }
 
   private getAssignedWorkerNames(job: ScheduleJob): string[] {

--- a/apps/api/src/reports/services/work-schedule-document.service.ts
+++ b/apps/api/src/reports/services/work-schedule-document.service.ts
@@ -3,8 +3,11 @@ import { DayOfWeek } from '@prisma/client';
 import { Content, ContentColumns, ContentStack, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { WorkScheduleReportData } from '../models/work-schedule-report-data';
 
-const LARGE_SHIFT_ASSIGNMENT_THRESHOLD = 10;
+const MAX_BULLETED_SHIFT_ASSIGNMENTS = 10;
 const MAX_ROSTER_ITEMS_PER_COLUMN = 42;
+const SHIFT_INDENT = 18;
+const JOB_INDENT = 30;
+const ROSTER_INDENT = 44;
 const DAY_NAMES: Readonly<Record<DayOfWeek, string>> = {
   [DayOfWeek.PRE_OPENING]: 'Pre-Opening',
   [DayOfWeek.OPENING_SUNDAY]: 'Opening Sunday',
@@ -73,11 +76,11 @@ export class WorkScheduleDocumentService {
         shiftHeading: {
           bold: true,
           fontSize: 12,
-          margin: [0, 0, 0, 5],
+          margin: [SHIFT_INDENT, 0, 0, 5],
         },
         jobHeading: {
           bold: true,
-          margin: [0, 0, 0, 2],
+          margin: [JOB_INDENT, 0, 0, 2],
         },
       },
     };
@@ -136,15 +139,12 @@ export class WorkScheduleDocumentService {
     ];
 
     return [
-      {
-        text: job.name,
-        style: 'jobHeading',
-      },
+      this.buildJobHeading(job),
       ...(slots.length > 0
         ? [
             {
               ul: slots,
-              margin: [14, 0, 0, 7],
+              margin: [ROSTER_INDENT, 0, 0, 7],
             } as Content,
           ]
         : []),
@@ -175,8 +175,8 @@ export class WorkScheduleDocumentService {
     const workers = this.getAssignedWorkers(shift);
     const roster =
       workers.length <= MAX_ROSTER_ITEMS_PER_COLUMN
-        ? [this.buildNumberedRoster(workers, 1)]
-        : this.buildSplitRoster(workers);
+        ? this.buildLargeJobSections(shift, 0, workers.length)
+        : [this.buildSplitRoster(shift, workers.length)];
 
     return {
       stack: [this.buildShiftHeading(shift), ...roster],
@@ -187,36 +187,70 @@ export class WorkScheduleDocumentService {
   private buildLargeShiftStack(shift: ScheduleShift): Content[] {
     return [
       this.buildShiftHeading(shift),
-      this.buildNumberedRoster(this.getAssignedWorkers(shift), 1),
+      ...this.buildLargeJobSections(shift, 0, this.getAssignedWorkers(shift).length),
     ];
   }
 
-  private buildSplitRoster(workers: ReadonlyArray<string>): ContentColumns[] {
-    const midpoint = Math.ceil(workers.length / 2);
-    return [
-      {
-        columns: [
-          {
-            width: '*',
-            stack: [this.buildNumberedRoster(workers.slice(0, midpoint), 1)],
-          },
-          {
-            width: '*',
-            stack: [
-              this.buildNumberedRoster(workers.slice(midpoint), midpoint + 1),
-            ],
-          },
-        ],
-        columnGap: 20,
-      },
-    ];
+  private buildSplitRoster(shift: ScheduleShift, workerCount: number): ContentColumns {
+    const midpoint = Math.ceil(workerCount / 2);
+    return {
+      columns: [
+        {
+          width: '*',
+          stack: this.buildLargeJobSections(shift, 0, midpoint),
+        },
+        {
+          width: '*',
+          stack: this.buildLargeJobSections(shift, midpoint, workerCount),
+        },
+      ],
+      columnGap: 20,
+    };
+  }
+
+  private buildLargeJobSections(
+    shift: ScheduleShift,
+    rangeStart: number,
+    rangeEnd: number
+  ): Content[] {
+    const content: Content[] = [];
+    let workerOffset = 0;
+
+    for (const job of shift.jobs) {
+      const workers = this.getAssignedWorkerNames(job);
+      const jobStart = workerOffset;
+      const jobEnd = jobStart + workers.length;
+      const sliceStart = Math.max(rangeStart, jobStart);
+      const sliceEnd = Math.min(rangeEnd, jobEnd);
+
+      if (sliceStart < sliceEnd) {
+        content.push(
+          this.buildJobHeading(job, sliceStart > jobStart),
+          this.buildNumberedRoster(
+            workers.slice(sliceStart - jobStart, sliceEnd - jobStart),
+            sliceStart + 1
+          )
+        );
+      }
+
+      workerOffset = jobEnd;
+    }
+
+    return content;
   }
 
   private buildNumberedRoster(workers: ReadonlyArray<string>, start: number): Content {
     return {
       ol: [...workers],
       start,
-      margin: [14, 0, 0, 5],
+      margin: [ROSTER_INDENT, 0, 0, 5],
+    };
+  }
+
+  private buildJobHeading(job: ScheduleJob, continued = false): Content {
+    return {
+      text: continued ? `${job.name} (continued)` : job.name,
+      style: 'jobHeading',
     };
   }
 
@@ -228,17 +262,15 @@ export class WorkScheduleDocumentService {
   }
 
   private isLargeShift(shift: ScheduleShift): boolean {
-    return this.getAssignedWorkers(shift).length >= LARGE_SHIFT_ASSIGNMENT_THRESHOLD;
+    return this.getAssignedWorkers(shift).length > MAX_BULLETED_SHIFT_ASSIGNMENTS;
   }
 
   private getAssignedWorkers(shift: ScheduleShift): string[] {
-    const includeJobName = shift.jobs.length > 1;
-    return shift.jobs.flatMap(job =>
-      job.registrations.map(registration => {
-        const name = this.formatUserName(registration.user);
-        return includeJobName ? `${name} - ${job.name}` : name;
-      })
-    );
+    return shift.jobs.flatMap(job => this.getAssignedWorkerNames(job));
+  }
+
+  private getAssignedWorkerNames(job: ScheduleJob): string[] {
+    return job.registrations.map(registration => this.formatUserName(registration.user));
   }
 
   private formatUserName(user: {

--- a/apps/api/src/reports/services/work-schedule-report.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-report.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { DayOfWeek } from '@prisma/client';
 import { GenerateWorkScheduleReportDto } from '../dto/generate-work-schedule-report.dto';
 import { PdfRenderer } from '../models/pdf-renderer';
 import { PdfDownloadService } from './pdf-download.service';
@@ -49,15 +49,30 @@ describe('WorkScheduleReportService', () => {
     );
   });
 
-  it('shouldRejectAnEmptyScheduleBeforeRendering', async () => {
+  it('shouldRejectAnEmptyFullScheduleBeforeRendering', async () => {
     mockGetReportData.mockResolvedValue({
       campName: 'Burning Sky',
       year: 2026,
       shifts: [],
     });
 
-    await expect(service.generate(new GenerateWorkScheduleReportDto())).rejects.toBeInstanceOf(
-      NotFoundException
+    await expect(service.generate(new GenerateWorkScheduleReportDto())).rejects.toThrow(
+      'No work schedule is available'
+    );
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('shouldRejectAnEmptySelectedDayBeforeRendering', async () => {
+    const inputOptions = new GenerateWorkScheduleReportDto();
+    inputOptions.dayOfWeek = DayOfWeek.MONDAY;
+    mockGetReportData.mockResolvedValue({
+      campName: 'Burning Sky',
+      year: 2026,
+      shifts: [],
+    });
+
+    await expect(service.generate(inputOptions)).rejects.toThrow(
+      'No work schedule matches the selected day'
     );
     expect(mockRender).not.toHaveBeenCalled();
   });

--- a/apps/api/src/reports/services/work-schedule-report.service.spec.ts
+++ b/apps/api/src/reports/services/work-schedule-report.service.spec.ts
@@ -1,0 +1,64 @@
+import { NotFoundException } from '@nestjs/common';
+import { GenerateWorkScheduleReportDto } from '../dto/generate-work-schedule-report.dto';
+import { PdfRenderer } from '../models/pdf-renderer';
+import { PdfDownloadService } from './pdf-download.service';
+import { WorkScheduleDataService } from './work-schedule-data.service';
+import { WorkScheduleDocumentService } from './work-schedule-document.service';
+import { WorkScheduleReportService } from './work-schedule-report.service';
+
+describe('WorkScheduleReportService', () => {
+  const mockGetReportData = jest.fn();
+  const mockBuild = jest.fn();
+  const mockRender = jest.fn();
+  const mockCreateDownload = jest.fn();
+  let service: WorkScheduleReportService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new WorkScheduleReportService(
+      { getReportData: mockGetReportData } as unknown as WorkScheduleDataService,
+      { build: mockBuild } as unknown as WorkScheduleDocumentService,
+      { render: mockRender } as PdfRenderer,
+      { create: mockCreateDownload } as unknown as PdfDownloadService
+    );
+  });
+
+  it('shouldGenerateAPdfWithTheConfiguredTitle', async () => {
+    const inputOptions = new GenerateWorkScheduleReportDto();
+    const expectedDownload = {
+      buffer: Buffer.from('%PDF'),
+      contentType: 'application/pdf' as const,
+      contentDisposition: 'attachment',
+      filename: 'work-schedule.pdf',
+    };
+    mockGetReportData.mockResolvedValue({
+      campName: 'Burning Sky',
+      year: 2026,
+      shifts: [{ id: 'shift' }],
+    });
+    mockBuild.mockReturnValue({ content: [] });
+    mockRender.mockResolvedValue(Buffer.from('%PDF'));
+    mockCreateDownload.mockReturnValue(expectedDownload);
+
+    const actualDownload = await service.generate(inputOptions);
+
+    expect(actualDownload).toBe(expectedDownload);
+    expect(mockCreateDownload).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      'Burning Sky Work Schedule 2026'
+    );
+  });
+
+  it('shouldRejectAnEmptyScheduleBeforeRendering', async () => {
+    mockGetReportData.mockResolvedValue({
+      campName: 'Burning Sky',
+      year: 2026,
+      shifts: [],
+    });
+
+    await expect(service.generate(new GenerateWorkScheduleReportDto())).rejects.toBeInstanceOf(
+      NotFoundException
+    );
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/reports/services/work-schedule-report.service.ts
+++ b/apps/api/src/reports/services/work-schedule-report.service.ts
@@ -19,7 +19,11 @@ export class WorkScheduleReportService {
   async generate(options: GenerateWorkScheduleReportDto): Promise<PdfDownload> {
     const data = await this.dataService.getReportData(options);
     if (data.shifts.length === 0) {
-      throw new NotFoundException('No work schedule matches the selected day');
+      throw new NotFoundException(
+        options.dayOfWeek
+          ? 'No work schedule matches the selected day'
+          : 'No work schedule is available'
+      );
     }
 
     const document = this.documentService.build(data);

--- a/apps/api/src/reports/services/work-schedule-report.service.ts
+++ b/apps/api/src/reports/services/work-schedule-report.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { GenerateWorkScheduleReportDto } from '../dto/generate-work-schedule-report.dto';
+import { PdfDownload } from '../models/pdf-download';
+import { PdfRenderer } from '../models/pdf-renderer';
+import { PdfDownloadService } from './pdf-download.service';
+import { WorkScheduleDataService } from './work-schedule-data.service';
+import { WorkScheduleDocumentService } from './work-schedule-document.service';
+
+/** Orchestrates work-schedule data, rendering, and download output. */
+@Injectable()
+export class WorkScheduleReportService {
+  constructor(
+    private readonly dataService: WorkScheduleDataService,
+    private readonly documentService: WorkScheduleDocumentService,
+    private readonly pdfRenderer: PdfRenderer,
+    private readonly downloadService: PdfDownloadService
+  ) {}
+
+  async generate(options: GenerateWorkScheduleReportDto): Promise<PdfDownload> {
+    const data = await this.dataService.getReportData(options);
+    if (data.shifts.length === 0) {
+      throw new NotFoundException('No work schedule matches the selected day');
+    }
+
+    const document = this.documentService.build(data);
+    const buffer = await this.pdfRenderer.render(document);
+    return this.downloadService.create(
+      buffer,
+      `${data.campName} Work Schedule ${data.year}`
+    );
+  }
+}

--- a/apps/api/src/shifts/models/work-schedule-data.ts
+++ b/apps/api/src/shifts/models/work-schedule-data.ts
@@ -1,0 +1,40 @@
+import { DayOfWeek } from '@prisma/client';
+
+interface WorkScheduleUser {
+  readonly id: string;
+  readonly firstName: string;
+  readonly lastName: string;
+  readonly playaName: string | null;
+}
+
+interface WorkScheduleRegistration {
+  readonly id: string;
+  readonly user: WorkScheduleUser;
+}
+
+interface WorkScheduleJob {
+  readonly id: string;
+  readonly name: string;
+  readonly location: string;
+  readonly maxRegistrations: number;
+  readonly categoryId: string;
+  readonly category: {
+    readonly id: string;
+    readonly name: string;
+  };
+  readonly registrations: ReadonlyArray<WorkScheduleRegistration>;
+}
+
+interface WorkScheduleShift {
+  readonly id: string;
+  readonly name: string;
+  readonly dayOfWeek: DayOfWeek;
+  readonly startTime: string;
+  readonly endTime: string;
+  readonly jobs: ReadonlyArray<WorkScheduleJob>;
+}
+
+/** Ordered shifts, jobs, and worker assignments for the configured registration year. */
+export interface WorkScheduleData {
+  readonly shifts: ReadonlyArray<WorkScheduleShift>;
+}

--- a/apps/api/src/shifts/shifts.controller.spec.ts
+++ b/apps/api/src/shifts/shifts.controller.spec.ts
@@ -3,15 +3,10 @@ import { ShiftsController } from './shifts.controller';
 import { ShiftsService } from './shifts.service';
 import { CreateShiftDto, UpdateShiftDto } from './dto';
 import { DayOfWeek } from '../common/enums/day-of-week.enum';
-import { PrismaService } from '../common/prisma/prisma.service';
-import { RegistrationsService } from '../registrations/registrations.service';
-import { CoreConfigService } from '../core-config/services/core-config.service';
 
 describe('ShiftsController', () => {
   let controller: ShiftsController;
   let service: ShiftsService;
-  let mockPrismaService: Record<string, Record<string, jest.Mock>>;
-  let mockCoreConfigService: Record<string, jest.Mock>;
 
   const mockShift = {
     id: 'test-id',
@@ -38,24 +33,7 @@ describe('ShiftsController', () => {
       findOne: jest.fn(() => Promise.resolve(mockShift)),
       update: jest.fn(() => Promise.resolve(mockUpdatedShift)),
       remove: jest.fn(() => Promise.resolve(mockShift)),
-    };
-
-    const mockRegistrationsService = {
-      create: jest.fn(() => Promise.resolve({ id: 'reg-id', userId: 'user-id', jobId: 'job-id' })),
-      findByUser: jest.fn(() => Promise.resolve([])),
-      findByJob: jest.fn(() => Promise.resolve([])),
-      findOne: jest.fn(() => Promise.resolve({ id: 'reg-id', userId: 'user-id', jobId: 'job-id' })),
-      update: jest.fn(() => Promise.resolve({ id: 'reg-id', userId: 'user-id', jobId: 'job-id', status: 'CANCELLED' })),
-    };
-
-    mockPrismaService = {
-      shift: {
-        findMany: jest.fn(),
-      },
-    };
-
-    mockCoreConfigService = {
-      findCurrent: jest.fn().mockResolvedValue({ registrationYear: 2026 }),
+      getWorkSchedule: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -64,18 +42,6 @@ describe('ShiftsController', () => {
         {
           provide: ShiftsService,
           useValue: mockShiftsService,
-        },
-        {
-          provide: RegistrationsService,
-          useValue: mockRegistrationsService,
-        },
-        {
-          provide: PrismaService,
-          useValue: mockPrismaService,
-        },
-        {
-          provide: CoreConfigService,
-          useValue: mockCoreConfigService,
         },
       ],
     }).compile();
@@ -151,85 +117,14 @@ describe('ShiftsController', () => {
   });
 
   describe('findAllWithJobsAndRegistrations', () => {
-    it('should filter registrations by the configured registration year', async () => {
-      const mockShiftsWithJobs = [
-        {
-          id: 'shift-1',
-          name: 'Morning Shift',
-          dayOfWeek: DayOfWeek.MONDAY,
-          startTime: '09:00',
-          endTime: '12:00',
-          jobs: [
-            {
-              id: 'job-1',
-              name: 'Gate',
-              location: 'Front Gate',
-              maxRegistrations: 5,
-              categoryId: 'cat-1',
-              category: { id: 'cat-1', name: 'Security' },
-              registrations: [
-                {
-                  id: 'reg-job-1',
-                  registration: {
-                    year: 2026,
-                    user: {
-                      id: 'user-1',
-                      firstName: 'Jane',
-                      lastName: 'Doe',
-                      playaName: 'Sparkle',
-                    },
-                  },
-                },
-              ],
-            },
-          ],
-        },
-      ];
+    it('should return the shared work schedule', async () => {
+      const expectedSchedule = { shifts: [] };
+      jest.spyOn(service, 'getWorkSchedule').mockResolvedValue(expectedSchedule);
 
-      mockPrismaService.shift.findMany.mockResolvedValue(mockShiftsWithJobs);
+      const actualSchedule = await controller.findAllWithJobsAndRegistrations();
 
-      const result = await controller.findAllWithJobsAndRegistrations();
-
-      // Verify CoreConfigService was called to get the registration year
-      expect(mockCoreConfigService.findCurrent).toHaveBeenCalled();
-
-      // Verify Prisma query includes year filter
-      expect(mockPrismaService.shift.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          include: expect.objectContaining({
-            jobs: expect.objectContaining({
-              where: {
-                OR: [
-                  { active: true },
-                  {
-                    registrations: {
-                      some: {
-                        registration: {
-                          year: 2026,
-                        },
-                      },
-                    },
-                  },
-                ],
-              },
-              include: expect.objectContaining({
-                registrations: expect.objectContaining({
-                  where: {
-                    registration: {
-                      year: 2026,
-                    },
-                  },
-                }),
-              }),
-            }),
-          }),
-        }),
-      );
-
-      // Verify response structure
-      expect(result.shifts).toHaveLength(1);
-      expect(result.shifts[0].jobs[0].registrations).toHaveLength(1);
-      expect(result.shifts[0].jobs[0].registrations[0].user.firstName).toBe('Jane');
+      expect(actualSchedule).toBe(expectedSchedule);
+      expect(service.getWorkSchedule).toHaveBeenCalledWith();
     });
   });
-}); 
+});

--- a/apps/api/src/shifts/shifts.controller.ts
+++ b/apps/api/src/shifts/shifts.controller.ts
@@ -6,19 +6,13 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { UserRole } from '@prisma/client';
-import { PrismaService } from '../common/prisma/prisma.service';
-import { CoreConfigService } from '../core-config/services/core-config.service';
 
 @ApiTags('shifts')
 @Controller('shifts')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @ApiBearerAuth()
 export class ShiftsController {
-  constructor(
-    private readonly shiftsService: ShiftsService,
-    private readonly prisma: PrismaService,
-    private readonly coreConfigService: CoreConfigService,
-  ) {}
+  constructor(private readonly shiftsService: ShiftsService) {}
 
   @Post()
   @Roles(UserRole.ADMIN, UserRole.STAFF)
@@ -40,90 +34,7 @@ export class ShiftsController {
   @ApiOperation({ summary: 'Get all shifts with jobs and registrations' })
   @ApiOkResponse({ description: 'Returns all shifts with jobs and user registrations.' })
   async findAllWithJobsAndRegistrations() {
-    // Get the configured registration year
-    const config = await this.coreConfigService.findCurrent();
-    const registrationYear = config.registrationYear;
-
-    // Get all shifts with their associated jobs and job registrations for the current year
-    const shifts = await this.prisma.shift.findMany({
-      include: {
-        jobs: {
-          where: {
-            OR: [
-              { active: true },
-              {
-                registrations: {
-                  some: {
-                    registration: {
-                      year: registrationYear,
-                    },
-                  },
-                },
-              },
-            ],
-          },
-          include: {
-            category: true,
-            registrations: {
-              where: {
-                registration: {
-                  year: registrationYear,
-                },
-              },
-              include: {
-                registration: {
-                  include: {
-                    user: {
-                      select: {
-                        id: true,
-                        firstName: true,
-                        lastName: true,
-                        playaName: true,
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      orderBy: [
-        { dayOfWeek: 'asc' },
-        { startTime: 'asc' }
-      ]
-    });
-
-    // Transform the data to match the expected format in the frontend
-    return {
-      shifts: shifts.map(shift => ({
-        id: shift.id,
-        name: shift.name,
-        dayOfWeek: shift.dayOfWeek,
-        startTime: shift.startTime,
-        endTime: shift.endTime,
-        jobs: shift.jobs.map(job => ({
-          id: job.id,
-          name: job.name,
-          location: job.location,
-          maxRegistrations: job.maxRegistrations,
-          categoryId: job.categoryId,
-          category: {
-            id: job.category.id,
-            name: job.category.name
-          },
-          registrations: job.registrations.map(regJob => ({
-            id: regJob.id,
-            user: {
-              id: regJob.registration.user.id,
-              firstName: regJob.registration.user.firstName,
-              lastName: regJob.registration.user.lastName,
-              playaName: regJob.registration.user.playaName
-            }
-          }))
-        }))
-      }))
-    };
+    return this.shiftsService.getWorkSchedule();
   }
 
   @Get(':id')

--- a/apps/api/src/shifts/shifts.service.spec.ts
+++ b/apps/api/src/shifts/shifts.service.spec.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../common/prisma/prisma.service';
 import { NotFoundException } from '@nestjs/common';
 import { DayOfWeek } from '../common/enums/day-of-week.enum';
 import { CoreConfigService } from '../core-config/services/core-config.service';
+import { CAPACITY_RESERVING_STATUSES } from '../registrations/constants/registration-status.constants';
 
 describe('ShiftsService', () => {
   let service: ShiftsService;
@@ -104,6 +105,17 @@ describe('ShiftsService', () => {
     it('shouldFilterByConfiguredYearAndOrderScheduleData', async () => {
           jest.spyOn(prismaService.shift, 'findMany').mockResolvedValueOnce([
             {
+              id: 'thursday-early',
+              name: 'Thursday Early',
+              description: null,
+              startTime: '8:00',
+              endTime: '09:00',
+              dayOfWeek: DayOfWeek.THURSDAY,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              jobs: [],
+            },
+            {
               id: 'thursday',
               name: 'Thursday AM',
               description: null,
@@ -168,6 +180,17 @@ describe('ShiftsService', () => {
                 },
               ],
             },
+            {
+              id: 'thursday-afternoon',
+              name: 'Thursday Afternoon',
+              description: null,
+              startTime: '13:00',
+              endTime: '14:00',
+              dayOfWeek: DayOfWeek.THURSDAY,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              jobs: [],
+            },
           ] as never);
 
           const actualSchedule = await service.getWorkSchedule(DayOfWeek.THURSDAY);
@@ -178,21 +201,46 @@ describe('ShiftsService', () => {
               where: { dayOfWeek: DayOfWeek.THURSDAY },
               include: expect.objectContaining({
                 jobs: expect.objectContaining({
+                  where: {
+                    OR: [
+                      { active: true },
+                      {
+                        registrations: {
+                          some: {
+                            registration: {
+                              year: 2026,
+                              status: { in: [...CAPACITY_RESERVING_STATUSES] },
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
                   include: expect.objectContaining({
                     registrations: expect.objectContaining({
-                      where: { registration: { year: 2026 } },
+                      where: {
+                        registration: {
+                          year: 2026,
+                          status: { in: [...CAPACITY_RESERVING_STATUSES] },
+                        },
+                      },
                     }),
                   }),
                 }),
               }),
             })
           );
-          expect(actualSchedule.shifts[0].jobs.map(job => job.name)).toEqual([
+          expect(actualSchedule.shifts.map(shift => shift.id)).toEqual([
+            'thursday-early',
+            'thursday',
+            'thursday-afternoon',
+          ]);
+          expect(actualSchedule.shifts[1].jobs.map(job => job.name)).toEqual([
             'Airport',
             'Manifest',
           ]);
           expect(
-            actualSchedule.shifts[0].jobs[1].registrations.map(
+            actualSchedule.shifts[1].jobs[1].registrations.map(
               registration => registration.user.firstName
             )
           ).toEqual(['Amy', 'Zoe']);

--- a/apps/api/src/shifts/shifts.service.spec.ts
+++ b/apps/api/src/shifts/shifts.service.spec.ts
@@ -3,10 +3,12 @@ import { ShiftsService } from './shifts.service';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { NotFoundException } from '@nestjs/common';
 import { DayOfWeek } from '../common/enums/day-of-week.enum';
+import { CoreConfigService } from '../core-config/services/core-config.service';
 
 describe('ShiftsService', () => {
   let service: ShiftsService;
   let prismaService: PrismaService;
+  let coreConfigService: CoreConfigService;
 
   const mockShift = {
     id: 'test-id',
@@ -51,11 +53,18 @@ describe('ShiftsService', () => {
             },
           },
         },
+        {
+          provide: CoreConfigService,
+          useValue: {
+            findCurrent: jest.fn().mockResolvedValue({ registrationYear: 2026 }),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<ShiftsService>(ShiftsService);
     prismaService = module.get<PrismaService>(PrismaService);
+    coreConfigService = module.get<CoreConfigService>(CoreConfigService);
   });
 
   it('should be defined', () => {
@@ -88,6 +97,105 @@ describe('ShiftsService', () => {
           jobs: true
         }
       });
+    });
+  });
+
+  describe('getWorkSchedule', () => {
+    it('shouldFilterByConfiguredYearAndOrderScheduleData', async () => {
+          jest.spyOn(prismaService.shift, 'findMany').mockResolvedValueOnce([
+            {
+              id: 'thursday',
+              name: 'Thursday AM',
+              description: null,
+              startTime: '09:30',
+              endTime: '14:30',
+              dayOfWeek: DayOfWeek.THURSDAY,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              jobs: [
+                {
+                  id: 'job-b',
+                  name: 'Manifest',
+                  location: 'Airport',
+                  maxRegistrations: 2,
+                  categoryId: 'category',
+                  active: true,
+                  alwaysRequired: false,
+                  staffOnly: false,
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  shiftId: 'thursday',
+                  category: { id: 'category', name: 'Operations' },
+                  registrations: [
+                    {
+                      id: 'registration-b',
+                      registration: {
+                        user: {
+                          id: 'user-b',
+                          firstName: 'Zoe',
+                          lastName: 'Alpha',
+                          playaName: null,
+                        },
+                      },
+                    },
+                    {
+                      id: 'registration-a',
+                      registration: {
+                        user: {
+                          id: 'user-a',
+                          firstName: 'Amy',
+                          lastName: 'Alpha',
+                          playaName: 'Spark',
+                        },
+                      },
+                    },
+                  ],
+                },
+                {
+                  id: 'job-a',
+                  name: 'Airport',
+                  location: 'Runway',
+                  maxRegistrations: 1,
+                  categoryId: 'category',
+                  active: true,
+                  alwaysRequired: false,
+                  staffOnly: false,
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  shiftId: 'thursday',
+                  category: { id: 'category', name: 'Operations' },
+                  registrations: [],
+                },
+              ],
+            },
+          ] as never);
+
+          const actualSchedule = await service.getWorkSchedule(DayOfWeek.THURSDAY);
+
+          expect(coreConfigService.findCurrent).toHaveBeenCalled();
+          expect(prismaService.shift.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+              where: { dayOfWeek: DayOfWeek.THURSDAY },
+              include: expect.objectContaining({
+                jobs: expect.objectContaining({
+                  include: expect.objectContaining({
+                    registrations: expect.objectContaining({
+                      where: { registration: { year: 2026 } },
+                    }),
+                  }),
+                }),
+              }),
+            })
+          );
+          expect(actualSchedule.shifts[0].jobs.map(job => job.name)).toEqual([
+            'Airport',
+            'Manifest',
+          ]);
+          expect(
+            actualSchedule.shifts[0].jobs[1].registrations.map(
+              registration => registration.user.firstName
+            )
+          ).toEqual(['Amy', 'Zoe']);
     });
   });
 

--- a/apps/api/src/shifts/shifts.service.ts
+++ b/apps/api/src/shifts/shifts.service.ts
@@ -2,11 +2,29 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { CreateShiftDto } from './dto/create-shift.dto';
 import { UpdateShiftDto } from './dto/update-shift.dto';
-import { Prisma, Shift } from '@prisma/client';
+import { DayOfWeek, Prisma, Shift } from '@prisma/client';
+import { CoreConfigService } from '../core-config/services/core-config.service';
+import { WorkScheduleData } from './models/work-schedule-data';
+
+const DAY_OF_WEEK_ORDER: Readonly<Record<DayOfWeek, number>> = {
+  [DayOfWeek.PRE_OPENING]: 0,
+  [DayOfWeek.OPENING_SUNDAY]: 1,
+  [DayOfWeek.MONDAY]: 2,
+  [DayOfWeek.TUESDAY]: 3,
+  [DayOfWeek.WEDNESDAY]: 4,
+  [DayOfWeek.THURSDAY]: 5,
+  [DayOfWeek.FRIDAY]: 6,
+  [DayOfWeek.SATURDAY]: 7,
+  [DayOfWeek.CLOSING_SUNDAY]: 8,
+  [DayOfWeek.POST_EVENT]: 9,
+};
 
 @Injectable()
 export class ShiftsService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly coreConfigService: CoreConfigService
+  ) {}
 
   /**
    * Create a new shift
@@ -36,6 +54,104 @@ export class ShiftsService {
         jobs: true,
       },
     });
+  }
+
+  /** Returns the printable work schedule for the configured registration year. */
+  async getWorkSchedule(
+    dayOfWeek?: DayOfWeek,
+    requestedYear?: number
+  ): Promise<WorkScheduleData> {
+    const registrationYear =
+      requestedYear ?? (await this.coreConfigService.findCurrent()).registrationYear;
+    const shifts = await this.prisma.shift.findMany({
+      ...(dayOfWeek ? { where: { dayOfWeek } } : {}),
+      include: {
+        jobs: {
+          where: {
+            OR: [
+              { active: true },
+              {
+                registrations: {
+                  some: {
+                    registration: {
+                      year: registrationYear,
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          include: {
+            category: true,
+            registrations: {
+              where: {
+                registration: {
+                  year: registrationYear,
+                },
+              },
+              include: {
+                registration: {
+                  include: {
+                    user: {
+                      select: {
+                        id: true,
+                        firstName: true,
+                        lastName: true,
+                        playaName: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return {
+      shifts: shifts
+        .map(shift => ({
+          id: shift.id,
+          name: shift.name,
+          dayOfWeek: shift.dayOfWeek,
+          startTime: shift.startTime,
+          endTime: shift.endTime,
+          jobs: shift.jobs
+            .map(job => ({
+              id: job.id,
+              name: job.name,
+              location: job.location,
+              maxRegistrations: job.maxRegistrations,
+              categoryId: job.categoryId,
+              category: {
+                id: job.category.id,
+                name: job.category.name,
+              },
+              registrations: job.registrations
+                .map(registration => ({
+                  id: registration.id,
+                  user: {
+                    id: registration.registration.user.id,
+                    firstName: registration.registration.user.firstName,
+                    lastName: registration.registration.user.lastName,
+                    playaName: registration.registration.user.playaName,
+                  },
+                }))
+                .sort((left, right) => this.compareUsers(left.user, right.user)),
+            }))
+            .sort((left, right) => left.name.localeCompare(right.name)),
+        }))
+        .sort((left, right) => {
+          const dayComparison =
+            DAY_OF_WEEK_ORDER[left.dayOfWeek] - DAY_OF_WEEK_ORDER[right.dayOfWeek];
+          if (dayComparison !== 0) {
+            return dayComparison;
+          }
+          const timeComparison = left.startTime.localeCompare(right.startTime);
+          return timeComparison !== 0 ? timeComparison : left.name.localeCompare(right.name);
+        }),
+    };
   }
 
   /**
@@ -110,4 +226,14 @@ export class ShiftsService {
       where: { id },
     });
   }
-} 
+
+  private compareUsers(
+    left: { readonly firstName: string; readonly lastName: string },
+    right: { readonly firstName: string; readonly lastName: string }
+  ): number {
+    const lastNameComparison = left.lastName.localeCompare(right.lastName);
+    return lastNameComparison !== 0
+      ? lastNameComparison
+      : left.firstName.localeCompare(right.firstName);
+  }
+}

--- a/apps/api/src/shifts/shifts.service.ts
+++ b/apps/api/src/shifts/shifts.service.ts
@@ -4,6 +4,7 @@ import { CreateShiftDto } from './dto/create-shift.dto';
 import { UpdateShiftDto } from './dto/update-shift.dto';
 import { DayOfWeek, Prisma, Shift } from '@prisma/client';
 import { CoreConfigService } from '../core-config/services/core-config.service';
+import { CAPACITY_RESERVING_STATUSES } from '../registrations/constants/registration-status.constants';
 import { WorkScheduleData } from './models/work-schedule-data';
 
 const DAY_OF_WEEK_ORDER: Readonly<Record<DayOfWeek, number>> = {
@@ -75,6 +76,7 @@ export class ShiftsService {
                   some: {
                     registration: {
                       year: registrationYear,
+                      status: { in: [...CAPACITY_RESERVING_STATUSES] },
                     },
                   },
                 },
@@ -87,6 +89,7 @@ export class ShiftsService {
               where: {
                 registration: {
                   year: registrationYear,
+                  status: { in: [...CAPACITY_RESERVING_STATUSES] },
                 },
               },
               include: {
@@ -148,10 +151,17 @@ export class ShiftsService {
           if (dayComparison !== 0) {
             return dayComparison;
           }
-          const timeComparison = left.startTime.localeCompare(right.startTime);
+          const timeComparison =
+            this.getStartTimeMinutes(left.startTime) -
+            this.getStartTimeMinutes(right.startTime);
           return timeComparison !== 0 ? timeComparison : left.name.localeCompare(right.name);
         }),
     };
+  }
+
+  private getStartTimeMinutes(startTime: string): number {
+    const [hours, minutes] = startTime.split(':').map(Number);
+    return hours * 60 + minutes;
   }
 
   /**

--- a/apps/api/test/reports.e2e-spec.ts
+++ b/apps/api/test/reports.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
-import { ReportType, User, UserRole } from '@prisma/client';
+import { DayOfWeek, ReportType, User, UserRole } from '@prisma/client';
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
 import { PrismaService } from '../src/common/prisma/prisma.service';
@@ -14,6 +14,9 @@ describe('ReportsController (e2e)', () => {
   let adminToken: string;
   let staffToken: string;
   let participantToken: string;
+  let workScheduleJobId: string;
+  let workScheduleShiftId: string;
+  let workScheduleCategoryId: string;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -44,9 +47,41 @@ describe('ReportsController (e2e)', () => {
     adminToken = createToken(testUsers[0]);
     staffToken = createToken(testUsers[1]);
     participantToken = createToken(testUsers[2]);
+
+    const category = await prisma.jobCategory.create({
+      data: {
+        name: `Reports E2E ${Date.now()}`,
+        description: 'Work schedule PDF fixture',
+      },
+    });
+    workScheduleCategoryId = category.id;
+    const shift = await prisma.shift.create({
+      data: {
+        name: 'Wednesday AM',
+        description: 'Work schedule PDF fixture',
+        dayOfWeek: DayOfWeek.WEDNESDAY,
+        startTime: '09:30',
+        endTime: '14:30',
+      },
+    });
+    workScheduleShiftId = shift.id;
+    const job = await prisma.job.create({
+      data: {
+        name: 'Airport Manager',
+        location: 'Airport',
+        maxRegistrations: 1,
+        active: true,
+        categoryId: category.id,
+        shiftId: shift.id,
+      },
+    });
+    workScheduleJobId = job.id;
   });
 
   afterAll(async () => {
+    await prisma.job.delete({ where: { id: workScheduleJobId } });
+    await prisma.shift.delete({ where: { id: workScheduleShiftId } });
+    await prisma.jobCategory.delete({ where: { id: workScheduleCategoryId } });
     await prisma.adminAudit.deleteMany({
       where: { adminUserId: { in: testUsers.map(user => user.id) } },
     });
@@ -63,6 +98,8 @@ describe('ReportsController (e2e)', () => {
     await request(app.getHttpServer()).get('/reports/ticket-receipt/configuration').expect(401);
 
     await request(app.getHttpServer()).post('/reports/ticket-receipt').send({}).expect(401);
+
+    await request(app.getHttpServer()).post('/reports/work-schedule').send({}).expect(401);
   });
 
   it('shouldRejectParticipantRequests', async () => {
@@ -75,6 +112,12 @@ describe('ReportsController (e2e)', () => {
       .post('/reports/ticket-receipt')
       .set('Authorization', `Bearer ${participantToken}`)
       .send(createReportRequest(1))
+      .expect(403);
+
+    await request(app.getHttpServer())
+      .post('/reports/work-schedule')
+      .set('Authorization', `Bearer ${participantToken}`)
+      .send({})
       .expect(403);
   });
 
@@ -125,6 +168,14 @@ describe('ReportsController (e2e)', () => {
       .expect(400);
   });
 
+  it('shouldRejectInvalidWorkScheduleDay', async () => {
+    await request(app.getHttpServer())
+      .post('/reports/work-schedule')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ dayOfWeek: 'SUNDAY' })
+      .expect(400);
+  });
+
   it('shouldReturnNotFoundWhenNoAttendeesOrBlankRowsExist', async () => {
     await request(app.getHttpServer())
       .post('/reports/ticket-receipt')
@@ -138,6 +189,19 @@ describe('ReportsController (e2e)', () => {
       .post('/reports/ticket-receipt')
       .set('Authorization', `Bearer ${staffToken}`)
       .send(createReportRequest(1))
+      .expect(200)
+      .expect('Content-Type', /application\/pdf/)
+      .expect('Content-Disposition', /attachment;/);
+
+    expect(Buffer.isBuffer(response.body)).toBe(true);
+    expect(response.body.subarray(0, 5).toString('ascii')).toBe('%PDF-');
+  });
+
+  it('shouldGenerateFilteredWorkSchedulePdfForStaff', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/reports/work-schedule')
+      .set('Authorization', `Bearer ${staffToken}`)
+      .send({ dayOfWeek: DayOfWeek.WEDNESDAY })
       .expect(200)
       .expect('Content-Type', /application\/pdf/)
       .expect('Content-Disposition', /attachment;/);

--- a/apps/web/src/lib/__tests__/api-work-schedule-report.test.ts
+++ b/apps/web/src/lib/__tests__/api-work-schedule-report.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('work schedule report API', () => {
+  let mockIsAxiosError: ReturnType<typeof vi.fn>;
   let mockApi: {
     post: ReturnType<typeof vi.fn>;
     get: ReturnType<typeof vi.fn>;
@@ -14,6 +15,7 @@ describe('work schedule report API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    mockIsAxiosError = vi.fn();
     mockApi = {
       post: vi.fn(),
       get: vi.fn(),
@@ -26,7 +28,7 @@ describe('work schedule report API', () => {
     vi.doMock('axios', () => ({
       default: {
         create: vi.fn(() => mockApi),
-        isAxiosError: vi.fn(),
+        isAxiosError: mockIsAxiosError,
       },
     }));
   });
@@ -59,5 +61,16 @@ describe('work schedule report API', () => {
       blob: inputBlob,
       filename: 'Burning Sky Work Schedule 2026.pdf',
     });
+  });
+
+  it('shouldDescribeAnEmptyFilteredOrFullSchedule', async () => {
+    mockIsAxiosError.mockReturnValue(true);
+    const { reports } = await import('../api');
+
+    const actualMessage = reports.getWorkScheduleReportErrorMessage({
+      response: { status: 404 },
+    });
+
+    expect(actualMessage).toBe('No work schedule is available.');
   });
 });

--- a/apps/web/src/lib/__tests__/api-work-schedule-report.test.ts
+++ b/apps/web/src/lib/__tests__/api-work-schedule-report.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('work schedule report API', () => {
+  let mockApi: {
+    post: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    defaults: { headers: { common: Record<string, unknown> } };
+    interceptors: {
+      request: { use: ReturnType<typeof vi.fn> };
+      response: { use: ReturnType<typeof vi.fn> };
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockApi = {
+      post: vi.fn(),
+      get: vi.fn(),
+      defaults: { headers: { common: {} } },
+      interceptors: {
+        request: { use: vi.fn() },
+        response: { use: vi.fn() },
+      },
+    };
+    vi.doMock('axios', () => ({
+      default: {
+        create: vi.fn(() => mockApi),
+        isAxiosError: vi.fn(),
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock('axios');
+  });
+
+  it('shouldPostTheSelectedDayAndUseTheServerFilename', async () => {
+    const inputBlob = new Blob(['pdf'], { type: 'application/pdf' });
+    mockApi.post.mockResolvedValue({
+      data: inputBlob,
+      headers: {
+        'content-disposition':
+          "attachment; filename=\"fallback.pdf\"; filename*=UTF-8''Burning%20Sky%20Work%20Schedule%202026.pdf",
+      },
+    });
+    const { reports } = await import('../api');
+
+    const actualDownload = await reports.generateWorkSchedulePdf({
+      dayOfWeek: 'CLOSING_SUNDAY',
+    });
+
+    expect(mockApi.post).toHaveBeenCalledWith(
+      '/reports/work-schedule',
+      { dayOfWeek: 'CLOSING_SUNDAY' },
+      { responseType: 'blob', timeout: 30000 }
+    );
+    expect(actualDownload).toEqual({
+      blob: inputBlob,
+      filename: 'Burning Sky Work Schedule 2026.pdf',
+    });
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -571,6 +571,10 @@ export interface TicketReceiptReportOptions extends TicketReceiptSettings {
   additionalBlankRows?: number;
 }
 
+export interface WorkScheduleReportOptions {
+  dayOfWeek?: string;
+}
+
 function getDownloadFilename(contentDisposition: string | undefined, fallback: string): string {
   const encodedMatch = contentDisposition?.match(/filename\*=UTF-8''([^;]+)/i);
   if (encodedMatch?.[1]) {
@@ -1239,6 +1243,35 @@ export const reports = {
         'ticket-receipt-report.pdf'
       ),
     };
+  },
+
+  generateWorkSchedulePdf: async (
+    options: WorkScheduleReportOptions = {}
+  ): Promise<{ blob: Blob; filename: string }> => {
+    const response = await api.post<Blob>('/reports/work-schedule', options, {
+      responseType: 'blob',
+      timeout: 30000,
+    });
+
+    return {
+      blob: response.data,
+      filename: getDownloadFilename(
+        response.headers['content-disposition'],
+        'work-schedule-report.pdf'
+      ),
+    };
+  },
+
+  getWorkScheduleReportErrorMessage: (error: unknown): string => {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 404) {
+        return 'No work schedule matches the selected day.';
+      }
+      if (error.response?.status === 403) {
+        return 'You do not have permission to generate this report.';
+      }
+    }
+    return 'Failed to generate the work schedule PDF. Please try again.';
   },
 
   getReportErrorMessage: (error: unknown): string => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1265,7 +1265,7 @@ export const reports = {
   getWorkScheduleReportErrorMessage: (error: unknown): string => {
     if (axios.isAxiosError(error)) {
       if (error.response?.status === 404) {
-        return 'No work schedule matches the selected day.';
+        return 'No work schedule is available.';
       }
       if (error.response?.status === 403) {
         return 'You do not have permission to generate this report.';

--- a/apps/web/src/pages/WorkScheduleReportPage.tsx
+++ b/apps/web/src/pages/WorkScheduleReportPage.tsx
@@ -5,6 +5,7 @@ import { reports } from '../lib/api';
 import { PATHS } from '../routes';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
 import { downloadCsv } from '../utils/csv';
+import { downloadFile } from '../utils/downloadFile';
 
 // Day of week values from backend for sorting
 // (removed enum definition to simplify type handling)
@@ -59,6 +60,7 @@ export function WorkScheduleReportPage() {
   const [error, setError] = useState<string | null>(null);
   const [showFilters, setShowFilters] = useState(false);
   const [dayFilter, setDayFilter] = useState<string>('all');
+  const [generatingPdf, setGeneratingPdf] = useState(false);
 
   // Define the order for days of the week
   const dayOrder = useMemo(() => [
@@ -157,7 +159,7 @@ export function WorkScheduleReportPage() {
   };
 
   // Export data to CSV using shared utility function
-  const exportData = () => {
+  const exportCsv = (): void => {
     if (!workScheduleData) return;
     
     // CSV headers
@@ -215,6 +217,22 @@ export function WorkScheduleReportPage() {
     downloadCsv(headers, csvRows, { filename });
   };
 
+  const downloadPdf = async (): Promise<void> => {
+    setGeneratingPdf(true);
+    setError(null);
+    try {
+      const download = await reports.generateWorkSchedulePdf(
+        dayFilter === 'all' ? {} : { dayOfWeek: dayFilter }
+      );
+      downloadFile(download.blob, download.filename);
+    } catch (generationError) {
+      console.error('Failed to generate work schedule PDF:', generationError);
+      setError(reports.getWorkScheduleReportErrorMessage(generationError));
+    } finally {
+      setGeneratingPdf(false);
+    }
+  };
+
   // Count total shifts, jobs, and registrations
   const summaryStats = useMemo(() => {
     if (!workScheduleData) return { shifts: 0, jobs: 0, registrations: 0 };
@@ -266,11 +284,23 @@ export function WorkScheduleReportPage() {
               Filters
             </button>
             <button
-              onClick={exportData}
+              onClick={exportCsv}
               className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-amber-600 hover:bg-amber-700"
             >
               <Download size={16} className="mr-2" />
-              Export
+              Export CSV
+            </button>
+            <button
+              onClick={() => void downloadPdf()}
+              disabled={generatingPdf}
+              className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {generatingPdf ? (
+                <LoadingSpinner size="sm" />
+              ) : (
+                <Download size={16} className="mr-2" />
+              )}
+              {generatingPdf ? 'Generating PDF…' : 'Download PDF'}
             </button>
           </div>
         </div>

--- a/apps/web/src/pages/WorkScheduleReportPage.tsx
+++ b/apps/web/src/pages/WorkScheduleReportPage.tsx
@@ -51,8 +51,6 @@ interface DayGroupedShifts {
   [key: string]: WorkScheduleShift[];
 }
 
-type ReportErrorSource = 'schedule' | 'pdf';
-
 /**
  * Work Schedule Report page
  * Displays all shifts with their jobs and user signups
@@ -60,8 +58,8 @@ type ReportErrorSource = 'schedule' | 'pdf';
 export function WorkScheduleReportPage() {
   const [workScheduleData, setWorkScheduleData] = useState<WorkScheduleData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [errorSource, setErrorSource] = useState<ReportErrorSource | null>(null);
+  const [scheduleError, setScheduleError] = useState<string | null>(null);
+  const [pdfError, setPdfError] = useState<string | null>(null);
   const [showFilters, setShowFilters] = useState(false);
   const [dayFilter, setDayFilter] = useState<string>('all');
   const [generatingPdf, setGeneratingPdf] = useState(false);
@@ -96,14 +94,12 @@ export function WorkScheduleReportPage() {
 
   const fetchWorkSchedule = useCallback(async (): Promise<void> => {
     setLoading(true);
-    setError(null);
-    setErrorSource(null);
+    setScheduleError(null);
     try {
       const data = await reports.getWorkSchedule();
       setWorkScheduleData(data);
     } catch (err) {
-      setError('Failed to fetch work schedule data');
-      setErrorSource('schedule');
+      setScheduleError('Failed to fetch work schedule data');
       console.error('Error fetching work schedule:', err);
     } finally {
       setLoading(false);
@@ -227,8 +223,7 @@ export function WorkScheduleReportPage() {
 
   const downloadPdf = async (): Promise<void> => {
     setGeneratingPdf(true);
-    setError(null);
-    setErrorSource(null);
+    setPdfError(null);
     try {
       const download = await reports.generateWorkSchedulePdf(
         dayFilter === 'all' ? {} : { dayOfWeek: dayFilter }
@@ -236,8 +231,7 @@ export function WorkScheduleReportPage() {
       downloadFile(download.blob, download.filename);
     } catch (generationError) {
       console.error('Failed to generate work schedule PDF:', generationError);
-      setError(reports.getWorkScheduleReportErrorMessage(generationError));
-      setErrorSource('pdf');
+      setPdfError(reports.getWorkScheduleReportErrorMessage(generationError));
     } finally {
       setGeneratingPdf(false);
     }
@@ -306,7 +300,10 @@ export function WorkScheduleReportPage() {
               className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {generatingPdf ? (
-                <LoadingSpinner size="sm" className="!p-0 mr-2" />
+                <LoadingSpinner
+                  size="sm"
+                  className="!p-0 mr-2 [&_svg]:!text-white"
+                />
               ) : (
                 <Download size={16} className="mr-2" />
               )}
@@ -358,14 +355,25 @@ export function WorkScheduleReportPage() {
           </div>
         )}
 
-        {/* Error Message */}
-        {error && (
+        {/* Schedule Error Message */}
+        {scheduleError && (
           <div className="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
-            <p className="text-red-800">{error}</p>
+            <p className="text-red-800">{scheduleError}</p>
             <button
-              onClick={() => {
-                void (errorSource === 'pdf' ? downloadPdf() : fetchWorkSchedule());
-              }}
+              onClick={() => void fetchWorkSchedule()}
+              className="mt-2 text-red-600 hover:text-red-700 underline"
+            >
+              Try again
+            </button>
+          </div>
+        )}
+
+        {/* PDF Error Message */}
+        {pdfError && (
+          <div className="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+            <p className="text-red-800">{pdfError}</p>
+            <button
+              onClick={() => void downloadPdf()}
               className="mt-2 text-red-600 hover:text-red-700 underline"
             >
               Try again

--- a/apps/web/src/pages/WorkScheduleReportPage.tsx
+++ b/apps/web/src/pages/WorkScheduleReportPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { ArrowLeft, Download, Filter, X, Calendar } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { reports } from '../lib/api';
@@ -6,6 +6,7 @@ import { PATHS } from '../routes';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
 import { downloadCsv } from '../utils/csv';
 import { downloadFile } from '../utils/downloadFile';
+import { getTimeInMinutes } from '../utils/shiftUtils';
 
 // Day of week values from backend for sorting
 // (removed enum definition to simplify type handling)
@@ -50,6 +51,8 @@ interface DayGroupedShifts {
   [key: string]: WorkScheduleShift[];
 }
 
+type ReportErrorSource = 'schedule' | 'pdf';
+
 /**
  * Work Schedule Report page
  * Displays all shifts with their jobs and user signups
@@ -58,6 +61,7 @@ export function WorkScheduleReportPage() {
   const [workScheduleData, setWorkScheduleData] = useState<WorkScheduleData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [errorSource, setErrorSource] = useState<ReportErrorSource | null>(null);
   const [showFilters, setShowFilters] = useState(false);
   const [dayFilter, setDayFilter] = useState<string>('all');
   const [generatingPdf, setGeneratingPdf] = useState(false);
@@ -90,24 +94,26 @@ export function WorkScheduleReportPage() {
     POST_EVENT: 'Post-Event'
   }), []);
 
+  const fetchWorkSchedule = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    setErrorSource(null);
+    try {
+      const data = await reports.getWorkSchedule();
+      setWorkScheduleData(data);
+    } catch (err) {
+      setError('Failed to fetch work schedule data');
+      setErrorSource('schedule');
+      console.error('Error fetching work schedule:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   // Fetch work schedule data
   useEffect(() => {
-    const fetchWorkSchedule = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await reports.getWorkSchedule();
-        setWorkScheduleData(data);
-      } catch (err) {
-        setError('Failed to fetch work schedule data');
-        console.error('Error fetching work schedule:', err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchWorkSchedule();
-  }, []);
+    void fetchWorkSchedule();
+  }, [fetchWorkSchedule]);
 
   // Group shifts by day of week
   const shiftsByDay = useMemo(() => {
@@ -171,7 +177,9 @@ export function WorkScheduleReportPage() {
     Object.entries(filteredShiftsByDay).forEach(([day, shifts]) => {
       // Sort shifts by start time
       const sortedShifts = [...shifts].sort((a, b) => {
-        return a.startTime.localeCompare(b.startTime);
+        const timeComparison =
+          getTimeInMinutes(a.startTime) - getTimeInMinutes(b.startTime);
+        return timeComparison || a.name.localeCompare(b.name);
       });
       
       sortedShifts.forEach(shift => {
@@ -220,6 +228,7 @@ export function WorkScheduleReportPage() {
   const downloadPdf = async (): Promise<void> => {
     setGeneratingPdf(true);
     setError(null);
+    setErrorSource(null);
     try {
       const download = await reports.generateWorkSchedulePdf(
         dayFilter === 'all' ? {} : { dayOfWeek: dayFilter }
@@ -228,6 +237,7 @@ export function WorkScheduleReportPage() {
     } catch (generationError) {
       console.error('Failed to generate work schedule PDF:', generationError);
       setError(reports.getWorkScheduleReportErrorMessage(generationError));
+      setErrorSource('pdf');
     } finally {
       setGeneratingPdf(false);
     }
@@ -296,7 +306,7 @@ export function WorkScheduleReportPage() {
               className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {generatingPdf ? (
-                <LoadingSpinner size="sm" />
+                <LoadingSpinner size="sm" className="!p-0 mr-2" />
               ) : (
                 <Download size={16} className="mr-2" />
               )}
@@ -354,17 +364,7 @@ export function WorkScheduleReportPage() {
             <p className="text-red-800">{error}</p>
             <button
               onClick={() => {
-                setLoading(true);
-                reports.getWorkSchedule()
-                  .then(data => {
-                    setWorkScheduleData(data);
-                    setError(null);
-                  })
-                  .catch(err => {
-                    setError('Failed to fetch work schedule data');
-                    console.error('Error fetching work schedule:', err);
-                  })
-                  .finally(() => setLoading(false));
+                void (errorSource === 'pdf' ? downloadPdf() : fetchWorkSchedule());
               }}
               className="mt-2 text-red-600 hover:text-red-700 underline"
             >
@@ -399,7 +399,11 @@ export function WorkScheduleReportPage() {
                     
                     {/* Sort shifts by start time */}
                     {[...shifts]
-                      .sort((a, b) => a.startTime.localeCompare(b.startTime))
+                      .sort((a, b) => {
+                        const timeComparison =
+                          getTimeInMinutes(a.startTime) - getTimeInMinutes(b.startTime);
+                        return timeComparison || a.name.localeCompare(b.name);
+                      })
                       .map(shift => (
                         <div key={shift.id} className="mb-6">
                           <h3 className="text-lg font-semibold text-gray-800 mb-2">

--- a/apps/web/src/pages/__tests__/WorkScheduleReportPage.test.tsx
+++ b/apps/web/src/pages/__tests__/WorkScheduleReportPage.test.tsx
@@ -23,7 +23,9 @@ vi.mock('../../utils/downloadFile', () => ({
 }));
 
 vi.mock('../../components/common/LoadingSpinner', () => ({
-  LoadingSpinner: () => <span>Loading</span>,
+  LoadingSpinner: ({ className }: { className?: string }) => (
+    <span data-testid="loading-spinner" className={className}>Loading</span>
+  ),
 }));
 
 describe('WorkScheduleReportPage', () => {
@@ -139,6 +141,38 @@ describe('WorkScheduleReportPage', () => {
     await waitFor(() => expect(reports.generateWorkSchedulePdf).toHaveBeenCalledTimes(2));
     expect(reports.getWorkSchedule).toHaveBeenCalledTimes(1);
     expect(downloadFile).toHaveBeenCalledWith(inputBlob, 'work-schedule.pdf');
+  });
+
+  it('shouldPreserveScheduleErrorsAfterSuccessfulPdfGeneration', async () => {
+    vi.mocked(reports.getWorkSchedule).mockRejectedValue(new Error('failed'));
+    vi.mocked(reports.generateWorkSchedulePdf).mockResolvedValue({
+      blob: new Blob(['pdf'], { type: 'application/pdf' }),
+      filename: 'work-schedule.pdf',
+    });
+    renderPage();
+    await screen.findByText('Failed to fetch work schedule data');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
+
+    await waitFor(() => expect(downloadFile).toHaveBeenCalled());
+    expect(screen.getByText('Failed to fetch work schedule data')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+  });
+
+  it('shouldShowAVisibleInlineSpinnerWhileGeneratingThePdf', async () => {
+    vi.mocked(reports.generateWorkSchedulePdf).mockReturnValue(
+      new Promise<never>(() => undefined)
+    );
+    renderPage();
+    await screen.findByText('Wednesday');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
+
+    expect(screen.getByTestId('loading-spinner')).toHaveClass(
+      '!p-0',
+      'mr-2',
+      '[&_svg]:!text-white'
+    );
   });
 
   it('shouldOrderUnpaddedShiftTimesChronologicallyForDisplayAndCsv', async () => {

--- a/apps/web/src/pages/__tests__/WorkScheduleReportPage.test.tsx
+++ b/apps/web/src/pages/__tests__/WorkScheduleReportPage.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { reports } from '../../lib/api';
+import { downloadCsv } from '../../utils/csv';
+import { downloadFile } from '../../utils/downloadFile';
+import { WorkScheduleReportPage } from '../WorkScheduleReportPage';
+
+vi.mock('../../lib/api', () => ({
+  reports: {
+    getWorkSchedule: vi.fn(),
+    generateWorkSchedulePdf: vi.fn(),
+    getWorkScheduleReportErrorMessage: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/csv', () => ({
+  downloadCsv: vi.fn(),
+}));
+
+vi.mock('../../utils/downloadFile', () => ({
+  downloadFile: vi.fn(),
+}));
+
+vi.mock('../../components/common/LoadingSpinner', () => ({
+  LoadingSpinner: () => <span>Loading</span>,
+}));
+
+describe('WorkScheduleReportPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(reports.getWorkSchedule).mockResolvedValue({
+      shifts: [
+        {
+          id: 'wednesday-am',
+          name: 'Wednesday AM',
+          dayOfWeek: 'WEDNESDAY',
+          startTime: '09:30',
+          endTime: '14:30',
+          jobs: [
+            {
+              id: 'airport-manager',
+              name: 'Airport Manager',
+              location: 'Airport',
+              maxRegistrations: 2,
+              categoryId: 'operations',
+              category: { id: 'operations', name: 'Operations' },
+              registrations: [
+                {
+                  id: 'assignment',
+                  user: {
+                    id: 'worker',
+                    firstName: 'Chris',
+                    lastName: 'Romp',
+                    playaName: 'romp',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('shouldKeepCsvExportAndDownloadTheFullPdf', async () => {
+    const inputBlob = new Blob(['pdf'], { type: 'application/pdf' });
+    vi.mocked(reports.generateWorkSchedulePdf).mockResolvedValue({
+      blob: inputBlob,
+      filename: 'Burning Sky Work Schedule 2026.pdf',
+    });
+    renderPage();
+    await screen.findByText('Wednesday');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
+
+    expect(downloadCsv).toHaveBeenCalled();
+    await waitFor(() => expect(reports.generateWorkSchedulePdf).toHaveBeenCalledWith({}));
+    expect(downloadFile).toHaveBeenCalledWith(
+      inputBlob,
+      'Burning Sky Work Schedule 2026.pdf'
+    );
+  });
+
+  it('shouldGenerateOnlyTheSelectedDay', async () => {
+    vi.mocked(reports.generateWorkSchedulePdf).mockResolvedValue({
+      blob: new Blob(['pdf'], { type: 'application/pdf' }),
+      filename: 'work-schedule.pdf',
+    });
+    renderPage();
+    await screen.findByText('Wednesday');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    fireEvent.change(screen.getByLabelText('Day of Week'), {
+      target: { value: 'WEDNESDAY' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
+
+    await waitFor(() =>
+      expect(reports.generateWorkSchedulePdf).toHaveBeenCalledWith({
+        dayOfWeek: 'WEDNESDAY',
+      })
+    );
+  });
+
+  it('shouldDisplayPdfGenerationErrors', async () => {
+    vi.mocked(reports.generateWorkSchedulePdf).mockRejectedValue(new Error('failed'));
+    vi.mocked(reports.getWorkScheduleReportErrorMessage).mockReturnValue(
+      'Failed to generate the work schedule PDF. Please try again.'
+    );
+    renderPage();
+    await screen.findByText('Wednesday');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
+
+    expect(
+      await screen.findByText('Failed to generate the work schedule PDF. Please try again.')
+    ).toBeInTheDocument();
+  });
+
+  function renderPage(): void {
+    render(
+      <MemoryRouter>
+        <WorkScheduleReportPage />
+      </MemoryRouter>
+    );
+  }
+});

--- a/apps/web/src/pages/__tests__/WorkScheduleReportPage.test.tsx
+++ b/apps/web/src/pages/__tests__/WorkScheduleReportPage.test.tsx
@@ -119,6 +119,83 @@ describe('WorkScheduleReportPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('shouldRetryPdfGenerationAfterADownloadError', async () => {
+    const inputBlob = new Blob(['pdf'], { type: 'application/pdf' });
+    vi.mocked(reports.generateWorkSchedulePdf)
+      .mockRejectedValueOnce(new Error('failed'))
+      .mockResolvedValueOnce({
+        blob: inputBlob,
+        filename: 'work-schedule.pdf',
+      });
+    vi.mocked(reports.getWorkScheduleReportErrorMessage).mockReturnValue(
+      'Failed to generate the work schedule PDF. Please try again.'
+    );
+    renderPage();
+    await screen.findByText('Wednesday');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Try again' }));
+
+    await waitFor(() => expect(reports.generateWorkSchedulePdf).toHaveBeenCalledTimes(2));
+    expect(reports.getWorkSchedule).toHaveBeenCalledTimes(1);
+    expect(downloadFile).toHaveBeenCalledWith(inputBlob, 'work-schedule.pdf');
+  });
+
+  it('shouldOrderUnpaddedShiftTimesChronologicallyForDisplayAndCsv', async () => {
+    vi.mocked(reports.getWorkSchedule).mockResolvedValue({
+      shifts: [
+        {
+          id: 'afternoon',
+          name: 'Afternoon',
+          dayOfWeek: 'WEDNESDAY',
+          startTime: '13:00',
+          endTime: '14:00',
+          jobs: [
+            {
+              id: 'afternoon-job',
+              name: 'Afternoon Job',
+              location: 'Camp',
+              maxRegistrations: 1,
+              categoryId: 'operations',
+              category: { id: 'operations', name: 'Operations' },
+              registrations: [],
+            },
+          ],
+        },
+        {
+          id: 'morning',
+          name: 'Morning',
+          dayOfWeek: 'WEDNESDAY',
+          startTime: '8:00',
+          endTime: '09:00',
+          jobs: [
+            {
+              id: 'morning-job',
+              name: 'Morning Job',
+              location: 'Camp',
+              maxRegistrations: 1,
+              categoryId: 'operations',
+              category: { id: 'operations', name: 'Operations' },
+              registrations: [],
+            },
+          ],
+        },
+      ],
+    });
+    renderPage();
+
+    const morningHeading = await screen.findByText('Morning (8:00 - 09:00)');
+    const afternoonHeading = screen.getByText('Afternoon (13:00 - 14:00)');
+    expect(
+      morningHeading.compareDocumentPosition(afternoonHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+    const csvRows = vi.mocked(downloadCsv).mock.calls[0][1];
+    expect(csvRows.map(row => row[1])).toEqual(['Morning', 'Afternoon']);
+  });
+
   function renderPage(): void {
     render(
       <MemoryRouter>

--- a/apps/web/src/utils/__tests__/shiftUtils.test.ts
+++ b/apps/web/src/utils/__tests__/shiftUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getFriendlyDayName, formatTime } from '../shiftUtils';
+import { getFriendlyDayName, formatTime, getTimeInMinutes } from '../shiftUtils';
 
 describe('shiftUtils', () => {
   describe('getFriendlyDayName', () => {
@@ -59,4 +59,12 @@ describe('shiftUtils', () => {
       expect(() => formatTime('some random text')).not.toThrow();
     });
   });
-}); 
+
+  describe('getTimeInMinutes', () => {
+    it('shouldNormalizeZeroPaddedAndUnpaddedTimes', () => {
+      expect(getTimeInMinutes('8:00')).toBe(480);
+      expect(getTimeInMinutes('08:00')).toBe(480);
+      expect(getTimeInMinutes('13:30')).toBe(810);
+    });
+  });
+});

--- a/apps/web/src/utils/shiftUtils.ts
+++ b/apps/web/src/utils/shiftUtils.ts
@@ -58,4 +58,12 @@ export const formatTime = (timeString: string): string => {
     // Return the original string if parsing fails
     return timeString;
   }
-}; 
+};
+
+/**
+ * Convert a 24-hour time string to minutes after midnight for chronological sorting.
+ */
+export const getTimeInMinutes = (timeString: string): number => {
+  const [hours, minutes] = timeString.split(':').map(Number);
+  return hours * 60 + minutes;
+};


### PR DESCRIPTION
## Why

The work schedule CSV is useful for data export but difficult to read or print as an operational camp schedule. This adds a PDF option that follows the established report hierarchy and roster formatting while reusing the shared PDF infrastructure.

## What changed

- Adds an authenticated work-schedule PDF endpoint backed by the same schedule data and ordering used by the web report.
- Adds a filtered **Download PDF** action alongside the existing CSV export.
- Formats the schedule as day, shift, job, and worker, with capacity-aware rosters:
  - Jobs with up to 10 slots use bullets and include vacancies.
  - Larger jobs use assigned-only numbered lists with no vacancy placeholders.
- Preserves Full/AM/PM chronological ordering and uses side-by-side or split-column layouts only when the rendered content fits safely.
- Allows long reports to paginate between intact job blocks and lets rosters over 84 workers flow across pages without truncation.
- Adds API, web, DTO, service, controller, and end-to-end coverage for the report flow and layout boundaries.

## Verification

- API report test suites
- Web work-schedule report tests
- API and web builds
- Local database-backed PDF rendering
- Stress PDF rendering for multi-page small-job shifts and an 85-person roster

Related to #70

Staff-only filtering follow-up: #225