### PR TITLE
Keep ticket receipt PDF rows together

### DIFF
--- a/apps/api/src/reports/constants/ticket-receipt-report.constants.ts
+++ b/apps/api/src/reports/constants/ticket-receipt-report.constants.ts
@@ -1,0 +1,3 @@
+export const TICKET_RECEIPT_REPORT_CONSTRAINTS = {
+  acknowledgementMaximumLines: 10,
+} as const;

--- a/apps/api/src/reports/dto/generate-ticket-receipt-report.dto.spec.ts
+++ b/apps/api/src/reports/dto/generate-ticket-receipt-report.dto.spec.ts
@@ -68,11 +68,14 @@ describe('GenerateTicketReceiptReportDto', () => {
   it('shouldAllowAcknowledgementWithTenLines', async () => {
     const inputDto = plainToInstance(GenerateTicketReceiptReportDto, {
       title: 'Ticket Receipt Report',
-      acknowledgementText: Array.from({ length: 10 }, () => 'Acknowledgement').join('\r\n'),
+      acknowledgementText: `${Array.from({ length: 10 }, () => 'Acknowledgement').join(
+        '\r\n'
+      )}\r\n`,
     });
 
     const actualErrors = await validate(inputDto);
 
     expect(actualErrors).toHaveLength(0);
+    expect(inputDto.acknowledgementText.endsWith('\r\n')).toBe(false);
   });
 });

--- a/apps/api/src/reports/dto/generate-ticket-receipt-report.dto.spec.ts
+++ b/apps/api/src/reports/dto/generate-ticket-receipt-report.dto.spec.ts
@@ -53,4 +53,26 @@ describe('GenerateTicketReceiptReportDto', () => {
     expect(inputDto.title).toBe('Ticket Receipt Report');
     expect(actualErrors.some(error => error.property === 'acknowledgementText')).toBe(true);
   });
+
+  it('shouldRejectAcknowledgementWithMoreThanTenLines', async () => {
+    const inputDto = plainToInstance(GenerateTicketReceiptReportDto, {
+      title: 'Ticket Receipt Report',
+      acknowledgementText: Array.from({ length: 11 }, () => 'Acknowledgement').join('\n'),
+    });
+
+    const actualErrors = await validate(inputDto);
+
+    expect(actualErrors.some(error => error.property === 'acknowledgementText')).toBe(true);
+  });
+
+  it('shouldAllowAcknowledgementWithTenLines', async () => {
+    const inputDto = plainToInstance(GenerateTicketReceiptReportDto, {
+      title: 'Ticket Receipt Report',
+      acknowledgementText: Array.from({ length: 10 }, () => 'Acknowledgement').join('\r\n'),
+    });
+
+    const actualErrors = await validate(inputDto);
+
+    expect(actualErrors).toHaveLength(0);
+  });
 });

--- a/apps/api/src/reports/dto/generate-ticket-receipt-report.dto.ts
+++ b/apps/api/src/reports/dto/generate-ticket-receipt-report.dto.ts
@@ -1,10 +1,24 @@
-import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import { IsInt, IsUUID, Max, Min, ValidateIf } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import { IsInt, IsString, IsUUID, Length, Max, Min, ValidateIf } from 'class-validator';
+import { TICKET_RECEIPT_REPORT_CONSTRAINTS } from '../constants/ticket-receipt-report.constants';
+import { MaxLineCount } from '../validators/max-line-count.validator';
 import { TicketReceiptSettingsDto } from './ticket-receipt-settings.dto';
 
 /** Validated options for generating a ticket-receipt signature form. */
 export class GenerateTicketReceiptReportDto extends TicketReceiptSettingsDto {
+  @ApiProperty({
+    description: 'Acknowledgement printed in every signature row',
+    example: 'I acknowledge receipt of my event ticket.',
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @Length(1, 1000)
+  @MaxLineCount(TICKET_RECEIPT_REPORT_CONSTRAINTS.acknowledgementMaximumLines, {
+    message: `Acknowledgement must be ${TICKET_RECEIPT_REPORT_CONSTRAINTS.acknowledgementMaximumLines} lines or fewer`,
+  })
+  acknowledgementText!: string;
+
   @ApiPropertyOptional({
     description: 'Registration year; defaults to the configured current year',
     example: 2026,

--- a/apps/api/src/reports/dto/ticket-receipt-settings.dto.ts
+++ b/apps/api/src/reports/dto/ticket-receipt-settings.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsString, Length } from 'class-validator';
+import { TICKET_RECEIPT_REPORT_CONSTRAINTS } from '../constants/ticket-receipt-report.constants';
+import { MaxLineCount } from '../validators/max-line-count.validator';
 
 /** Shared defaults persisted for the ticket-receipt report. */
 export class TicketReceiptSettingsDto {
@@ -20,5 +22,8 @@ export class TicketReceiptSettingsDto {
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
   @Length(1, 1000)
+  @MaxLineCount(TICKET_RECEIPT_REPORT_CONSTRAINTS.acknowledgementMaximumLines, {
+    message: `Acknowledgement must be ${TICKET_RECEIPT_REPORT_CONSTRAINTS.acknowledgementMaximumLines} lines or fewer`,
+  })
   acknowledgementText!: string;
 }

--- a/apps/api/src/reports/dto/ticket-receipt-settings.dto.ts
+++ b/apps/api/src/reports/dto/ticket-receipt-settings.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsString, Length } from 'class-validator';
-import { TICKET_RECEIPT_REPORT_CONSTRAINTS } from '../constants/ticket-receipt-report.constants';
-import { MaxLineCount } from '../validators/max-line-count.validator';
 
 /** Shared defaults persisted for the ticket-receipt report. */
 export class TicketReceiptSettingsDto {
@@ -22,8 +20,5 @@ export class TicketReceiptSettingsDto {
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
   @Length(1, 1000)
-  @MaxLineCount(TICKET_RECEIPT_REPORT_CONSTRAINTS.acknowledgementMaximumLines, {
-    message: `Acknowledgement must be ${TICKET_RECEIPT_REPORT_CONSTRAINTS.acknowledgementMaximumLines} lines or fewer`,
-  })
   acknowledgementText!: string;
 }

--- a/apps/api/src/reports/services/report-configuration.service.spec.ts
+++ b/apps/api/src/reports/services/report-configuration.service.spec.ts
@@ -62,6 +62,25 @@ describe('ReportConfigurationService', () => {
     );
   });
 
+  it('shouldReturnLegacySettingsThatExceedTheGenerationLineLimit', async () => {
+    const expectedAcknowledgement = Array.from({ length: 11 }, () => 'Acknowledgement').join('\n');
+    mockFindUnique.mockResolvedValue({
+      id: 'configuration-id',
+      reportType: ReportType.TICKET_RECEIPT_SIGNATURE,
+      schemaVersion: 1,
+      settings: {
+        title: 'Ticket Receipt Report',
+        acknowledgementText: expectedAcknowledgement,
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const actualSettings = await service.getTicketReceiptSettings();
+
+    expect(actualSettings.acknowledgementText).toBe(expectedAcknowledgement);
+  });
+
   it('shouldCreateAndAuditChangedSettings', async () => {
     mockTransactionFindUnique.mockResolvedValue(null);
     mockUpsert.mockResolvedValue({
@@ -164,6 +183,51 @@ describe('ReportConfigurationService', () => {
         oldValues: {
           title: 'Previous title',
           acknowledgementText: 'Previous acknowledgement',
+        },
+        newValues: {
+          title: 'Next title',
+          acknowledgementText: 'Next acknowledgement',
+        },
+      }),
+    });
+  });
+
+  it('shouldReplaceLegacySettingsThatExceedTheGenerationLineLimit', async () => {
+    const inputLegacyAcknowledgement = Array.from({ length: 11 }, () => 'Acknowledgement').join(
+      '\n'
+    );
+    mockTransactionFindUnique.mockResolvedValue({
+      id: 'configuration-id',
+      reportType: ReportType.TICKET_RECEIPT_SIGNATURE,
+      schemaVersion: 1,
+      settings: {
+        title: 'Previous title',
+        acknowledgementText: inputLegacyAcknowledgement,
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockUpsert.mockResolvedValue({
+      id: 'configuration-id',
+      reportType: ReportType.TICKET_RECEIPT_SIGNATURE,
+      schemaVersion: 1,
+      settings: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const inputSettings = Object.assign(new TicketReceiptSettingsDto(), {
+      title: 'Next title',
+      acknowledgementText: 'Next acknowledgement',
+    });
+
+    await service.saveTicketReceiptSettings('user-id', inputSettings);
+
+    expect(mockUpsert).toHaveBeenCalled();
+    expect(mockCreateAudit).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        oldValues: {
+          title: 'Previous title',
+          acknowledgementText: inputLegacyAcknowledgement,
         },
         newValues: {
           title: 'Next title',

--- a/apps/api/src/reports/services/ticket-receipt-document.service.spec.ts
+++ b/apps/api/src/reports/services/ticket-receipt-document.service.spec.ts
@@ -1,4 +1,4 @@
-import { Content, ContentTable } from 'pdfmake/interfaces';
+import { Content, ContentTable, CustomTableLayout } from 'pdfmake/interfaces';
 import { GenerateTicketReceiptReportDto } from '../dto/generate-ticket-receipt-report.dto';
 import { TicketReceiptDocumentService } from './ticket-receipt-document.service';
 
@@ -17,11 +17,17 @@ describe('TicketReceiptDocumentService', () => {
     });
     const content = actualDocument.content as Content[];
     const table = content[2] as ContentTable;
+    const layout = table.layout as CustomTableLayout;
 
     expect(actualDocument.pageOrientation).toBe('landscape');
+    expect(content[1]).toEqual(expect.objectContaining({ text: 'Registration Year: 2026' }));
     expect(table.table.headerRows).toBe(1);
-    expect(table.table.dontBreakRows).toBeUndefined();
+    expect(table.table.dontBreakRows).toBe(true);
     expect(table.table.widths).toEqual([110, 140, 225, 132, 63]);
+    expect(layout.hLineWidth).toEqual(expect.any(Function));
+    expect(layout.vLineWidth).toEqual(expect.any(Function));
+    expect(layout.hLineWidth?.(0, table)).toBe(1);
+    expect(layout.vLineWidth?.(0, table)).toBe(1);
     expect(table.table.body).toHaveLength(4);
     expect(table.table.body[1]).toEqual([
       expect.objectContaining({ text: 'Alex Burner' }),
@@ -35,26 +41,5 @@ describe('TicketReceiptDocumentService', () => {
       expect.objectContaining({ text: 'I received one ticket.' })
     );
     expect(typeof actualDocument.footer).toBe('function');
-  });
-
-  it('shouldAllowOversizedAcknowledgementRowsToBreakAcrossPages', () => {
-    const service = new TicketReceiptDocumentService();
-    const inputOptions = Object.assign(new GenerateTicketReceiptReportDto(), {
-      title: 'Ticket Pickup',
-      acknowledgementText: Array.from({ length: 500 }, () => 'I').join('\n'),
-      additionalBlankRows: 0,
-    });
-
-    const actualDocument = service.build(inputOptions, {
-      year: 2026,
-      attendees: [{ name: 'Alex Burner', workShifts: 'Gate (Monday)' }],
-    });
-    const content = actualDocument.content as Content[];
-    const table = content[2] as ContentTable;
-
-    expect(table.table.dontBreakRows).toBeUndefined();
-    expect(table.table.body[1][2]).toEqual(
-      expect.objectContaining({ text: inputOptions.acknowledgementText })
-    );
   });
 });

--- a/apps/api/src/reports/services/ticket-receipt-document.service.ts
+++ b/apps/api/src/reports/services/ticket-receipt-document.service.ts
@@ -48,7 +48,7 @@ export class TicketReceiptDocumentService {
           style: 'reportTitle',
         },
         {
-          text: `Registration year: ${data.year}`,
+          text: `Registration Year: ${data.year}`,
           alignment: 'center',
           margin: [0, 0, 0, 12],
         },
@@ -56,6 +56,7 @@ export class TicketReceiptDocumentService {
           layout: TABLE_LAYOUT,
           table: {
             headerRows: 1,
+            dontBreakRows: true,
             heights: (rowIndex: number) => (rowIndex === 0 ? 24 : 55),
             widths: TABLE_COLUMN_WIDTHS,
             body: this.buildRows(options, data),

--- a/apps/api/src/reports/validators/max-line-count.validator.ts
+++ b/apps/api/src/reports/validators/max-line-count.validator.ts
@@ -1,0 +1,22 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+
+/** Validates that a string contains no more than the configured number of lines. */
+export function MaxLineCount(
+  maximumLines: number,
+  validationOptions?: ValidationOptions
+): PropertyDecorator {
+  return (target: object, propertyKey: string | symbol): void => {
+    registerDecorator({
+      name: 'maxLineCount',
+      target: target.constructor,
+      propertyName: propertyKey.toString(),
+      constraints: [maximumLines],
+      options: validationOptions,
+      validator: {
+        validate(value: unknown): boolean {
+          return typeof value !== 'string' || value.split(/\r\n|\r|\n/).length <= maximumLines;
+        },
+      },
+    });
+  };
+}

--- a/apps/web/src/pages/TicketReceiptReportPage.tsx
+++ b/apps/web/src/pages/TicketReceiptReportPage.tsx
@@ -83,7 +83,9 @@ export function TicketReceiptReportPage() {
     if (!form.acknowledgementText.trim()) {
       return 'Acknowledgement text is required.';
     }
-    if (form.acknowledgementText.split(/\r\n|\r|\n/).length > ACKNOWLEDGEMENT_MAXIMUM_LINES) {
+    if (
+      form.acknowledgementText.trim().split(/\r\n|\r|\n/).length > ACKNOWLEDGEMENT_MAXIMUM_LINES
+    ) {
       return `Acknowledgement must be ${ACKNOWLEDGEMENT_MAXIMUM_LINES} lines or fewer.`;
     }
     if (

--- a/apps/web/src/pages/TicketReceiptReportPage.tsx
+++ b/apps/web/src/pages/TicketReceiptReportPage.tsx
@@ -8,6 +8,8 @@ import { PATHS } from '../routes';
 import { CampingOption } from '../types';
 import { downloadFile } from '../utils/downloadFile';
 
+const ACKNOWLEDGEMENT_MAXIMUM_LINES = 10;
+
 interface TicketReceiptFormState {
   readonly title: string;
   readonly acknowledgementText: string;
@@ -80,6 +82,9 @@ export function TicketReceiptReportPage() {
     }
     if (!form.acknowledgementText.trim()) {
       return 'Acknowledgement text is required.';
+    }
+    if (form.acknowledgementText.split(/\r\n|\r|\n/).length > ACKNOWLEDGEMENT_MAXIMUM_LINES) {
+      return `Acknowledgement must be ${ACKNOWLEDGEMENT_MAXIMUM_LINES} lines or fewer.`;
     }
     if (
       !Number.isInteger(form.additionalBlankRows) ||
@@ -205,7 +210,8 @@ export function TicketReceiptReportPage() {
                 className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
               />
               <p className="mt-1 text-xs text-gray-500">
-                The title and acknowledgement become shared defaults after a successful download.
+                Up to {ACKNOWLEDGEMENT_MAXIMUM_LINES} lines. The title and acknowledgement become
+                shared defaults after a successful download.
               </p>
             </div>
 

--- a/apps/web/src/pages/__tests__/TicketReceiptReportPage.test.tsx
+++ b/apps/web/src/pages/__tests__/TicketReceiptReportPage.test.tsx
@@ -147,6 +147,32 @@ describe('TicketReceiptReportPage', () => {
     expect(reports.generateTicketReceipt).not.toHaveBeenCalled();
   });
 
+  it('shouldValidateTheTrimmedAcknowledgementLineCount', async () => {
+    const inputBlob = new Blob(['pdf'], { type: 'application/pdf' });
+    vi.mocked(reports.generateTicketReceipt).mockResolvedValue({
+      blob: inputBlob,
+      filename: 'tickets.pdf',
+    });
+    render(
+      <MemoryRouter>
+        <TicketReceiptReportPage />
+      </MemoryRouter>
+    );
+    await screen.findByDisplayValue('I received my ticket.');
+    const inputAcknowledgement = Array.from({ length: 10 }, () => 'Acknowledgement').join('\n');
+
+    fireEvent.change(screen.getByLabelText('Acknowledgement'), {
+      target: { value: `${inputAcknowledgement}\n` },
+    });
+    fireEvent.submit(screen.getByRole('button', { name: 'Generate PDF' }).closest('form')!);
+
+    await waitFor(() => {
+      expect(reports.generateTicketReceipt).toHaveBeenCalledWith(
+        expect.objectContaining({ acknowledgementText: inputAcknowledgement })
+      );
+    });
+  });
+
   it('shouldSurfaceGenerationErrors', async () => {
     vi.mocked(reports.generateTicketReceipt).mockRejectedValue(new Error('no rows'));
     vi.mocked(reports.getReportErrorMessage).mockReturnValue(

--- a/apps/web/src/pages/__tests__/TicketReceiptReportPage.test.tsx
+++ b/apps/web/src/pages/__tests__/TicketReceiptReportPage.test.tsx
@@ -130,6 +130,23 @@ describe('TicketReceiptReportPage', () => {
     expect(reports.generateTicketReceipt).not.toHaveBeenCalled();
   });
 
+  it('shouldRejectAcknowledgementWithMoreThanTenLines', async () => {
+    render(
+      <MemoryRouter>
+        <TicketReceiptReportPage />
+      </MemoryRouter>
+    );
+    await screen.findByDisplayValue('I received my ticket.');
+
+    fireEvent.change(screen.getByLabelText('Acknowledgement'), {
+      target: { value: Array.from({ length: 11 }, () => 'Acknowledgement').join('\n') },
+    });
+    fireEvent.submit(screen.getByRole('button', { name: 'Generate PDF' }).closest('form')!);
+
+    expect(screen.getByText('Acknowledgement must be 10 lines or fewer.')).toBeInTheDocument();
+    expect(reports.generateTicketReceipt).not.toHaveBeenCalled();
+  });
+
   it('shouldSurfaceGenerationErrors', async () => {
     vi.mocked(reports.generateTicketReceipt).mockRejectedValue(new Error('no rows'));
     vi.mocked(reports.getReportErrorMessage).mockReturnValue(


### PR DESCRIPTION
Ticket receipt signature rows could split across pages, separating a person's name from the acknowledgement and leaving borderless continuation fragments that made the signing area ambiguous.

This change uses pdfmake's non-breaking row support so each signature row moves to the next page as a unit while retaining repeated headers and cell borders. Because pdfmake can truncate a row taller than a full page, acknowledgement text is limited to 10 lines in both API validation and the report form; the existing 1,000-character limit remains unchanged. The report subheading is also corrected to `Registration Year: ####`.

## Validation

- Targeted API report tests
- Targeted web report-page tests
- API and web production builds
- Multipage PDF render inspection, including maximum permitted acknowledgement content